### PR TITLE
Make Null Return Optional

### DIFF
--- a/examples/test.az
+++ b/examples/test.az
@@ -3,7 +3,7 @@ struct object
 {
     inner: &i64;
 
-    fn drop(self: &object) -> null
+    fn drop(self: &object)
     {
         println("dropping object");
         delete self->inner;

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -148,25 +148,6 @@ auto is_type_fundamental(const type_name& type) -> bool
         || type == null_type();
 }
 
-// Loads each key/value pair from src into dst. If the key already exists in dst and has a
-// different value, stop and return false.
-auto update(
-    std::unordered_map<int, type_name>& dst, const std::unordered_map<int, type_name>& src
-)
-    -> bool
-{
-    for (const auto& [key, value] : src) {
-        if (auto it = dst.find(key); it != dst.end()) {
-            if (it->second != value) {
-                return false;
-            }
-        } else {
-            dst.emplace(key, value);
-        }
-    }
-    return true;
-}
-
 auto to_string(const signature& sig) -> std::string
 {
     const auto proj = [](const auto& arg) { return arg.type; };

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -359,8 +359,11 @@ auto parse_function_def_stmt(tokenstream& tokens) -> node_stmt_ptr
         param.type = parse_type(tokens);
         stmt.sig.params.push_back(param);
     });    
-    tokens.consume_only(tk_rarrow);
-    stmt.sig.return_type = parse_type(tokens);
+    if (tokens.consume_maybe(tk_rarrow)) {
+        stmt.sig.return_type = parse_type(tokens);
+    } else {
+        stmt.sig.return_type = null_type();
+    }
     stmt.body = parse_statement(tokens);
     return node;
 }
@@ -383,9 +386,12 @@ auto parse_member_function_def_stmt(
         tokens.consume_only(tk_colon);
         param.type = parse_type(tokens);
         stmt.sig.params.push_back(param);
-    });    
-    tokens.consume_only(tk_rarrow);
-    stmt.sig.return_type = parse_type(tokens);
+    });
+    if (tokens.consume_maybe(tk_rarrow)) {
+        stmt.sig.return_type = parse_type(tokens);
+    } else {
+        stmt.sig.return_type = null_type();
+    }
     stmt.body = parse_statement(tokens);
     return node;
 }


### PR DESCRIPTION
* If a function returns `null`, the `-> null` may be omitted from the function definition.
* Removed an unused function.