### PR TITLE
Basic Loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,30 @@ An interpreted programming language written in C++. This started out as a stack-
     }
     ```
 
-* `while` loops (with optional `break` and `continue`):
+* basic `loop` loops (with `break` and `continue`):
+    ```rs
+    loop {
+        ...
+    }
+    ```
+
+* `while` loops:
 
     ```rs
     while <condition> {
         ...
     }
     ```
+
+* `for` loops (for arrays only for now):
+
+    ```rs
+    for <name> in <array> {
+        <body>
+    }
+    ```
+    NOTE: `name` is a pointer to the element in the array
+
 * `fn` function statements:
 
     ```rs

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,12 +1,8 @@
 
 
-idx := 0u;
-loop {
-    if idx == 10u {
-        break;
-    }
-    println("loop");
-    idx = idx + 1u;
-    continue;
-    println("after");
+for x in [1, 2, 3] {
+    println(*x);
 }
+
+l := 5;
+println(l);

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,7 +1,12 @@
-arr := [1, 2, 3];
-for x in arr {
-    println(*x);
-}
 
-x := 4;
-println(x);
+
+idx := 0u;
+loop {
+    if idx == 10u {
+        break;
+    }
+    println("loop");
+    idx = idx + 1u;
+    continue;
+    println("after");
+}

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -103,6 +103,11 @@ auto print_node(const node_stmt& root, int indent) -> void
                 print_node(*seq_node, indent + 1);
             }
         },
+        [&](const node_loop_stmt& node) {
+            print("{}Loop:\n", spaces);
+            print("{}- Body:\n", spaces);
+            print_node(*node.body, indent + 1);
+        },
         [&](const node_while_stmt& node) {
             print("{}While:\n", spaces);
             print("{}- Condition:\n", spaces);

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -152,6 +152,13 @@ struct node_sequence_stmt
     anzu::token token;
 };
 
+struct node_loop_stmt
+{
+    node_stmt_ptr body;
+
+    anzu::token token;
+};
+
 struct node_while_stmt
 {
     node_expr_ptr condition;
@@ -255,6 +262,7 @@ struct node_delete_stmt
 
 struct node_stmt : std::variant<
     node_sequence_stmt,
+    node_loop_stmt,
     node_while_stmt,
     node_for_stmt,
     node_if_stmt,

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -897,9 +897,9 @@ auto compile_loop(compiler& com, std::function<void()> body) -> void
         body();
     }
     const auto end_pos = std::ssize(com.program);
-
     com.program.emplace_back(op_jump_rel{ .jump=(begin_pos - end_pos) });
 
+    // Fix up the breaks and continues
     const auto& control_flow = com.control_flow.top();
     for (const auto idx : control_flow.break_stmts) {
         std::get<op_jump_rel>(com.program[idx]).jump = end_pos + 1 - idx; // Jump past end

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -887,7 +887,7 @@ void compile_stmt(compiler& com, const node_sequence_stmt& node)
     }
 }
 
