### PR TITLE
`lengthof` Operator

### DIFF
--- a/anzu-lang/syntaxes/anzu.tmLanguage.json
+++ b/anzu-lang/syntaxes/anzu.tmLanguage.json
@@ -17,7 +17,7 @@
 		},
 		{
 			"name": "keyword.other.anzu",
-			"match": "\\b(in|fn|struct|sizeof|new|delete|default)\\b"
+			"match": "\\b(in|fn|struct|sizeof|lengthof|new|delete|default)\\b"
 		},
 		{
 			"name": "storage.type.anzu",

--- a/examples/test.az
+++ b/examples/test.az
@@ -42,3 +42,7 @@ fn myfunc(x: unique_int)
     xy := "a";
     x := xy[0u];
 }
+
+arr := [1, 2, 3, 4];
+println(sizeof(arr));
+println(lengthof(arr));

--- a/examples/test.az
+++ b/examples/test.az
@@ -43,6 +43,6 @@ fn myfunc(x: unique_int)
     x := xy[0u];
 }
 
-arr := [1, 2, 3, 4];
+arr := [[1, 2], [2, 3], [3, 4], [4, 5]];
 println(sizeof(arr));
-println(lengthof(arr));
+println(lengthof(arr[0u]));

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -78,6 +78,10 @@ auto print_node(const node_expr& root, int indent) -> void
             print("{}SizeOf:\n", spaces);
             print_node(*node.expr, indent + 1);
         },
+        [&](const node_lengthof_expr& node) {
+            print("{}LengthOf:\n", spaces);
+            print_node(*node.expr, indent + 1);
+        },
         [&](const node_subscript_expr& node) {
             print("{}Subscript:\n", spaces);
             print("{}- Expr:\n", spaces);

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -102,6 +102,13 @@ struct node_sizeof_expr
     anzu::token token;
 };
 
+struct node_lengthof_expr
+{
+    node_expr_ptr expr;
+
+    anzu::token token;
+};
+
 struct node_subscript_expr
 {
     node_expr_ptr expr;
@@ -129,6 +136,7 @@ struct node_expr : std::variant<
     node_repeat_list_expr,
     node_addrof_expr,
     node_sizeof_expr,
+    node_lengthof_expr,
     node_new_expr,
 
     // Lvalue expressions

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -601,6 +601,9 @@ auto type_of_expr(const compiler& com, const node_expr& node) -> type_name
         [&](const node_sizeof_expr& expr) {
             return u64_type();
         },
+        [&](const node_lengthof_expr& expr) {
+            return u64_type();
+        },
         [&](const node_variable_expr& expr) {
             return get_var_type(com, expr.token, expr.name);
         },
@@ -813,6 +816,14 @@ auto push_expr_val(compiler& com, const node_addrof_expr& node) -> type_name
 }
 
 auto push_expr_val(compiler& com, const node_sizeof_expr& node) -> type_name
+{
+    const auto type = type_of_expr(com, *node.expr);
+    const auto size = com.types.size_of(type);
+    push_literal(com, size);
+    return u64_type();
+}
+
+auto push_expr_val(compiler& com, const node_lengthof_expr& node) -> type_name
 {
     const auto type = type_of_expr(com, *node.expr);
     const auto size = com.types.size_of(type);

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -826,7 +826,9 @@ auto push_expr_val(compiler& com, const node_sizeof_expr& node) -> type_name
 auto push_expr_val(compiler& com, const node_lengthof_expr& node) -> type_name
 {
     const auto type = type_of_expr(com, *node.expr);
-    const auto size = com.types.size_of(type);
+    node.token.assert(is_list_type(type), "cannot call lengthof on a non-array type");
+
+    const auto size = array_length(type);
     push_literal(com, size);
     return u64_type();
 }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -218,6 +218,13 @@ auto parse_single_factor(tokenstream& tokens) -> node_expr_ptr
         expr.expr = parse_expression(tokens);
         tokens.consume_only(tk_rparen);
     }
+    else if (tokens.peek(tk_lengthof)) {
+        auto& expr = node->emplace<node_lengthof_expr>();
+        expr.token = tokens.consume();
+        tokens.consume_only(tk_lparen);
+        expr.expr = parse_expression(tokens);
+        tokens.consume_only(tk_rparen);
+    }
     else if (tokens.peek(tk_mul)) {
         auto& expr = node->emplace<node_deref_expr>();
         expr.token = tokens.consume();

--- a/src/vocabulary.cpp
+++ b/src/vocabulary.cpp
@@ -10,7 +10,7 @@ auto is_keyword(std::string_view token) -> bool
     static const std::unordered_set<std::string_view> tokens = {
         tk_break, tk_continue, tk_else, tk_false, tk_for, tk_if, tk_in, tk_null, tk_true,
         tk_while, tk_bool, tk_function, tk_return, tk_struct, tk_sizeof, tk_char,
-        tk_i32, tk_i64, tk_u64, tk_f64, tk_new, tk_delete, tk_default
+        tk_i32, tk_i64, tk_u64, tk_f64, tk_new, tk_delete, tk_default, tk_lengthof
     };
     return tokens.contains(token);
 }

--- a/src/vocabulary.hpp
+++ b/src/vocabulary.hpp
@@ -23,6 +23,7 @@ constexpr auto tk_sizeof    = sv{"sizeof"};
 constexpr auto tk_new       = sv{"new"};
 constexpr auto tk_delete    = sv{"delete"};
 constexpr auto tk_default   = sv{"default"};
+constexpr auto tk_lengthof  = sv{"lengthof"};
 
 // Builtin Types
 constexpr auto tk_i32       = sv{"i32"};


### PR DESCRIPTION
* Add `lengthof` operator that is similar to `sizeof`, but returns the number of elements in an array. It is a compiler error to call `lengthof` of a non-array object.
* Will be used to implement for loops.