### PR TITLE
Copy/Assign Cleanup

### DIFF
--- a/examples/feature_test.az
+++ b/examples/feature_test.az
@@ -101,6 +101,17 @@ struct vec2
 {
     x: i64;
     y: i64;
+
+    fn copy(self: &vec2) -> vec2
+    {
+        return vec2(self->x, self->y);
+    }
+
+    fn assign(self: &vec2, other: &vec2)
+    {
+        other->x = self->x;
+        other->y = self->y;
+    }
 }
 
 fn println(v: vec2) -> null
@@ -152,6 +163,17 @@ struct span
 {
     p: &vec2;
     size: u64;
+
+    fn copy(self: &span) -> span
+    {
+        return span(self->p, self->size);
+    }
+
+    fn assign(self: &span, other: &span)
+    {
+        other->p = self->p;
+        other->size = self->size;
+    }
 }
 
 fn test_ptr_arithmetic(s: span) -> null
@@ -187,6 +209,18 @@ struct vec3
         y_squared := square(self->y);
         z_squared := square(self->z);
         return sqrt(x_squared + y_squared + z_squared);
+    }
+
+    fn copy(self: &vec3) -> vec3
+    {
+        return vec3(self->x, self->y, self->z);
+    }
+
+    fn assign(self: &vec3, other: &vec3)
+    {
+        other->x = self->x;
+        other->y = self->y;
+        other->z = self->z;
     }
 }
 

--- a/examples/test.az
+++ b/examples/test.az
@@ -32,5 +32,6 @@ fn myfunc(x: unique_int)
 {
     x := [unique_int(5), unique_int(6)];
     y := x;
+    y = x;
     println(y[0u].val);
 }

