### PR TITLE
Copy/Assign for Arrays

### DIFF
--- a/examples/test.az
+++ b/examples/test.az
@@ -8,7 +8,6 @@ struct unique_int
     fn drop(self: &unique_int)
     {
         println("dropping");
-        println(self->val);
     }
 }
 
@@ -23,7 +22,7 @@ fn myfunc(x: unique_int)
 }
 
 {
-    x := [1, 2, 3];
-    x = [4, 5, 6, 7];
-    println(x[0u]);
+    x := [1, 2];
+    y := x;
+    println(y[0u].val);
 }

--- a/examples/test.az
+++ b/examples/test.az
@@ -22,9 +22,7 @@ fn myfunc(x: unique_int)
 }
 
 {
-    t := new i64;
-    x := [t, t];
-    y := x;
-    println(y[0u]);
-    delete t;
+    x := [unique_int(5), unique_int(6)];
+    y := [unique_int(1), unique_int(2)];
+    x = y;
 }

--- a/examples/test.az
+++ b/examples/test.az
@@ -22,7 +22,9 @@ fn myfunc(x: unique_int)
 }
 
 {
-    x := [1, 2];
+    t := new i64;
+    x := [t, t];
     y := x;
-    println(y[0u].val);
+    println(y[0u]);
+    delete t;
 }

--- a/examples/test.az
+++ b/examples/test.az
@@ -23,14 +23,7 @@ fn myfunc(x: unique_int)
 }
 
 {
-    x := unique_int(5);
-    #myfunc(x);
-
-    println("done");
-    println(add(3, 4));
-    a := 5;
-    b := 6;
-    println(add(a, b));
+    x := [1, 2, 3];
+    x = [4, 5, 6, 7];
+    println(x[0u]);
 }
-
-println("after");

--- a/examples/test.az
+++ b/examples/test.az
@@ -3,8 +3,16 @@ struct unique_int
 {
     val: i64;
 
-    fn copy = delete;
-    fn assign = delete;
+    fn copy(self: &unique_int) -> unique_int
+    {
+        return unique_int(self->val);
+    }
+
+    fn assign(self: &unique_int, other: &unique_int)
+    {
+        other->val = self->val;
+    }
+
     fn drop(self: &unique_int)
     {
         println("dropping");
@@ -23,6 +31,6 @@ fn myfunc(x: unique_int)
 
 {
     x := [unique_int(5), unique_int(6)];
-    y := [unique_int(1), unique_int(2)];
-    x = y;
+    y := x;
+    println(y[0u].val);
 }

--- a/examples/test.az
+++ b/examples/test.az
@@ -8,6 +8,7 @@ struct unique_int
     fn drop(self: &unique_int)
     {
         println("dropping");
+        println(self->val);
     }
 }
 

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -191,4 +191,9 @@ auto is_lvalue_expr(const node_expr& expr) -> bool
         || std::holds_alternative<node_subscript_expr>(expr);
 }
 
+auto is_rvalue_expr(const node_expr& expr) -> bool
+{
+    return !is_lvalue_expr(expr);
+}
+
 }

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -140,6 +140,7 @@ struct node_expr : std::variant<
 };
 
 auto is_lvalue_expr(const node_expr& expr) -> bool;
