### PR TITLE
Full Destructor Implementation

### DIFF
--- a/examples/test.az
+++ b/examples/test.az
@@ -21,7 +21,8 @@ struct outer
 
 {
     println("before creation");
-    x := outer(object(5));
+    o := object(5);
+    x := [o; 3u];
     println("after creation");
 }
 

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,17 +1,20 @@
 
 struct object
 {
-    val: i64;
+    id: i64;
 
     fn drop(self: &object) -> null
     {
-        println("dropping object");
+        print("dropping object ");
+        println(self->id);
     }
 }
 
 {
     println("before creation");
-    x := [object(4); 5u];
+    x := [object(1), object(2)];
+    println(x[0u].id);
+    println(x[1u].id);
     println("after creation");
 }
 

--- a/examples/test.az
+++ b/examples/test.az
@@ -19,7 +19,7 @@ fn make_ptr(val: i64) -> object
 
 {
     println("before");
-    x := make_ptr(5);
+    x := object(new i64);
     println("after");
 }
 

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,29 +1,28 @@
 
-struct managed_int
+struct object
 {
-    val: &i64;
+    val: i64;
 
-    fn drop(self: &managed_int) -> null
+    fn drop(self: &object) -> null
     {
-        print("deleting int: ");
-        println(*(self->val));
-        delete self->val;
+        println("dropping object");
     }
 }
 
-fn make_int(val: i64) -> managed_int
+struct outer
 {
-    ret := managed_int(new i64);
-    *(ret.val) = val;
-    return ret;
+    inner: object;
+
+    fn drop(self: &outer) -> null
+    {
+        println("dropping outer");
+    }
 }
 
 {
-    b := "hello";
-    a := 1;
-    f := make_int(60);
-    c := 5;
-    println("here i am");
+    println("before creation");
+    x := outer(object(5));
+    println("after creation");
 }
 
 println("end");

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,21 +1,26 @@
 
 struct object
 {
-    id: i64;
+    inner: &i64;
 
     fn drop(self: &object) -> null
     {
-        print("dropping object ");
-        println(self->id);
+        println("dropping object");
+        delete self->inner;
     }
 }
 
+fn make_ptr(val: i64) -> object
 {
-    println("before creation");
-    x := [object(1), object(2)];
-    println(x[0u].id);
-    println(x[1u].id);
-    println("after creation");
+    p1 := new i64;
+    *p1 = val;
+    return object(p1);
+}
+
+{
+    println("before");
+    x := make_ptr(5);
+    println("after");
 }
 
 println("end");

--- a/examples/test.az
+++ b/examples/test.az
@@ -9,20 +9,9 @@ struct object
     }
 }
 
-struct outer
-{
-    inner: object;
-
-    fn drop(self: &outer) -> null
-    {
-        println("dropping outer");
-    }
-}
-
 {
     println("before creation");
-    o := object(5);
-    x := [o; 3u];
+    x := [object(4); 5u];
     println("after creation");
 }
 

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -370,19 +370,20 @@ auto call_destructor(compiler& com, const std::string& var, const type_name& typ
             compiler_assert(
                 sig.return_type == null_type(), tok, "{} must return null", destructor_name
             );
+            const auto inner_size = com.types.size_of(*list.inner_type);
 
             for (std::size_t index = 0; index != list.count; ++index) {
                 // Push the args to the stack
                 push_literal(com, std::uint64_t{0}); // base ptr
                 push_literal(com, std::uint64_t{0}); // prog ptr
                 push_var_addr(com, tok, var);
-                push_literal(com, index);
+                push_literal(com, index * inner_size);
                 com.program.emplace_back(op_modify_ptr{});
 
                 com.program.emplace_back(op_function_call{
                     .name=destructor_name,
                     .ptr=ptr + 1, // Jump into the function
-                    .args_size=com.types.size_of(concrete_ptr_type(type)) + 2 * sizeof(std::uint64_t)
+                    .args_size=com.types.size_of(concrete_ptr_type(*list.inner_type)) + 2 * sizeof(std::uint64_t)
                 });
                 com.program.emplace_back(op_pop{ .size = com.types.size_of(null_type()) });
             }

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -463,6 +463,9 @@ auto type_of_expr(const compiler& com, const node_expr& node) -> type_name
             return r->result_type;
         },
         [&](const node_function_call_expr& expr) {
+            if (com.types.contains(make_type(expr.function_name))) { // constructor
+                return make_type(expr.function_name);
+            }
             auto key = function_key{};
             key.name = expr.function_name;
             key.args.reserve(expr.args.size());
@@ -471,7 +474,7 @@ auto type_of_expr(const compiler& com, const node_expr& node) -> type_name
             }
             auto it = com.functions.find(key);
             if (it == com.functions.end()) {
-                compiler_error(expr.token, "could not find function '{}({})'", key.name, format_comma_separated(key.args));
+                compiler_error(expr.token, "(1) could not find function '{}({})'", key.name, format_comma_separated(key.args));
             }
             return it->second.sig.return_type;
         },
@@ -487,7 +490,7 @@ auto type_of_expr(const compiler& com, const node_expr& node) -> type_name
             const auto it = com.functions.find(key);
             if (it == com.functions.end()) {
                 const auto function_str = std::format("{}({})", key.name, format_comma_separated(key.args));
-                compiler_error(expr.token, "could not find function '{}'", function_str);
+                compiler_error(expr.token, "(2) could not find function '{}'", function_str);
             }
             return it->second.sig.return_type;
         },
@@ -694,7 +697,7 @@ auto compile_expr_val(compiler& com, const node_function_call_expr& node) -> typ
     }
 
     const auto function_str = std::format("{}({})", node.function_name, format_comma_separated(key.args));
-    compiler_error(node.token, "could not find function '{}'", function_str);
+    compiler_error(node.token, "(3) could not find function '{}'", function_str);
 }
 
 auto compile_expr_val(compiler& com, const node_member_function_call_expr& node) -> type_name
@@ -712,7 +715,7 @@ auto compile_expr_val(compiler& com, const node_member_function_call_expr& node)
     
     const auto it = com.functions.find(key);
     if (it == com.functions.end()) {
-        compiler_error(node.token, "could not find function '{}'", qualified_function_name);
+        compiler_error(node.token, "(4) could not find function '{}'", qualified_function_name);
     }
     
     const auto& [sig, ptr, tok] = it->second;


### PR DESCRIPTION
* When arrays go out of scope, call the destructor of the inner type for each element, right to left.
* Destructors now recurse through member variables and call those destructors too, starting from the last.
* Bugfix: Getting the return type of a constructor is now handled specially, it previously looked for a function definition which didn't exist. Was causing expressions like `[object(5); 6]` to be invalid since the compiler couldn't work out the size of the list.