### PR TITLE
Bugfix: List Destructors

### DIFF
--- a/examples/list_destruction.az
+++ b/examples/list_destruction.az
@@ -1,0 +1,15 @@
+struct object
+{
+    inner: i64;
+
+    fn drop(self: &object) -> null
+    {
+        print("dropping object ");
+        println(self->inner);
+    }
+}
+
+
+x := 10; # makes the address of the following list non-zero, to make sure offsets work
+l := [object(1), object(2), object(3)];
+println("end");

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -390,6 +390,7 @@ auto call_destructor_named_var(compiler& com, const std::string& var, const type
                 call_destructor(com, inner_type, [&](const token& tok) {
                     push_var_addr(com, tok, var);
                     push_literal(com, index * inner_size);
+                    com.program.emplace_back(op_modify_ptr{});
                 });
             }
         },


### PR DESCRIPTION
* I missed an op code that correctly set the pointer to the array element being destructed.
* I missed this because in my example, the list was the only variable in the program, so `push_var_addr(com, tok, var)` just pushed a zero, so `push_literal(com, index * inner_size)` was actually pushing the correct position on its own. With another variable declared before it, it all goes wrong.