### PR TITLE
Replace Relative Jumps with Absolute Jumps

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,10 @@
             "type": "cppvsdbg",
             "request": "launch",
             "program": "${workspaceFolder}/build/src/Debug/anzu.exe",
-            "args": ["${workspaceFolder}/examples/test.az", "run"],
+            "args": [
+                "${workspaceFolder}/examples/euler.az",
+                "run"
+            ],
             "stopAtEntry": false,
             "cwd": "${fileDirname}",
             "environment": [],

--- a/examples/euler.az
+++ b/examples/euler.az
@@ -12,6 +12,4 @@ while i < 1000 {
     i = i + 1;
 }
 
-x := "hello";
-
 println(count);

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,8 +1,4 @@
 
-
-for x in [1, 2, 3] {
-    println(*x);
+loop {
+    println("i love corinne");
 }
-
-l := 5;
-println(l);

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -909,15 +909,15 @@ auto compile_loop(compiler& com, std::function<void()> body) -> void
         const auto body_scope = scope_guard{com};
         body();
     }
-    com.program.emplace_back(op_jump_abs{ .jump=begin_pos });
+    com.program.emplace_back(op_jump{ .jump=begin_pos });
 
     // Fix up the breaks and continues
     const auto& control_flow = com.control_flow.top();
     for (const auto idx : control_flow.break_stmts) {
-        std::get<op_jump_abs>(com.program[idx]).jump = com.program.size(); // Jump past end
+        std::get<op_jump>(com.program[idx]).jump = com.program.size(); // Jump past end
     }
     for (const auto idx : control_flow.continue_stmts) {
-        std::get<op_jump_abs>(com.program[idx]).jump = begin_pos; // Jump to start
+        std::get<op_jump>(com.program[idx]).jump = begin_pos; // Jump to start
     }
 }
 
@@ -949,9 +949,9 @@ void compile_stmt(compiler& com, const node_while_stmt& node)
         const auto cond_type = push_expr_val(com, *node.condition);
         node.token.assert_eq(cond_type, bool_type(), "while-stmt invalid condition");
         com.program.emplace_back(op_bool_not{});
-        const auto jump_pos = append_op(com, op_jump_abs_if_false{});
+        const auto jump_pos = append_op(com, op_jump_if_false{});
         push_break(com);
-        std::get<op_jump_abs_if_false>(com.program[jump_pos]).jump = com.program.size(); // Jump past the end if false
+        std::get<op_jump_if_false>(com.program[jump_pos]).jump = com.program.size(); // Jump past the end if false
         
         // <body>
         compile_stmt(com, *node.body);
@@ -1003,9 +1003,9 @@ void compile_stmt(compiler& com, const node_for_stmt& node)
         load_variable(com, node.token, "#:idx");
         load_variable(com, node.token, "#:size");
         com.program.emplace_back(op_u64_eq{});
-        const auto jump_pos = append_op(com, op_jump_abs_if_false{});
+        const auto jump_pos = append_op(com, op_jump_if_false{});
         push_break(com);
-        std::get<op_jump_abs_if_false>(com.program[jump_pos]).jump = com.program.size(); // Jump past the end if false
+        std::get<op_jump_if_false>(com.program[jump_pos]).jump = com.program.size(); // Jump past the end if false
 
         // name := &iter[idx];
         if (is_rvalue_expr(*node.iter)) {
@@ -1035,16 +1035,16 @@ void compile_stmt(compiler& com, const node_if_stmt& node)
     const auto cond_type = push_expr_val(com, *node.condition);
     node.token.assert_eq(cond_type, bool_type(), "if-stmt invalid condition");
 
-    const auto jump_pos = append_op(com, op_jump_abs_if_false{});
+    const auto jump_pos = append_op(com, op_jump_if_false{});
     compile_stmt(com, *node.body);
 
     if (node.else_body) {
-        const auto else_pos = append_op(com, op_jump_abs{});
+        const auto else_pos = append_op(com, op_jump{});
         compile_stmt(com, *node.else_body);
-        std::get<op_jump_abs_if_false>(com.program[jump_pos]).jump = else_pos + 1; // Jump into the else block if false
-        std::get<op_jump_abs>(com.program[else_pos]).jump = com.program.size(); // Jump past the end if false
+        std::get<op_jump_if_false>(com.program[jump_pos]).jump = else_pos + 1; // Jump into the else block if false
+        std::get<op_jump>(com.program[else_pos]).jump = com.program.size(); // Jump past the end if false
     } else {
-        std::get<op_jump_abs_if_false>(com.program[jump_pos]).jump = com.program.size(); // Jump past the end if false
+        std::get<op_jump_if_false>(com.program[jump_pos]).jump = com.program.size(); // Jump past the end if false
     }
 }
 