+auto is_rvalue_expr(const node_expr& expr) -> bool;
 
 struct node_stmt;
 using node_stmt_ptr = std::unique_ptr<node_stmt>;

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -949,7 +949,7 @@ void compile_stmt(compiler& com, const node_continue_stmt&)
 void compile_stmt(compiler& com, const node_declaration_stmt& node)
 {
     const auto type = type_of_expr(com, *node.expr);
-    if (!is_lvalue_expr(*node.expr) || is_type_fundamental(type)) {
+    if (is_rvalue_expr(*node.expr) || is_type_trivially_copyable(type)) {
         const auto type = compile_expr_val(com, *node.expr);
         declare_var(com, node.token, node.name, type);
         return;
@@ -960,6 +960,7 @@ void compile_stmt(compiler& com, const node_declaration_stmt& node)
         const auto length = array_length(type);
         const auto inner_size = com.types.size_of(etype);
         const auto it = com.functions.find(copy_fn(etype));
+
         if (it == com.functions.end()) {
             compiler_error(node.token, "{} cannot be copied", etype);
         }

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -359,7 +359,7 @@ auto call_destructor(compiler& com, const type_name& type, compile_obj_ptr_cb co
         com.program.emplace_back(op_function_call{
             .name=destructor_name,
             .ptr=ptr + 1, // Jump into the function
-            .args_size=com.types.size_of(concrete_ptr_type(type)) + 2 * sizeof(std::uint64_t)
+            .args_size=signature_args_size(com, sig)
         });
         com.program.emplace_back(op_pop{ .size = com.types.size_of(sig.return_type) });
     }
@@ -703,7 +703,7 @@ auto compile_expr_val(compiler& com, const node_function_call_expr& node) -> typ
                 com.program.emplace_back(op_function_call{
                     .name=copy_fn.name,
                     .ptr=ptr + 1, // Jump into the function
-                    .args_size=com.types.size_of(concrete_ptr_type(type)) + 2 * sizeof(std::uint64_t)
+                    .args_size=signature_args_size(com, sig)
                 });
 
             } else {
@@ -956,7 +956,7 @@ void compile_stmt(compiler& com, const node_declaration_stmt& node)
         com.program.emplace_back(op_function_call{
             .name=copy_fn.name,
             .ptr=ptr + 1, // Jump into the function
-            .args_size=com.types.size_of(concrete_ptr_type(type)) + 2 * sizeof(std::uint64_t)
+            .args_size=signature_args_size(com, sig)
         });
 
         // Store the result as the new variable
@@ -999,7 +999,7 @@ void compile_stmt(compiler& com, const node_assignment_stmt& node)
         com.program.emplace_back(op_function_call{
             .name=copy_fn.name,
             .ptr=ptr + 1, // Jump into the function
-            .args_size=2 * com.types.size_of(concrete_ptr_type(type)) + 2 * sizeof(std::uint64_t)
+            .args_size=signature_args_size(com, sig)
         });
         com.program.emplace_back(op_pop{ .size = com.types.size_of(sig.return_type) });
     } else {

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -137,6 +137,16 @@ auto inner_type(const type_name& t) -> type_name
     return {};
 }
 
+auto array_length(const type_name& t) -> std::size_t
+{
+    if (is_list_type(t)) {
+        return std::get<type_list>(t).count;
+    }
+    print("OH NO MY TYPE\n");
+    std::exit(1);
+    return {};
+}
+
 auto is_type_fundamental(const type_name& type) -> bool
 {
     return type == i32_type()

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -158,6 +158,13 @@ auto is_type_fundamental(const type_name& type) -> bool
         || type == null_type();
 }
 
+auto is_type_trivially_copyable(const type_name& type) -> bool
+{
+    return is_type_fundamental(type)
+        || is_ptr_type(type)
+        || (is_list_type(type) && is_type_trivially_copyable(inner_type(type)));
+}
+
 auto to_string(const signature& sig) -> std::string
 {
     const auto proj = [](const auto& arg) { return arg.type; };

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -89,9 +89,13 @@ auto is_ptr_type(const type_name& t) -> bool;
 // Extracts the single inner type of the given t. Undefined if the given t is not a compound
 // type with a single subtype.
 auto inner_type(const type_name& t) -> type_name;
+
+// Extracts the array size of the given type. Undefined if the given t is not an array
 auto array_length(const type_name& t) -> std::size_t;
 
 auto is_type_fundamental(const type_name& type) -> bool;
+
+auto is_type_trivially_copyable(const type_name& type) -> bool;
 
 struct signature
 {

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -89,6 +89,7 @@ auto is_ptr_type(const type_name& t) -> bool;
 // Extracts the single inner type of the given t. Undefined if the given t is not a compound
 // type with a single subtype.
 auto inner_type(const type_name& t) -> type_name;
+auto array_length(const type_name& t) -> std::size_t;
 
 auto is_type_fundamental(const type_name& type) -> bool;
 

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -387,6 +387,7 @@ auto parse_member_function_def_stmt(
         );
         if (tokens.consume_maybe(tk_default)) { // defaulted
             stmt.sig.special = signature::special_type::defaulted;
+            parser_error(stmt.token, "defaulting copy/assign currently not supported");
         } else if (tokens.consume_maybe(tk_delete)) { // deleted
             stmt.sig.special = signature::special_type::deleted;
         } else {


### PR DESCRIPTION
* Fixes a bunch of holes, most notably copying and assigning from arrays. These now call the correct functions if provided.
* Fixes a bug where pointers were classed as not copyable/assignable. Introduced `is_type_trivially_copyable` which is true if the type is fundamental, a pointer, or an array of trivially copyable types. Currently only defined for builtin types (although pointers to user types are fine).
* Disabled `= default` for copy and assign for now, since that needs to call the copy/assign functions for the members rather than just doing a memcpy. With that, there should be no holes in the lifetime model now.
* Will reenable `= default` at some point, and make that the actual default when it is done. For now, user types are not copyable/assignable by default and implementations must be provided (though rvalues are still fine).
* The code was a mess before, and it's worse now, a cleanup of this code should be done before implementing more.