### PR TITLE
Copy and Assignment

### DIFF
--- a/anzu-lang/syntaxes/anzu.tmLanguage.json
+++ b/anzu-lang/syntaxes/anzu.tmLanguage.json
@@ -17,7 +17,7 @@
 		},
 		{
 			"name": "keyword.other.anzu",
-			"match": "\\b(in|fn|struct|sizeof|new|delete)\\b"
+			"match": "\\b(in|fn|struct|sizeof|new|delete|default)\\b"
 		},
 		{
 			"name": "storage.type.anzu",
@@ -60,8 +60,7 @@
 	],
 	"repository": {
 		"keywords": {
-			"patterns": [
-			]
+			"patterns": []
 		},
 		"strings": {
 			"name": "string.quoted.double.anzu",

--- a/examples/test.az
+++ b/examples/test.az
@@ -16,8 +16,9 @@ fn constructor(x: i64, y: i64) -> vec2
     return vec2(x, y);
 }
 
+a := vec2(2, 3);
 b := vec2(1, 2);
-a := b;
+a = b;
 
 println(a.x);
 println(a.y);

--- a/examples/test.az
+++ b/examples/test.az
@@ -3,13 +3,18 @@ struct unique_int
 {
     val: i64;
 
-    fn copy = default;
+    fn copy = delete;
+    fn assign = delete;
+}
+
+fn myfunc(x: unique_int)
+{
+    println(x.val);
 }
 
 {
     x := unique_int(5);
-    y := x;
-    println("after assign");
+    myfunc(x);
 
     println("done");
 }

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,31 +1,10 @@
 
-struct object
+struct vec2
 {
-    inner: &i64;
-
-    fn drop(self: &object)
-    {
-        println("dropping object");
-        delete self->inner;
-    } 
-
-    fn copy(self: &object, other: &object)
-    {
-        
-    }
+    x: i64;
+    y: i64;
 }
 
-fn make_ptr(val: i64) -> object
-{
-    p1 := new i64;
-    *p1 = val;
-    return object(p1);
-}
+l := [vec2(1, 1), vec2(2, 2)];
 
-{
-    println("before");
-    x := object(new i64);
-    println("after");
-}
-
-println("end");
+a := l[0u];

--- a/examples/test.az
+++ b/examples/test.az
@@ -26,6 +26,8 @@ struct unique_int
     y := x;
     println(x.val);
     println(y.val);
+    y = x;
+    println("after assign");
 
     println("done");
 }

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,15 +1,33 @@
 
-struct vec2
+struct unique_int
 {
-    x: i64;
-    y: i64;
+    val: i64;
 
-    fn copy = null;
+    fn drop(self: &unique_int)
+    {
+        println("calling drop");
+    }
+
+    fn copy(self: &unique_int) -> unique_int
+    {
+        println("calling copy");
+        return unique_int(self->val);
+    }
+
+    fn assign(self: &unique_int, other: &unique_int)
+    {
+        println("calling assign");
+        other->val = self->val;
+    }
 }
 
-a := vec2(2, 3);
-b := vec2(1, 2);
-a = b;
+{
+    x := unique_int(5);
+    y := x;
+    println(x.val);
+    println(y.val);
 
-println(a.x);
-println(a.y);
+    println("done");
+}
+
+println("after");

--- a/examples/test.az
+++ b/examples/test.az
@@ -5,6 +5,10 @@ struct vec2
     y: i64;
 }
 
-l := [vec2(1, 1), vec2(2, 2)];
+fn constructor(x: i64, y: i64) -> vec2
+{
+    return vec2(x, y);
+}
 
-a := l[0u];
+a := constructor(0, 1);
+println(a.x);