-auto compile_loop(compiler& com, const token& tok, std::function<void()> body) -> void
+auto compile_loop(compiler& com, std::function<void()> body) -> void
 {
     const auto scope = scope_guard{com, var_scope::scope_type::loop};
     
@@ -911,7 +911,7 @@ auto compile_loop(compiler& com, const token& tok, std::function<void()> body) -
 
 void compile_stmt(compiler& com, const node_loop_stmt& node)
 {
-    compile_loop(com, node.token, [&] {
+    compile_loop(com, [&] {
         compile_stmt(com, *node.body);
     });
 }
@@ -932,7 +932,7 @@ loop {
 */
 void compile_stmt(compiler& com, const node_while_stmt& node)
 {
-    compile_loop(com, node.token, [&] {
+    compile_loop(com, [&] {
         // if !<condition> break;
         const auto cond_type = push_expr_val(com, *node.condition);
         node.token.assert_eq(cond_type, bool_type(), "while-stmt invalid condition");
@@ -986,7 +986,7 @@ void compile_stmt(compiler& com, const node_for_stmt& node)
     push_literal(com, array_length(iter_type));
     declare_var(com, node.token, "#:size", u64_type());
 
-    compile_loop(com, node.token, [&] {
+    compile_loop(com, [&] {
         // if idx == size break;
         load_variable(com, node.token, "#:idx");
         load_variable(com, node.token, "#:size");

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -159,16 +159,25 @@ auto call_destructor_named_var(compiler& com, const std::string& var, const type
 class scope_guard
 {
     compiler* d_com;
+    var_scope::scope_type d_type;
 
 public:
     scope_guard(compiler& com, var_scope::scope_type type = var_scope::scope_type::block)
         : d_com(&com)
+        , d_type(type)
     {
         current_vars(com).push_scope(type);
+        if (type == var_scope::scope_type::loop) {
+            com.control_flow.emplace();
+        }
     }
 
     ~scope_guard()
     {
+        if (d_type == var_scope::scope_type::loop) {
+            d_com->control_flow.pop();
+        }
+
         // destruct all variables in the current scope
         auto& scope = current_vars(*d_com).current_scope();
         for (const auto& [name, info] : scope.vars | std::views::reverse) {
@@ -878,23 +887,18 @@ void compile_stmt(compiler& com, const node_sequence_stmt& node)
     }
 }
 
-auto compile_while_loop(compiler& com, const token& tok, std::function<type_name()> condition, std::function<void()> body) -> void
+auto compile_loop(compiler& com, const token& tok, std::function<void()> body) -> void
 {
     const auto scope = scope_guard{com, var_scope::scope_type::loop};
-
+    
     const auto begin_pos = std::ssize(com.program);
-    const auto cond_type = condition();
-    tok.assert_eq(cond_type, bool_type(), "while-stmt invalid condition");
-
-    const auto jump_pos = append_op(com, op_jump_rel_if_false{});
-
-    com.control_flow.emplace();
-    body();
-
+    {
+        const auto body_scope = scope_guard{com};
+        body();
+    }
     const auto end_pos = std::ssize(com.program);
-    com.program.emplace_back(op_jump_rel{ .jump=(begin_pos - end_pos) });
 
-    std::get<op_jump_rel_if_false>(com.program[jump_pos]).jump = end_pos + 1 - jump_pos;
+    com.program.emplace_back(op_jump_rel{ .jump=(begin_pos - end_pos) });
 
     const auto& control_flow = com.control_flow.top();
     for (const auto idx : control_flow.break_stmts) {
@@ -903,44 +907,64 @@ auto compile_while_loop(compiler& com, const token& tok, std::function<type_name
     for (const auto idx : control_flow.continue_stmts) {
         std::get<op_jump_rel>(com.program[idx]).jump = begin_pos - idx; // Jump to start
     }
-    com.control_flow.pop();
 }
 
 void compile_stmt(compiler& com, const node_loop_stmt& node)
 {
-    const auto scope = scope_guard{com, var_scope::scope_type::loop};
-
-    const auto begin_pos = std::ssize(com.program);
-
-    com.control_flow.emplace();
-    compile_stmt(com, *node.body);
-
-    const auto end_pos = std::ssize(com.program);
-    com.program.emplace_back(op_jump_rel{ .jump=(begin_pos - end_pos) });
-
-    const auto& control_flow = com.control_flow.top();
-    for (const auto idx : control_flow.break_stmts) {
-        std::get<op_jump_rel>(com.program[idx]).jump = end_pos + 1 - idx; // Jump past end
-    }
-    for (const auto idx : control_flow.continue_stmts) {
-        std::get<op_jump_rel>(com.program[idx]).jump = begin_pos - idx; // Jump to start
-    }
-    com.control_flow.pop();
+    compile_loop(com, node.token, [&] {
+        compile_stmt(com, *node.body);
+    });
 }
 
+void push_break(compiler& com);
+
+/*
+while <condition> {
+    <body>
+}
+
+becomes
+
+loop {
+    if !<condition> break;
+    <body>
+}
+*/
 void compile_stmt(compiler& com, const node_while_stmt& node)
 {
-    const auto condition_compiler = [&] {
-        return push_expr_val(com, *node.condition);
-    };
-
-    const auto body_compiler = [&] {
+    compile_loop(com, node.token, [&] {
+        // if !<condition> break;
+        const auto cond_type = push_expr_val(com, *node.condition);
+        node.token.assert_eq(cond_type, bool_type(), "while-stmt invalid condition");
+        com.program.emplace_back(op_bool_not{});
+        const auto jump_pos = append_op(com, op_jump_rel_if_false{});
+        push_break(com);
+        std::get<op_jump_rel_if_false>(com.program[jump_pos]).jump = com.program.size() - jump_pos; // Jump past the end if false
+        
+        // <body>
         compile_stmt(com, *node.body);
-    };
-
-    compile_while_loop(com, node.token, condition_compiler, body_compiler);
+    });
 }
 
+/*
+for <name> in <iter> {
+    <body>
+}
+
+becomes
+
+{
+    <<create temporary var if iter is an rvalue>>
+    idx = 0u;
+    size := <<length of iter>>;
+    loop {
+        if idx == size break;
+        name := &iter[idx];
+        idx = idx + 1u;
+        <body>
+    }
+}
+*/
 void compile_stmt(compiler& com, const node_for_stmt& node)
 {
     const auto scope = scope_guard{com};
@@ -962,15 +986,14 @@ void compile_stmt(compiler& com, const node_for_stmt& node)
     push_literal(com, array_length(iter_type));
     declare_var(com, node.token, "#:size", u64_type());
 
-    const auto condition_compiler = [&] {
+    compile_loop(com, node.token, [&] {
+        // if idx == size break;
         load_variable(com, node.token, "#:idx");
         load_variable(com, node.token, "#:size");
-        com.program.emplace_back(op_u64_ne{});
-        return bool_type();
-    };
-
-    const auto body_compiler = [&] {
-        const auto scope = scope_guard{com};
+        com.program.emplace_back(op_u64_eq{});
+        const auto jump_pos = append_op(com, op_jump_rel_if_false{});
+        push_break(com);
+        std::get<op_jump_rel_if_false>(com.program[jump_pos]).jump = com.program.size() - jump_pos; // Jump past the end if false
 
         // name := &iter[idx];
         if (is_rvalue_expr(*node.iter)) {
@@ -990,10 +1013,9 @@ void compile_stmt(compiler& com, const node_for_stmt& node)
         com.program.emplace_back(op_u64_add{});
         save_variable(com, node.token, "#:idx");
 
-        compile_stmt(com, *node.body);          
-    };
-
-    compile_while_loop(com, node.token, condition_compiler, body_compiler);
+        // main body
+        compile_stmt(com, *node.body);
+    });
 }
 
 void compile_stmt(compiler& com, const node_if_stmt& node)
@@ -1027,11 +1049,16 @@ void compile_stmt(compiler& com, const node_struct_stmt& node)
     }
 }
 
-void compile_stmt(compiler& com, const node_break_stmt&)
+void push_break(compiler& com)
 {
     destruct_on_break_or_continue(com);
     const auto pos = append_op(com, op_jump_rel{});
     com.control_flow.top().break_stmts.insert(pos);
+}
+
+void compile_stmt(compiler& com, const node_break_stmt&)
+{
+    push_break(com);
 }
 
 void compile_stmt(compiler& com, const node_continue_stmt&)

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -415,6 +415,16 @@ auto parse_return_stmt(tokenstream& tokens) -> node_stmt_ptr
     return node;
 }
 
+auto parse_loop_stmt(tokenstream& tokens) -> node_stmt_ptr
+{
+    auto node = std::make_unique<node_stmt>();
+    auto& stmt = node->emplace<node_loop_stmt>();
+
+    stmt.token = tokens.consume_only(tk_loop);
+    stmt.body = parse_statement(tokens);
+    return node;
+}
+
 auto parse_while_stmt(tokenstream& tokens) -> node_stmt_ptr
 {
     auto node = std::make_unique<node_stmt>();
@@ -522,6 +532,9 @@ auto parse_statement(tokenstream& tokens) -> node_stmt_ptr
     }
     if (tokens.peek(tk_return)) {
         return parse_return_stmt(tokens);
+    }
+    if (tokens.peek(tk_loop)) {
+        return parse_loop_stmt(tokens);
     }
     if (tokens.peek(tk_while)) {
         return parse_while_stmt(tokens);

--- a/src/vocabulary.cpp
+++ b/src/vocabulary.cpp
@@ -10,7 +10,7 @@ auto is_keyword(std::string_view token) -> bool
     static const std::unordered_set<std::string_view> tokens = {
         tk_break, tk_continue, tk_else, tk_false, tk_for, tk_if, tk_in, tk_null, tk_true,
         tk_while, tk_bool, tk_function, tk_return, tk_struct, tk_sizeof, tk_char,
-        tk_i32, tk_i64, tk_u64, tk_f64, tk_new, tk_delete, tk_default
+        tk_i32, tk_i64, tk_u64, tk_f64, tk_new, tk_delete, tk_default, tk_loop
     };
     return tokens.contains(token);
 }

--- a/src/vocabulary.hpp
+++ b/src/vocabulary.hpp
@@ -23,6 +23,7 @@ constexpr auto tk_sizeof    = sv{"sizeof"};
 constexpr auto tk_new       = sv{"new"};
 constexpr auto tk_delete    = sv{"delete"};
 constexpr auto tk_default   = sv{"default"};
+constexpr auto tk_loop      = sv{"loop"};
 
 // Builtin Types
 constexpr auto tk_i32       = sv{"i32"};


### PR DESCRIPTION
* Add `loop {}` syntax, just like in Rust.
* `while` and `for` loops are rewritten to be in terms of basic loops.
* `break`, `continue` and `loop` now use absolute jumps instead of relative loops, easier to think about.