@@ -1064,7 +1064,7 @@ void compile_stmt(compiler& com, const node_struct_stmt& node)
 void push_break(compiler& com)
 {
     destruct_on_break_or_continue(com);
-    const auto pos = append_op(com, op_jump_abs{});
+    const auto pos = append_op(com, op_jump{});
     com.control_flow.top().break_stmts.insert(pos);
 }
 
@@ -1076,7 +1076,7 @@ void compile_stmt(compiler& com, const node_break_stmt&)
 void compile_stmt(compiler& com, const node_continue_stmt&)
 {
     destruct_on_break_or_continue(com);
-    const auto pos = append_op(com, op_jump_abs{});
+    const auto pos = append_op(com, op_jump{});
     com.control_flow.top().continue_stmts.insert(pos);
 }
 
@@ -1153,7 +1153,7 @@ void compile_function_body(
 {
     const auto key = make_key(com, tok, name, sig);
 
-    const auto begin_pos = append_op(com, op_jump_abs{});
+    const auto begin_pos = append_op(com, op_jump{});
     com.functions[key] = { .sig=sig, .ptr=begin_pos, .tok=tok };
 
     com.current_func.emplace(current_function{ .vars={}, .return_type=sig.return_type });
@@ -1183,7 +1183,7 @@ void compile_function_body(
 
     com.current_func.reset();
 
-    std::get<op_jump_abs>(com.program[begin_pos]).jump = com.program.size();
+    std::get<op_jump>(com.program[begin_pos]).jump = com.program.size();
 }
 
 void compile_stmt(compiler& com, const node_function_def_stmt& node)

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -588,6 +588,11 @@ auto type_of_expr(const compiler& com, const node_expr& node) -> type_name
             const auto rhs = type_of_expr(com, *expr.rhs);
             const auto op = expr.token.text;
 
+            // Pointer arithmetic
+            if (is_ptr_type(lhs) && rhs == u64_type() && op == tk_add) {
+                return lhs;
+            }
+
             const auto info = resolve_operation(lhs, rhs, op);
             expr.token.assert(info.has_value(), "could not find op '{} {} {}'", lhs, op, rhs);
             return info->return_type;
@@ -727,6 +732,14 @@ auto push_expr_val(compiler& com, const node_binary_op_expr& node) -> type_name
     const auto lhs = push_expr_val(com, *node.lhs);
     const auto rhs = push_expr_val(com, *node.rhs);
     const auto op = node.token.text;
+
+    // Pointer arithmetic, multiply the offset by the size of the type before adding
+    if (is_ptr_type(lhs) && rhs == u64_type() && op == tk_add) {
+        push_literal(com, com.types.size_of(inner_type(lhs)));
+        com.program.emplace_back(op_u64_mul{});
+        com.program.emplace_back(op_u64_add{});
+        return lhs;
+    }
     
     const auto info = resolve_operation(lhs, rhs, op);
     node.token.assert(info.has_value(), "could not find op '{} {} {}'", lhs, op, rhs);

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -949,9 +949,9 @@ void compile_stmt(compiler& com, const node_while_stmt& node)
         const auto cond_type = push_expr_val(com, *node.condition);
         node.token.assert_eq(cond_type, bool_type(), "while-stmt invalid condition");
         com.program.emplace_back(op_bool_not{});
-        const auto jump_pos = append_op(com, op_jump_rel_if_false{});
+        const auto jump_pos = append_op(com, op_jump_abs_if_false{});
         push_break(com);
-        std::get<op_jump_rel_if_false>(com.program[jump_pos]).jump = com.program.size() - jump_pos; // Jump past the end if false
+        std::get<op_jump_abs_if_false>(com.program[jump_pos]).jump = com.program.size(); // Jump past the end if false
         
         // <body>
         compile_stmt(com, *node.body);
@@ -1003,9 +1003,9 @@ void compile_stmt(compiler& com, const node_for_stmt& node)
         load_variable(com, node.token, "#:idx");
         load_variable(com, node.token, "#:size");
         com.program.emplace_back(op_u64_eq{});
-        const auto jump_pos = append_op(com, op_jump_rel_if_false{});
+        const auto jump_pos = append_op(com, op_jump_abs_if_false{});
         push_break(com);
-        std::get<op_jump_rel_if_false>(com.program[jump_pos]).jump = com.program.size() - jump_pos; // Jump past the end if false
+        std::get<op_jump_abs_if_false>(com.program[jump_pos]).jump = com.program.size(); // Jump past the end if false
 
         // name := &iter[idx];
         if (is_rvalue_expr(*node.iter)) {
@@ -1035,16 +1035,16 @@ void compile_stmt(compiler& com, const node_if_stmt& node)
     const auto cond_type = push_expr_val(com, *node.condition);
     node.token.assert_eq(cond_type, bool_type(), "if-stmt invalid condition");
 
-    const auto jump_pos = append_op(com, op_jump_rel_if_false{});
+    const auto jump_pos = append_op(com, op_jump_abs_if_false{});
     compile_stmt(com, *node.body);
 
     if (node.else_body) {
-        const auto else_pos = append_op(com, op_jump_rel{});
+        const auto else_pos = append_op(com, op_jump_abs{});
         compile_stmt(com, *node.else_body);
-        std::get<op_jump_rel_if_false>(com.program[jump_pos]).jump = else_pos + 1 - jump_pos; // Jump into the else block if false
-        std::get<op_jump_rel>(com.program[else_pos]).jump = com.program.size() - else_pos; // Jump past the end if false
+        std::get<op_jump_abs_if_false>(com.program[jump_pos]).jump = else_pos + 1; // Jump into the else block if false
+        std::get<op_jump_abs>(com.program[else_pos]).jump = com.program.size(); // Jump past the end if false
     } else {
-        std::get<op_jump_rel_if_false>(com.program[jump_pos]).jump = com.program.size() - jump_pos; // Jump past the end if false
+        std::get<op_jump_abs_if_false>(com.program[jump_pos]).jump = com.program.size(); // Jump past the end if false
     }
 }
 

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -914,7 +914,7 @@ auto compile_loop(compiler& com, std::function<void()> body) -> void
     // Fix up the breaks and continues
     const auto& control_flow = com.control_flow.top();
     for (const auto idx : control_flow.break_stmts) {
-        std::get<op_jump_abs>(com.program[idx]).jump = com.program.size() + 1; // Jump past end
+        std::get<op_jump_abs>(com.program[idx]).jump = com.program.size(); // Jump past end
     }
     for (const auto idx : control_flow.continue_stmts) {
         std::get<op_jump_abs>(com.program[idx]).jump = begin_pos; // Jump to start

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -86,9 +86,7 @@ auto to_string(const op& op_code) -> std::string
         [](op_pop op) { return std::format("POP({})", op.size); },
         [](op_allocate op) { return std::format("ALLOCATE({})", op.type_size); },
         [](op_deallocate op) { return std::string{"DEALLOCATE"}; },
-        [](op_jump_rel op) { return std::format("JUMP_REL({})", op.jump); },
         [](op_jump_abs op) { return std::format("JUMP_ABS({})", op.jump); },
-        [](op_jump_rel_if_false op) { return std::format("JUMP_REL_IF_FALSE({})", op.jump); },
         [](op_jump_abs_if_false op) { return std::format("JUMP_ABS_IF_FALSE({})", op.jump); },
         [](op_return op) { return std::format("RETURN({})", op.size); },
 

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -86,8 +86,8 @@ auto to_string(const op& op_code) -> std::string
         [](op_pop op) { return std::format("POP({})", op.size); },
         [](op_allocate op) { return std::format("ALLOCATE({})", op.type_size); },
         [](op_deallocate op) { return std::string{"DEALLOCATE"}; },
-        [](op_jump_abs op) { return std::format("JUMP_ABS({})", op.jump); },
-        [](op_jump_abs_if_false op) { return std::format("JUMP_ABS_IF_FALSE({})", op.jump); },
+        [](op_jump op) { return std::format("JUMP({})", op.jump); },
+        [](op_jump_if_false op) { return std::format("JUMP_IF_FALSE({})", op.jump); },
         [](op_return op) { return std::format("RETURN({})", op.size); },
 
         [](const op_function_call& op) {

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -89,14 +89,15 @@ auto to_string(const op& op_code) -> std::string
         [](op_jump_rel op) { return std::format("JUMP_REL({})", op.jump); },
         [](op_jump_abs op) { return std::format("JUMP_ABS({})", op.jump); },
         [](op_jump_rel_if_false op) { return std::format("JUMP_REL_IF_FALSE({})", op.jump); },
+        [](op_jump_abs_if_false op) { return std::format("JUMP_ABS_IF_FALSE({})", op.jump); },
         [](op_return op) { return std::format("RETURN({})", op.size); },
 
-        [&](const op_function_call& op) {
+        [](const op_function_call& op) {
             const auto func_str = std::format("FUNCTION_CALL({})", op.name);
             const auto jump_str = std::format("JUMP -> {}", op.ptr);
             return std::format(FORMAT2, func_str, jump_str);
         },
-        [&](const op_builtin_call& op) { return std::format("BUILTIN_CALL({})", op.name); },
+        [](const op_builtin_call& op) { return std::format("BUILTIN_CALL({})", op.name); },
         [](const op_debug& op) { return std::format("DEBUG({})", op.message); }
     }, op_code);
 }

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -110,17 +110,7 @@ struct op_deallocate
 {
 };
 
-struct op_jump_rel
-{
-    std::int64_t jump;
-};
-
 struct op_jump_abs
-{
-    std::size_t jump;
-};
-
-struct op_jump_rel_if_false
 {
     std::size_t jump;
 };
@@ -224,8 +214,6 @@ struct op : std::variant<
     op_pop,
     op_allocate,
     op_deallocate,
-    op_jump_rel,
-    op_jump_rel_if_false,
     op_jump_abs,
     op_jump_abs_if_false,
     op_return,

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -110,12 +110,12 @@ struct op_deallocate
 {
 };
 
-struct op_jump_abs
+struct op_jump
 {
     std::size_t jump;
 };
 
-struct op_jump_abs_if_false
+struct op_jump_if_false
 {
     std::size_t jump;
 };
@@ -214,8 +214,8 @@ struct op : std::variant<
     op_pop,
     op_allocate,
     op_deallocate,
-    op_jump_abs,
-    op_jump_abs_if_false,
+    op_jump,
+    op_jump_if_false,
     op_return,
     op_function_call,
     op_builtin_call,

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -125,6 +125,11 @@ struct op_jump_rel_if_false
     std::size_t jump;
 };
 
+struct op_jump_abs_if_false
+{
+    std::size_t jump;
+};
+
 struct op_function_call
 {
     std::string name;
@@ -222,6 +227,7 @@ struct op : std::variant<
     op_jump_rel,
     op_jump_rel_if_false,
     op_jump_abs,
+    op_jump_abs_if_false,
     op_return,
     op_function_call,
     op_builtin_call,

--- a/src/resolver.cpp
+++ b/src/resolver.cpp
@@ -9,7 +9,6 @@ auto resolve_operation(
 )
     -> std::optional<op_info>
 {
-    if (is_ptr_type(lhs) && rhs == u64_type()) return op_info{ {op_u64_add{}}, lhs };
     if (lhs != rhs) return std::nullopt;
 
     const auto& type = lhs;

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -194,10 +194,10 @@ auto apply_op(runtime_context& ctx, const op& op_code) -> void
             ctx.allocator.deallocate(heap_ptr, size + sizeof(std::uint64_t));
             ++ctx.prog_ptr;
         },
-        [&](op_jump_abs op) {
+        [&](op_jump op) {
             ctx.prog_ptr = op.jump;
         },
-        [&](op_jump_abs_if_false op) {
+        [&](op_jump_if_false op) {
             if (pop_value<bool>(ctx.stack)) {
                 ++ctx.prog_ptr;
             } else {

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -194,18 +194,8 @@ auto apply_op(runtime_context& ctx, const op& op_code) -> void
             ctx.allocator.deallocate(heap_ptr, size + sizeof(std::uint64_t));
             ++ctx.prog_ptr;
         },
-        [&](op_jump_rel op) {
-            ctx.prog_ptr += op.jump;
-        },
         [&](op_jump_abs op) {
             ctx.prog_ptr = op.jump;
-        },
-        [&](op_jump_rel_if_false op) {
-            if (pop_value<bool>(ctx.stack)) {
-                ++ctx.prog_ptr;
-            } else {
-                ctx.prog_ptr += op.jump;
-            }
         },
         [&](op_jump_abs_if_false op) {
             if (pop_value<bool>(ctx.stack)) {

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -207,6 +207,13 @@ auto apply_op(runtime_context& ctx, const op& op_code) -> void
                 ctx.prog_ptr += op.jump;
             }
         },
+        [&](op_jump_abs_if_false op) {
+            if (pop_value<bool>(ctx.stack)) {
+                ++ctx.prog_ptr;
+            } else {
+                ctx.prog_ptr = op.jump;
+            }
+        },
         [&](op_return op) {
             const auto prev_base_ptr = read_value<std::uint64_t>(ctx.stack, ctx.base_ptr);
             const auto prev_prog_ptr = read_value<std::uint64_t>(ctx.stack, ctx.base_ptr + sizeof(std::uint64_t));


### PR DESCRIPTION
* I changed to relative jumps ages back for some reason, but it just makes the code harder to reason about.
* Now that I've added back absolute jumps, this replaces all remaining relatives ones.
* Removed the relative jump op codes.
* Fixed an off by one error with the break statement in the last PR.
* Fixed pointer arithmetic, dealt with specially rather than in the resolver since it requires extra work to multiply by the size of the type.