--- a/examples/test.az
+++ b/examples/test.az
@@ -3,7 +3,7 @@ struct unique_int
 {
     val: i64;
 
-    fn copy = null;
+    fn copy = default;
 }
 
 {

--- a/examples/test.az
+++ b/examples/test.az
@@ -9,7 +9,7 @@ struct vec2
 
 a := vec2(2, 3);
 b := vec2(1, 2);
-a = b;
+c := b;
 
-println(a.x);
-println(a.y);
+println(c.x);
+println(c.y);

--- a/examples/test.az
+++ b/examples/test.az
@@ -9,7 +9,7 @@ struct vec2
 
 a := vec2(2, 3);
 b := vec2(1, 2);
-c := b;
+a = b;
 
-println(c.x);
-println(c.y);
+println(a.x);
+println(a.y);

--- a/examples/test.az
+++ b/examples/test.az
@@ -3,6 +3,12 @@ struct vec2
 {
     x: i64;
     y: i64;
+
+    fn copy(self: &vec2, other: &vec2)
+    {
+        self->x = other->x;
+        self->y = other->y;
+    }
 }
 
 fn constructor(x: i64, y: i64) -> vec2
@@ -10,5 +16,8 @@ fn constructor(x: i64, y: i64) -> vec2
     return vec2(x, y);
 }
 
-a := constructor(0, 1);
+b := vec2(1, 2);
+a := b;
+
 println(a.x);
+println(a.y);

--- a/examples/test.az
+++ b/examples/test.az
@@ -5,6 +5,15 @@ struct unique_int
 
     fn copy = delete;
     fn assign = delete;
+    fn drop(self: &unique_int)
+    {
+        println("dropping");
+    }
+}
+
+fn add(x: i64, y: i64) -> i64
+{
+    return x + y;
 }
 
 fn myfunc(x: unique_int)
@@ -14,9 +23,13 @@ fn myfunc(x: unique_int)
 
 {
     x := unique_int(5);
-    myfunc(x);
+    #myfunc(x);
 
     println("done");
+    println(add(3, 4));
+    a := 5;
+    b := 6;
+    println(add(a, b));
 }
 
 println("after");

--- a/examples/test.az
+++ b/examples/test.az
@@ -3,21 +3,12 @@ struct unique_int
 {
     val: i64;
 
-    fn drop(self: &unique_int)
-    {
-        println("calling drop");
-    }
-
     fn copy = null;
-    fn assign = null;
 }
 
 {
     x := unique_int(5);
     y := x;
-    println(x.val);
-    println(y.val);
-    y = x;
     println("after assign");
 
     println("done");

--- a/examples/test.az
+++ b/examples/test.az
@@ -4,16 +4,7 @@ struct vec2
     x: i64;
     y: i64;
 
-    fn copy(self: &vec2, other: &vec2)
-    {
-        self->x = other->x;
-        self->y = other->y;
-    }
-}
-
-fn constructor(x: i64, y: i64) -> vec2
-{
-    return vec2(x, y);
+    fn copy = null;
 }
 
 a := vec2(2, 3);

--- a/examples/test.az
+++ b/examples/test.az
@@ -8,17 +8,8 @@ struct unique_int
         println("calling drop");
     }
 
-    fn copy(self: &unique_int) -> unique_int
-    {
-        println("calling copy");
-        return unique_int(self->val);
-    }
-
-    fn assign(self: &unique_int, other: &unique_int)
-    {
-        println("calling assign");
-        other->val = self->val;
-    }
+    fn copy = null;
+    fn assign = null;
 }
 
 {

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -183,4 +183,12 @@ auto print_node(const node_stmt& root, int indent) -> void
     }, root);
 }
 
+auto is_lvalue_expr(const node_expr& expr) -> bool
+{
+    return std::holds_alternative<node_variable_expr>(expr)
+        || std::holds_alternative<node_field_expr>(expr)
+        || std::holds_alternative<node_deref_expr>(expr)
+        || std::holds_alternative<node_subscript_expr>(expr);
+}
+
 }

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -139,6 +139,8 @@ struct node_expr : std::variant<
 {
 };
 