--- a/examples/test.az
+++ b/examples/test.az
@@ -31,8 +31,11 @@ fn myfunc(x: unique_int)
 }
 
 {
-    x := [unique_int(null), unique_int(null)];
-    y := x;
-    y = x;
-    println(y[0u].val);
+    #x := [unique_int(null), unique_int(null)];
+    #y := x;
+    #y = x;
+    #println(y[0u].val);
+
+    unique_int(null);
+    println("after");
 }

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,16 +1,17 @@
 
 struct unique_int
 {
-    val: i64;
+    val: null;
 
     fn copy(self: &unique_int) -> unique_int
     {
-        return unique_int(self->val);
+        println("copying");
+        return unique_int(null);
     }
 
     fn assign(self: &unique_int, other: &unique_int)
     {
-        other->val = self->val;
+        println("assigning");
     }
 
     fn drop(self: &unique_int)
@@ -30,7 +31,7 @@ fn myfunc(x: unique_int)
 }
 
 {
-    x := [unique_int(5), unique_int(6)];
+    x := [unique_int(null), unique_int(null)];
     y := x;
     y = x;
     println(y[0u].val);

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -692,9 +692,6 @@ auto push_expr_val(compiler& com, const node_function_call_expr& node) -> type_n
                 const auto& [sig, ptr, tok] = it->second;
 
                 switch (sig.special) {
-                    break; case signature::special_type::defaulted: {
-                        push_expr_val(com, *arg);
-                    }
                     break; case signature::special_type::deleted: {
                         node.token.error("{} is a non-copyable type", type);
                     }
@@ -944,13 +941,7 @@ void compile_stmt(compiler& com, const node_declaration_stmt& node)
         const auto& [name, args] = it->first;
         const auto& [sig, ptr, tok] = it->second;
 
-        // This is definitely wrong here, but it's fine because we currently disallow
-        // defaulted copy. If the inner copy is default copyable, we still need to do the loop
-        if (sig.special == signature::special_type::defaulted) {
-            const auto type = push_expr_val(com, *node.expr);
-            declare_var(com, node.token, node.name, etype);
-            return;
-        } else if (sig.special == signature::special_type::deleted) {
+        if (sig.special == signature::special_type::deleted) {
             node.token.error("{} is a non-copyable type", etype);
         }
 
@@ -975,11 +966,7 @@ void compile_stmt(compiler& com, const node_declaration_stmt& node)
     const auto& [name, args] = it->first;
     const auto& [sig, ptr, tok] = it->second;
 
-    if (sig.special == signature::special_type::defaulted) {
-        const auto type = push_expr_val(com, *node.expr);
-        declare_var(com, node.token, node.name, type);
-        return;
-    } else if (sig.special == signature::special_type::deleted) {
+    if (sig.special == signature::special_type::deleted) {
         node.token.error("{} is a non-copyable type", type);
     }
 
@@ -1015,13 +1002,7 @@ void compile_stmt(compiler& com, const node_assignment_stmt& node)
         const auto& [name, args] = it->first;
         const auto& [sig, ptr, tok] = it->second;
 
-        if (sig.special == signature::special_type::defaulted) {
-            const auto rhs = push_expr_val(com, *node.expr);
-            const auto lhs = push_expr_ptr(com, *node.position);
-            node.token.assert_eq(lhs, rhs, "invalid assignment");
-            com.program.emplace_back(op_save{ .size=com.types.size_of(lhs) });
-            return;
-        } else if (sig.special == signature::special_type::deleted) {
+        if (sig.special == signature::special_type::deleted) {
             node.token.error("{} is a non-assignable type", etype);
         }
 
@@ -1051,13 +1032,7 @@ void compile_stmt(compiler& com, const node_assignment_stmt& node)
     const auto& [name, args] = it->first;
     const auto& [sig, ptr, tok] = it->second;
 
-    if (sig.special == signature::special_type::defaulted) {
-        const auto rhs = push_expr_val(com, *node.expr);
-        const auto lhs = push_expr_ptr(com, *node.position);
-        node.token.assert_eq(lhs, rhs, "invalid assignment");
-        com.program.emplace_back(op_save{ .size=com.types.size_of(lhs) });
-        return;
-    } else if (sig.special == signature::special_type::deleted) {
+    if (sig.special == signature::special_type::deleted) {
         node.token.error("{} is a non-assignable type", type);
     }
 

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -231,7 +231,7 @@ auto type_store::size_of(const type_name& type) const -> std::size_t
 auto type_store::fields_of(const type_name& t) const -> type_fields
 {
     if (auto it = d_classes.find(t); it != d_classes.end()) {
-        return it->second;
+        return it->second.fields;
     }
     return {};
 }

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -3,6 +3,7 @@
 #include "utility/print.hpp"
 #include "utility/overloaded.hpp"
 
+#include <cassert>
 #include <algorithm>
 #include <ranges>
 #include <string_view>

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -64,17 +64,9 @@ struct field
 };
 using type_fields = std::vector<field>;
 
-enum class special_fn
-{
-    deleted,
-    implemented,
-};
-
 struct type_info
 {
     type_fields fields;
-    special_fn  copy   = special_fn::deleted;
-    special_fn  assign = special_fn::deleted;
 };
 
 auto hash(const type_name& type) -> std::size_t;

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -62,8 +62,12 @@ struct field
     type_name   type;
     auto operator==(const field&) const -> bool = default;
 };
-
 using type_fields = std::vector<field>;
+
+struct type_info
+{
+    type_fields fields;
+};
 
 auto hash(const type_name& type) -> std::size_t;
 auto hash(const type_list& type) -> std::size_t;
@@ -122,7 +126,7 @@ struct signature
 class type_store
 {
     using type_hash = decltype([](const type_name& t) { return anzu::hash(t); });
-    std::unordered_map<type_name, type_fields, type_hash> d_classes;
+    std::unordered_map<type_name, type_info, type_hash> d_classes;
 
 public:
     auto add(const type_name& name, const type_fields& fields) -> bool;

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -64,9 +64,18 @@ struct field
 };
 using type_fields = std::vector<field>;
 
+enum class special_fn
+{
+    defaulted,
+    deleted,
+    implemented,
+};
+
 struct type_info
 {
     type_fields fields;
+    special_fn  copy   = special_fn::deleted;
+    special_fn  assign = special_fn::deleted;
 };
 
 auto hash(const type_name& type) -> std::size_t;
@@ -113,8 +122,7 @@ struct signature
     enum class special_type
     {
         none,
-        deleted,
-        defaulted,
+        deleted
     };
 
     std::vector<parameter> params;

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -66,7 +66,6 @@ using type_fields = std::vector<field>;
 
 enum class special_fn
 {
-    defaulted,
     deleted,
     implemented,
 };

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -110,15 +110,8 @@ struct signature
         auto operator==(const parameter&) const -> bool = default;
     };
 
-    enum class special_type
-    {
-        none,
-        deleted
-    };
-
     std::vector<parameter> params;
     type_name              return_type;
-    special_type           special = special_type::none;
     auto operator==(const signature&) const -> bool = default;
 };
 

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -362,21 +362,24 @@ auto parse_member_function_def_stmt(
     stmt.token = tokens.consume_only(tk_function);
     stmt.struct_name = struct_name;
     stmt.function_name = parse_name(tokens);
-    if (tokens.consume_maybe(tk_assign)) {
-        stmt.token.assert(
-            stmt.function_name == "copy" || stmt.function_name == "assign",
-            "only copy and assign can be deleted or defaulted"
-        );
-        if (tokens.consume_maybe(tk_delete)) { // deleted
-            stmt.sig.special = signature::special_type::deleted;
-        } else {
-            stmt.token.error("can only =delete a function");
-        }
-        stmt.sig.return_type = null_type();
-        stmt.body = std::make_unique<node_stmt>(node_sequence_stmt{});
-        tokens.consume_only(tk_semicolon);
-        return node;
-    }
+
+    // TODO: Reimplement the = delete/default logic 
+    //if (tokens.consume_maybe(tk_assign)) {
+    //    stmt.token.assert(
+    //        stmt.function_name == "copy" || stmt.function_name == "assign",
+    //        "only copy and assign can be deleted or defaulted"
+    //    );
+    //    if (tokens.consume_maybe(tk_delete)) { // deleted
+    //        stmt.sig.special = signature::special_type::deleted;
+    //    } else {
+    //        stmt.token.error("can only =delete a function");
+    //    }
+    //    stmt.sig.return_type = null_type();
+    //    stmt.body = std::make_unique<node_stmt>(node_sequence_stmt{});
+    //    tokens.consume_only(tk_semicolon);
+    //    return node;
+    //}
+    
     tokens.consume_only(tk_lparen);
     tokens.consume_comma_separated_list(tk_rparen, [&]{
         auto param = signature::parameter{};

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -367,13 +367,10 @@ auto parse_member_function_def_stmt(
             stmt.function_name == "copy" || stmt.function_name == "assign",
             "only copy and assign can be deleted or defaulted"
         );
-        if (tokens.consume_maybe(tk_default)) { // defaulted
-            stmt.sig.special = signature::special_type::defaulted;
-            stmt.token.error("defaulting copy/assign currently not supported");
-        } else if (tokens.consume_maybe(tk_delete)) { // deleted
+        if (tokens.consume_maybe(tk_delete)) { // deleted
             stmt.sig.special = signature::special_type::deleted;
         } else {
-            stmt.token.error("can only =default or =delete");
+            stmt.token.error("can only =delete a function");
         }
         stmt.sig.return_type = null_type();
         stmt.body = std::make_unique<node_stmt>(node_sequence_stmt{});


### PR DESCRIPTION
* Remove `=delete` and `=default` for now.
* `copy` and `assign` are deleted by default, and get the implementation if explicitly defined.
* Added `push_object_copy` to the compiler. This evaluates an expression and puts it on the stack, calling the copy constructor if it's an lvalue. This really should replace `push_expr_val` but I can't quite figure out how to do that yet. Potentially will be a huge simplification if I can do it.
* The above will also fix a bunch of other potential holes in the type system
* Added `pop_object`, which assumes the top of the stack contains an object of a certain type, then calls the destructor and pops the bytes. Used in order to call destructors for unassigned expressions. Should be the default function for removing data from the stack.
* Renamed a lot of the `compile_` functions to be `push_`.
* Lots of other simplifications in the compiler, cleaning the code up a bit.
* When calling destructors, move the array handling code from `_named_var` into the main `call_destructor`. Now destructors will be called on temporary unassigned arrays.