### PR TITLE
Move Asserts to Token

### DIFF
--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -148,7 +148,7 @@ auto lex_line(
     -> void
 {
     const auto push_token = [&](const std::string& text, std::int64_t col, token_type type) {
-        tokens.push_back({ .text=text, .line=lineno, .col=col, .type=type });
+        tokens.push_back({ text, lineno, col, type });
     };
 
     auto iter = line_iterator{line};

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -75,8 +75,7 @@ auto parse_f64(const token& tok) -> object
 
 auto parse_char(const token& tok) -> object
 {
-    tok.assert(tok.text.size() == 1, "failed to parse char");
-
+    tok.assert_eq(tok.text.size(), 1, "failed to parse char");
     const auto bytes = as_bytes(tok.text.front());
     return object{ .data={bytes.begin(), bytes.end()}, .type=char_type() };
 }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -12,32 +12,16 @@
 namespace anzu {
 namespace {
 
-template <typename... Args>
-[[noreturn]] void parser_error(const token& tok, std::string_view msg, Args&&... args)
-{
-    const auto formatted_msg = std::format(msg, std::forward<Args>(args)...);
-    print("[ERROR] ({}:{}) {}\n", tok.line, tok.col, formatted_msg);
-    std::exit(1);
-}
-
-template <typename... Args>
-void parser_assert(bool cond, const token& tok, std::string_view msg, Args&&... args)
-{
-    if (!cond) {
-        parser_error(tok, msg, std::forward<Args>(args)...);
-    }
-}
-
 auto parse_i32(const token& tok) -> object
 {
     auto text = std::string_view{tok.text};
 
-    parser_assert(text.ends_with(tk_i32), tok, "expected suffix '{}'\n", tk_i32);
+    tok.assert(text.ends_with(tk_i32), "expected suffix '{}'\n", tk_i32);
     text.remove_suffix(tk_i32.size());
     
     auto result = std::int32_t{};
     const auto [ptr, ec] = std::from_chars(text.data(), text.data() + text.size(), result);
-    parser_assert(ec == std::errc{}, tok, "cannot convert '{}' to '{}'\n", text, tk_i32);
+    tok.assert(ec == std::errc{}, "cannot convert '{}' to '{}'\n", text, tk_i32);
 
     const auto bytes = as_bytes(result);
     return object{ .data={bytes.begin(), bytes.end()}, .type=i32_type() };
@@ -53,7 +37,7 @@ auto parse_i64(const token& tok) -> object
 
     auto result = std::int64_t{};
     const auto [ptr, ec] = std::from_chars(text.data(), text.data() + text.size(), result);
-    parser_assert(ec == std::errc{}, tok, "cannot convert '{}' to '{}'\n", text, tk_i64);
+    tok.assert(ec == std::errc{}, "cannot convert '{}' to '{}'\n", text, tk_i64);
 
     const auto bytes = as_bytes(result);
     return object{ .data={bytes.begin(), bytes.end()}, .type=i64_type() };
@@ -71,7 +55,7 @@ auto parse_u64(const token& tok) -> object
 
     auto result = std::uint64_t{};
     const auto [ptr, ec] = std::from_chars(text.data(), text.data() + text.size(), result);
-    parser_assert(ec == std::errc{}, tok, "cannot convert '{}' to '{}'\n", text, tk_u64);
+    tok.assert(ec == std::errc{}, "cannot convert '{}' to '{}'\n", text, tk_u64);
 
     const auto bytes = as_bytes(result);
     return object{ .data={bytes.begin(), bytes.end()}, .type=u64_type() };
@@ -83,7 +67,7 @@ auto parse_f64(const token& tok) -> object
 
     auto result = double{};
     const auto [ptr, ec] = std::from_chars(text.data(), text.data() + text.size(), result);
-    parser_assert(ec == std::errc{}, tok, "cannot convert '{}' to '{}'\n", text, tk_f64);
+    tok.assert(ec == std::errc{}, "cannot convert '{}' to '{}'\n", text, tk_f64);
 
     const auto bytes = as_bytes(result);
     return object{ .data={bytes.begin(), bytes.end()}, .type=f64_type() };
@@ -91,7 +75,7 @@ auto parse_f64(const token& tok) -> object
 
 auto parse_char(const token& tok) -> object
 {
-    parser_assert(tok.text.size() == 1, tok, "failed to parse char");
+    tok.assert(tok.text.size() == 1, "failed to parse char");
 
     const auto bytes = as_bytes(tok.text.front());
     return object{ .data={bytes.begin(), bytes.end()}, .type=char_type() };
@@ -136,7 +120,7 @@ auto parse_literal(tokenstream& tokens) -> object
     if (tokens.consume_maybe(tk_null)) {
         return object{ .data{std::byte{0}}, .type=null_type() };
     }
-    parser_error(tokens.curr(), "failed to parse literal ({})", tokens.curr().text);
+    tokens.curr().error("failed to parse literal ({})", tokens.curr().text);
 };
 
 auto precedence_table()
@@ -323,7 +307,7 @@ auto parse_name(tokenstream& tokens)
 {
     const auto token = tokens.consume();
     if (token.type != token_type::name) {
-        parser_error(token, "'{}' is not a valid name", token.text);
+        token.error("'{}' is not a valid name", token.text);
     }
     return token.text;   
 }
@@ -380,18 +364,17 @@ auto parse_member_function_def_stmt(
     stmt.struct_name = struct_name;
     stmt.function_name = parse_name(tokens);
     if (tokens.consume_maybe(tk_assign)) {
-        parser_assert(
+        stmt.token.assert(
             stmt.function_name == "copy" || stmt.function_name == "assign",
-            stmt.token,
             "only copy and assign can be deleted or defaulted"
         );
         if (tokens.consume_maybe(tk_default)) { // defaulted
             stmt.sig.special = signature::special_type::defaulted;
-            parser_error(stmt.token, "defaulting copy/assign currently not supported");
+            stmt.token.error("defaulting copy/assign currently not supported");
         } else if (tokens.consume_maybe(tk_delete)) { // deleted
             stmt.sig.special = signature::special_type::deleted;
         } else {
-            parser_assert(false, stmt.token, "can only =default or =delete");
+            stmt.token.error("can only =default or =delete");
         }
         stmt.sig.return_type = null_type();
         stmt.body = std::make_unique<node_stmt>(node_sequence_stmt{});
@@ -523,7 +506,7 @@ auto parse_statement(tokenstream& tokens) -> node_stmt_ptr
 {
     while (tokens.consume_maybe(tk_semicolon));
     if (tokens.peek(tk_function) || tokens.peek(tk_struct)) {
-        parser_error(tokens.curr(), "functions and structs can only be declared in the global scope");
+        tokens.curr().error("functions and structs can only be declared in the global scope");
     }
     if (tokens.peek(tk_return)) {
         return parse_return_stmt(tokens);

--- a/src/token.cpp
+++ b/src/token.cpp
@@ -16,7 +16,7 @@ auto is_consumable_type(token_type type) -> bool
 
 }
 
-auto token::error(std::string_view message) const -> void
+void token::error(std::string_view message) const
 {
     print("[ERROR] ({}:{}) {}\n", line, col, message);
     std::exit(1);

--- a/src/token.cpp
+++ b/src/token.cpp
@@ -25,16 +25,16 @@ void token::error(std::string_view message) const
 auto to_string(token_type type) -> std::string
 {
     switch (type) {
-        break; case token_type::keyword:   { return "keyword"; };
-        break; case token_type::symbol:    { return "symbol"; };
-        break; case token_type::name:      { return "name"; };
-        break; case token_type::character: { return "character"; };
-        break; case token_type::string:    { return "string"; };
-        break; case token_type::i32:       { return "i32"; };
-        break; case token_type::i64:       { return "i64"; };
-        break; case token_type::u64:       { return "u64"; };
-        break; case token_type::f64:       { return "f64"; };
-        break; default:                    { return "UNKNOWN"; };
+        break; case token_type::keyword:   { return "keyword"; }
+        break; case token_type::symbol:    { return "symbol"; }
+        break; case token_type::name:      { return "name"; }
+        break; case token_type::character: { return "character"; }
+        break; case token_type::string:    { return "string"; }
+        break; case token_type::i32:       { return "i32"; }
+        break; case token_type::i64:       { return "i64"; }
+        break; case token_type::u64:       { return "u64"; }
+        break; case token_type::f64:       { return "f64"; }
+        break; default:                    { return "UNKNOWN"; }
     }
 }
 
@@ -66,9 +66,7 @@ auto tokenstream::consume_only(std::string_view text) -> token
         std::exit(1);
     }
     if (curr().text != text || !is_consumable_type(curr().type)) {
-        const auto [tok_text, line, col, type] = curr();
-        anzu::print("[ERROR] ({}:{}) expected '{}', got '{}'\n", line, col, text, tok_text);
-        std::exit(1);
+        curr().error("expected {}, got '{}'\n", text, curr().text);
     }
     return consume();
 }
@@ -80,9 +78,7 @@ auto tokenstream::consume_i64() -> std::int64_t
         std::exit(1);
     }
     if (curr().type != token_type::i64) {
-        const auto [tok_text, line, col, type] = curr();
-        anzu::print("[ERROR] ({}:{}) expected an int, got '{}\n", line, col, tok_text);
-        std::exit(1);
+        curr().error("expected i64, got '{}'\n", curr().text);
     }
     return std::stoll(consume().text);
 }
@@ -94,9 +90,7 @@ auto tokenstream::consume_u64() -> std::uint64_t
         std::exit(1);
     }
     if (curr().type != token_type::u64) {
-        const auto [tok_text, line, col, type] = curr();
-        anzu::print("[ERROR] ({}:{}) expected a uint, got '{}\n", line, col, tok_text);
-        std::exit(1);
+        curr().error("expected u64, got '{}'\n", curr().text);
     }
     return std::stoull(consume().text);
 }

--- a/src/token.cpp
+++ b/src/token.cpp
@@ -1,7 +1,10 @@
 #include "token.hpp"
 #include "utility/print.hpp"
 
+#include <format>
+
 namespace anzu {
+namespace {
 
 // Returns true if the value is either a keyword or a symbol, which are the only
 // types expected to be consumed by the consume_*, peek, curr and next functions.
@@ -9,6 +12,14 @@ namespace anzu {
 auto is_consumable_type(token_type type) -> bool
 {
     return type == token_type::keyword || type == token_type::symbol;
+}
+
+}
+
+auto token::error(std::string_view message) const -> void
+{
+    print("[ERROR] ({}:{}) {}\n", line, col, message);
+    std::exit(1);
 }
 
 auto to_string(token_type type) -> std::string

--- a/src/token.hpp
+++ b/src/token.hpp
@@ -28,18 +28,27 @@ struct token
     std::int64_t col;
     token_type   type;
 
-    [[noreturn]] auto error(std::string_view message) const -> void;
+    [[noreturn]] void error(std::string_view msg) const;
 
     template <typename... Args>
-    [[noreturn]] auto error(std::string_view message, Args&&... args) const -> void
+    [[noreturn]] void error(std::string_view msg, Args&&... args) const
     {
-        error(std::format(message, std::forward<Args>(args)...));
+        error(std::format(msg, std::forward<Args>(args)...));
     }
 
     template <typename... Args>
-    auto assert(bool condition, std::string_view message, Args&&... args) const -> void
+    void assert(bool condition, std::string_view msg, Args&&... args) const
     {
-        if (!condition) error(std::format(message, std::forward<Args>(args)...));
+        if (!condition) error(std::format(msg, std::forward<Args>(args)...));
+    }
+
+    template <typename... Args>
+    void assert_eq(const auto& lhs, const auto& rhs, std::string_view msg, Args&&... args) const
+    {
+        if (lhs != rhs) {
+            const auto user_msg = std::format(msg, std::forward<Args>(args)...);
+            error("{}: expected {}, got {}", user_msg, rhs, lhs);
+        }
     }
 };
 

--- a/src/token.hpp
+++ b/src/token.hpp
@@ -27,6 +27,20 @@ struct token
     std::int64_t line;
     std::int64_t col;
     token_type   type;
+
+    [[noreturn]] auto error(std::string_view message) const -> void;
+
+    template <typename... Args>
+    [[noreturn]] auto error(std::string_view message, Args&&... args) const -> void
+    {
+        error(std::format(message, std::forward<Args>(args)...));
+    }
+
+    template <typename... Args>
+    auto assert(bool condition, std::string_view message, Args&&... args) const -> void
+    {
+        if (!condition) error(std::format(message, std::forward<Args>(args)...));
+    }
 };
 
 auto to_string(token_type type) -> std::string;


### PR DESCRIPTION
* We had duplicate error checking functions in the parser and compiler, this PR moves them all onto the token class to make them available everywhere, and also makes the calls simpler.