+auto is_lvalue_expr(const node_expr& expr) -> bool;
+
 struct node_stmt;
 using node_stmt_ptr = std::unique_ptr<node_stmt>;
 

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -1041,11 +1041,20 @@ void compile_stmt(compiler& com, const node_member_function_def_stmt& node)
     const auto name = std::format("{}::{}", node.struct_name, node.function_name);
 
     if (node.sig.special != signature::special_type::none) {
-        const auto key = function_key{
-            .name = name,
-            .args = { expected, expected }
-        };
-        com.functions[key] = { .sig=node.sig, .ptr=0, .tok=node.token };
+        if (node.function_name == "assign") {
+            const auto key = function_key{
+                .name = name,
+                .args = { expected, expected }
+            };
+            com.functions[key] = { .sig=node.sig, .ptr=0, .tok=node.token };
+        }
+        else if (node.function_name == "copy") {
+            const auto key = function_key{
+                .name = name,
+                .args = { expected }
+            };
+            com.functions[key] = { .sig=node.sig, .ptr=0, .tok=node.token };
+        }
         return;
     }
     compiler_assert(node.sig.params.size() >= 1, node.token, "member functions must have at least one arg");

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -941,10 +941,29 @@ void compile_stmt(compiler& com, const node_declaration_stmt& node)
 
 void compile_stmt(compiler& com, const node_assignment_stmt& node)
 {
-    const auto rhs = compile_expr_val(com, *node.expr);
-    if (is_lvalue_expr(*node.expr) && !is_type_fundamental(rhs)) {
-        compiler_error(node.token, "{} cannot be copy-assigned", rhs);
+    const auto type = type_of_expr(com, *node.expr);
+    if (is_lvalue_expr(*node.expr) && !is_type_fundamental(type)) {
+        auto copy_fn = function_key{};
+        copy_fn.name = std::format("{}::copy", type);;
+        copy_fn.args = { concrete_ptr_type(type), concrete_ptr_type(type) };
+        if (auto it = com.functions.find(copy_fn); it != com.functions.end()) {
+            const auto& [sig, ptr, tok] = it->second;
+            push_literal(com, std::uint64_t{0}); // base ptr
+            push_literal(com, std::uint64_t{0}); // prog ptr
+            compile_expr_ptr(com, *node.position);
+            compile_expr_ptr(com, *node.expr);
+
+            com.program.emplace_back(op_function_call{
+                .name=copy_fn.name,
+                .ptr=ptr + 1, // Jump into the function
+                .args_size=2 * com.types.size_of(concrete_ptr_type(type)) + 2 * sizeof(std::uint64_t)
+            });
+            com.program.emplace_back(op_pop{ .size = com.types.size_of(sig.return_type) });
+        } else {
+            compiler_error(node.token, "{} cannot be copy-constructed", type);
+        }
     } else {
+        const auto rhs = compile_expr_val(com, *node.expr);
         const auto lhs = compile_expr_ptr(com, *node.position);
         compiler_assert_eq(lhs, rhs, node.token, "invalid assignment");
         com.program.emplace_back(op_save{ .size=com.types.size_of(lhs) });

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -1040,7 +1040,7 @@ void compile_function_body(
     declare_var(com, tok, "# old_base_ptr", u64_type()); // Store the old base ptr
     declare_var(com, tok, "# old_prog_ptr", u64_type()); // Store the old program ptr
     for (const auto& arg : sig.params) {
-        declare_var(com, tok, arg.name, arg.type); // TODO: run copy constructors here
+        declare_var(com, tok, arg.name, arg.type);
     }
     compile_stmt(com, *body);
 

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -903,10 +903,37 @@ void compile_stmt(compiler& com, const node_continue_stmt&)
 
 void compile_stmt(compiler& com, const node_declaration_stmt& node)
 {
-    const auto type = compile_expr_val(com, *node.expr);
+    const auto type = type_of_expr(com, *node.expr);
     if (is_lvalue_expr(*node.expr) && !is_type_fundamental(type)) {
-        compiler_error(node.token, "{} cannot be copy-constructed", type);
+        // 1) Create space for new variable
+        const auto bytes = std::vector(com.types.size_of(type), std::byte{0});
+        com.program.emplace_back(op_load_bytes{ .bytes = bytes });
+
+        // 2) Assign that space to the new variable
+        declare_var(com, node.token, node.name, type);
+
+        // 3) Call copy assignment
+        auto copy_fn = function_key{};
+        copy_fn.name = std::format("{}::copy", type);;
+        copy_fn.args = { concrete_ptr_type(type), concrete_ptr_type(type) };
+        if (auto it = com.functions.find(copy_fn); it != com.functions.end()) {
+            const auto& [sig, ptr, tok] = it->second;
+            push_literal(com, std::uint64_t{0}); // base ptr
+            push_literal(com, std::uint64_t{0}); // prog ptr
+            push_var_addr(com, node.token, node.name);
+            compile_expr_ptr(com, *node.expr);
+
+            com.program.emplace_back(op_function_call{
+                .name=copy_fn.name,
+                .ptr=ptr + 1, // Jump into the function
+                .args_size=2 * com.types.size_of(concrete_ptr_type(type)) + 2 * sizeof(std::uint64_t)
+            });
+            com.program.emplace_back(op_pop{ .size = com.types.size_of(sig.return_type) });
+        } else {
+            compiler_error(node.token, "{} cannot be copy-constructed", type);
+        }
     } else {
+        const auto type = compile_expr_val(com, *node.expr);
         declare_var(com, node.token, node.name, type);
         save_variable(com, node.token, node.name);
     }

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -905,7 +905,7 @@ void compile_stmt(compiler& com, const node_declaration_stmt& node)
 {
     const auto type = compile_expr_val(com, *node.expr);
     if (is_lvalue_expr(*node.expr) && !is_type_fundamental(type)) {
-        compiler_error(node.token, "copy construction not defined for {}", type);
+        compiler_error(node.token, "{} cannot be copy-constructed", type);
     } else {
         declare_var(com, node.token, node.name, type);
         save_variable(com, node.token, node.name);
@@ -916,7 +916,7 @@ void compile_stmt(compiler& com, const node_assignment_stmt& node)
 {
     const auto rhs = compile_expr_val(com, *node.expr);
     if (is_lvalue_expr(*node.expr) && !is_type_fundamental(rhs)) {
-        compiler_error(node.token, "copy assignment not defined for {}", rhs);
+        compiler_error(node.token, "{} cannot be copy-assigned", rhs);
     } else {
         const auto lhs = compile_expr_ptr(com, *node.position);
         compiler_assert_eq(lhs, rhs, node.token, "invalid assignment");

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -904,7 +904,7 @@ void compile_stmt(compiler& com, const node_declaration_stmt& node)
         copy_fn.args = { concrete_ptr_type(type) };
         const auto it = com.functions.find(copy_fn);
         if (it == com.functions.end()) {
-            compiler_error(node.token, "{} cannot be copy-constructed", type);
+            compiler_error(node.token, "{} cannot be copied", type);
         }
         const auto& [sig, ptr, tok] = it->second;
 
@@ -945,7 +945,7 @@ void compile_stmt(compiler& com, const node_assignment_stmt& node)
         copy_fn.args = { concrete_ptr_type(type), concrete_ptr_type(type) };
         const auto it = com.functions.find(copy_fn);
         if (it == com.functions.end()) {
-            compiler_error(node.token, "{} cannot be copy-assigned", type);
+            compiler_error(node.token, "{} cannot be assigned", type);
         }
         const auto& [sig, ptr, tok] = it->second;
 
@@ -956,7 +956,7 @@ void compile_stmt(compiler& com, const node_assignment_stmt& node)
             com.program.emplace_back(op_save{ .size=com.types.size_of(lhs) });
             return;
         } else if (sig.special == signature::special_type::deleted) {
-            compiler_error(node.token, "{} is a non-copyable type", type);
+            compiler_error(node.token, "{} is a non-assignable type", type);
         }
 
         push_literal(com, std::uint64_t{0}); // base ptr

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -252,13 +252,6 @@ auto push_var_addr(compiler& com, const token& tok, const std::string& name) -> 
     compiler_error(tok, "could not find variable '{}'\n", name);
 }
 
-auto save_variable(compiler& com, const token& tok, const std::string& name) -> void
-{
-    const auto type = push_var_addr(com, tok, name);
-    const auto size = com.types.size_of(type);
-    com.program.emplace_back(op_save{ .size=size });
-}
-
 auto load_variable(compiler& com, const token& tok, const std::string& name) -> void
 {
     const auto type = push_var_addr(com, tok, name);
@@ -918,7 +911,6 @@ void compile_stmt(compiler& com, const node_declaration_stmt& node)
         if (sig.special == signature::special_type::defaulted) {
             const auto type = compile_expr_val(com, *node.expr);
             declare_var(com, node.token, node.name, type);
-            save_variable(com, node.token, node.name);
             return;
         } else if (sig.special == signature::special_type::deleted) {
             compiler_error(node.token, "{} is a non-copyable type", type);
@@ -941,7 +933,6 @@ void compile_stmt(compiler& com, const node_declaration_stmt& node)
     } else {
         const auto type = compile_expr_val(com, *node.expr);
         declare_var(com, node.token, node.name, type);
-        save_variable(com, node.token, node.name);
     }
 }
 

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -1029,6 +1029,9 @@ void compile_stmt(compiler& com, const node_function_def_stmt& node)
 
 void compile_stmt(compiler& com, const node_member_function_def_stmt& node)
 {
+    if (node.sig.special != signature::special_type::none) {
+        return;
+    }
     compiler_assert(node.sig.params.size() >= 1, node.token, "member functions must have at least one arg");
 
     const auto expected = concrete_ptr_type(make_type(node.struct_name));

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -101,8 +101,16 @@ struct signature
         auto operator==(const parameter&) const -> bool = default;
     };
 
+    enum class special_type
+    {
+        none,
+        deleted,
+        defaulted,
+    };
+
     std::vector<parameter> params;
     type_name              return_type;
+    special_type           special = special_type::none;
     auto operator==(const signature&) const -> bool = default;
 };
 

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -90,6 +90,8 @@ auto is_ptr_type(const type_name& t) -> bool;
 // type with a single subtype.
 auto inner_type(const type_name& t) -> type_name;
 
+auto is_type_fundamental(const type_name& type) -> bool;
+
 struct signature
 {
     struct parameter

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -388,6 +388,8 @@ auto parse_member_function_def_stmt(
         } else {
             parser_assert(false, stmt.token, "can only =default or =delete");
         }
+        stmt.sig.return_type = null_type();
+        stmt.body = std::make_unique<node_stmt>(node_sequence_stmt{});
         tokens.consume_only(tk_semicolon);
         return node;
     }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -380,7 +380,11 @@ auto parse_member_function_def_stmt(
     stmt.struct_name = struct_name;
     stmt.function_name = parse_name(tokens);
     if (tokens.consume_maybe(tk_assign)) {
-        parser_assert(stmt.function_name == "copy", stmt.token, "only copy can be deleted or defaulted");
+        parser_assert(
+            stmt.function_name == "copy" || stmt.function_name == "assign",
+            stmt.token,
+            "only copy and assign can be deleted or defaulted"
+        );
         if (tokens.consume_maybe(tk_null)) { // defaulted
             stmt.sig.special = signature::special_type::defaulted;
         } else if (tokens.consume_maybe(tk_delete)) { // deleted

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -385,7 +385,7 @@ auto parse_member_function_def_stmt(
             stmt.token,
             "only copy and assign can be deleted or defaulted"
         );
-        if (tokens.consume_maybe(tk_null)) { // defaulted
+        if (tokens.consume_maybe(tk_default)) { // defaulted
             stmt.sig.special = signature::special_type::defaulted;
         } else if (tokens.consume_maybe(tk_delete)) { // deleted
             stmt.sig.special = signature::special_type::deleted;

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -379,6 +379,18 @@ auto parse_member_function_def_stmt(
     stmt.token = tokens.consume_only(tk_function);
     stmt.struct_name = struct_name;
     stmt.function_name = parse_name(tokens);
+    if (tokens.consume_maybe(tk_assign)) {
+        parser_assert(stmt.function_name == "copy", stmt.token, "only copy can be deleted or defaulted");
+        if (tokens.consume_maybe(tk_null)) { // defaulted
+            stmt.sig.special = signature::special_type::defaulted;
+        } else if (tokens.consume_maybe(tk_delete)) { // deleted
+            stmt.sig.special = signature::special_type::deleted;
+        } else {
+            parser_assert(false, stmt.token, "can only =default or =delete");
+        }
+        tokens.consume_only(tk_semicolon);
+        return node;
+    }
     tokens.consume_only(tk_lparen);
     tokens.consume_comma_separated_list(tk_rparen, [&]{
         auto param = signature::parameter{};

--- a/src/vocabulary.cpp
+++ b/src/vocabulary.cpp
@@ -10,7 +10,7 @@ auto is_keyword(std::string_view token) -> bool
     static const std::unordered_set<std::string_view> tokens = {
         tk_break, tk_continue, tk_else, tk_false, tk_for, tk_if, tk_in, tk_null, tk_true,
         tk_while, tk_bool, tk_function, tk_return, tk_struct, tk_sizeof, tk_char,
-        tk_i32, tk_i64, tk_u64, tk_f64, tk_new, tk_delete
+        tk_i32, tk_i64, tk_u64, tk_f64, tk_new, tk_delete, tk_default
     };
     return tokens.contains(token);
 }

--- a/src/vocabulary.hpp
+++ b/src/vocabulary.hpp
@@ -22,6 +22,7 @@ constexpr auto tk_struct    = sv{"struct"};
 constexpr auto tk_sizeof    = sv{"sizeof"};
 constexpr auto tk_new       = sv{"new"};
 constexpr auto tk_delete    = sv{"delete"};
+constexpr auto tk_default   = sv{"default"};
 
 // Builtin Types
 constexpr auto tk_i32       = sv{"i32"};


### PR DESCRIPTION
* Two new special member functions `fn copy(self: &T) -> T` and `fn assign(self: &T, other: &T)`
* `copy` is called for declarations (`x := y`) and function parameters if the right hand side is an lvalue. If it's an rvalue, no copy constructor is called and the object is just moved (memcpy'd).
* `assign` is called for assignments (`x = y`) if the right hand side is an lvalue. If it's an rvalue, it is similarly just moved.
* `copy` and `assign` can be defaulted with the syntax `fn copy = default` and `fn assign = default`. This just makes them act like a memcpy which is how fundamental types behave.
* By default, `copy` and `assign` are deleted.
* Really, the `= default` should be the default behaviour, otherwise it's a bad name. It's also less verbose for simple types.
* The compiler should enforce that if a user implements one of `drop`, `copy` and `assign`, they must implement or `= delete` or explicitly `= default` them all (rule of 3).
* They can also be specified as `= delete` to disable copying and assigning, making it possible to implement something similar to `std::unique_ptr<T>` in C++.
* The code needs a big clean up, but it works.
* Fixed a bug where `drop` was not getting called on function parameters.