### PR TITLE
`typeof` Operator

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
             "request": "launch",
             "program": "${workspaceFolder}/build/src/Debug/anzu.exe",
             "args": [
-                "${workspaceFolder}/examples/euler.az",
+                "${workspaceFolder}/examples/feature_test.az",
                 "run"
             ],
             "stopAtEntry": false,

--- a/anzu-lang/syntaxes/anzu.tmLanguage.json
+++ b/anzu-lang/syntaxes/anzu.tmLanguage.json
@@ -13,11 +13,11 @@
 		},
 		{
 			"name": "keyword.control.anzu",
-			"match": "\\b(if|else|while|break|continue|return|for)\\b"
+			"match": "\\b(if|else|while|loop|break|continue|return|for)\\b"
 		},
 		{
 			"name": "keyword.other.anzu",
-			"match": "\\b(in|fn|struct|sizeof|new|delete|default)\\b"
+			"match": "\\b(in|fn|struct|sizeof|typeof|new|delete|default)\\b"
 		},
 		{
 			"name": "storage.type.anzu",

--- a/examples/feature_test.az
+++ b/examples/feature_test.az
@@ -159,9 +159,9 @@ fn println(v: vec2) -> null
     println("xl2 should have size 32 but length 2:");
     print("size: ");
     println(sizeof(xl2));
-    println(sizeof(xl2[0]));
+    println(sizeof(xl2[0u]));
     print("length: ");
-    println(sizeof(xl2) / sizeof(xl2[0]));
+    println(sizeof(xl2) / sizeof(xl2[0u]));
 }
 
 # Pointer Arithmetic

--- a/examples/feature_test.az
+++ b/examples/feature_test.az
@@ -273,3 +273,9 @@ fn typeof_example(y: typeof(variable)) -> i64
     return y + y;
 }
 println(typeof_example(3)); # no error here!
+
+#fn typeof_example2(a: u64) -> typeof(a)
+#{
+#    return a * a;
+#}
+#println(typeof_example2(6u));

--- a/examples/feature_test.az
+++ b/examples/feature_test.az
@@ -274,8 +274,8 @@ fn typeof_example(y: typeof(variable)) -> i64
 }
 println(typeof_example(3)); # no error here!
 
-#fn typeof_example2(a: u64) -> typeof(a)
-#{
-#    return a * a;
-#}
-#println(typeof_example2(6u));
+fn typeof_example2(a: u64) -> typeof(a)
+{
+    return a * a;
+}
+println(typeof_example2(6u));

--- a/examples/feature_test.az
+++ b/examples/feature_test.az
@@ -265,3 +265,11 @@ struct vec3
         println(v->y);
     }
 }
+
+# typeof operator
+variable := 0;
+fn typeof_example(y: typeof(variable)) -> i64
+{
+    return y + y;
+}
+println(typeof_example(3)); # no error here!

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,4 +1,9 @@
 
-loop {
-    println("i love corinne");
+x := 5;
+
+fn foo(y: typeof(x))
+{
+    println(y);
 }
+
+foo(6u);

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,9 +1,5 @@
 
 x := 5;
 
-fn foo(y: typeof(x))
-{
-    println(y);
-}
-
-foo(6u);
+arr := new typeof(x) : 5u;
+delete arr;

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -86,7 +86,7 @@ auto print_node(const node_expr& root, int indent) -> void
             print_node(*node.index, indent + 1);
         },
         [&](const node_new_expr& node) {
-            print("{}New {}:\n", spaces, node.type);
+            print("{}New {}:\n", spaces, *node.type);
             print("{}- Size:\n", spaces);
             print_node(*node.size, indent + 1);
         }
@@ -138,7 +138,7 @@ auto print_node(const node_stmt& root, int indent) -> void
             print("{}- Name: {}\n", spaces, node.name);
             print("{}- Fields:\n", spaces);
             for (const auto& field : node.fields) {
-                print("{}  - {}: {}\n", spaces, field.name, field.type);
+                print("{}  - {}: {}\n", spaces, field.name, *field.type);
             }
             print("{}- MemberFunctions:\n", spaces);
             for (const auto& function : node.functions) {
@@ -167,17 +167,17 @@ auto print_node(const node_stmt& root, int indent) -> void
         [&](const node_function_def_stmt& node) {
             print("{}Function: {} (", spaces, node.name);
             print_comma_separated(node.sig.params, [](const auto& arg) {
-                return std::format("{}: {}", arg.name, arg.type);
+                return std::format("{}: {}", arg.name, *arg.type);
             });
-            print(") -> {}\n", node.sig.return_type);
+            print(") -> {}\n", *node.sig.return_type);
             print_node(*node.body, indent + 1);
         },
         [&](const node_member_function_def_stmt& node) {
             print("{}MemberFunction: {}::{} (", spaces, node.struct_name, node.function_name);
             print_comma_separated(node.sig.params, [](const auto& arg) {
-                return std::format("{}: {}", arg.name, arg.type);
+                return std::format("{}: {}", arg.name, *arg.type);
             });
-            print(") -> {}\n", node.sig.return_type);
+            print(") -> {}\n", *node.sig.return_type);
             print_node(*node.body, indent + 1);
         },
         [&](const node_expression_stmt& node) {
@@ -195,6 +195,20 @@ auto print_node(const node_stmt& root, int indent) -> void
     }, root);
 }
 
+auto print_node(const anzu::node_type& root, int indent) -> void
+{
+    const auto spaces = std::string(4 * indent, ' ');
+    std::visit(overloaded {
+        [&](const node_named_type& node) {
+            print("{}NamedType:\n {}", spaces, node.type);
+        },
+        [&](const node_expr_type& node) {
+            print("{}ExprType:\n", spaces);
+            print_node(*node.expr, indent + 1);
+        }
+    }, root);
+}
+
 auto is_lvalue_expr(const node_expr& expr) -> bool
 {
     return std::holds_alternative<node_variable_expr>(expr)
@@ -206,6 +220,11 @@ auto is_lvalue_expr(const node_expr& expr) -> bool
 auto is_rvalue_expr(const node_expr& expr) -> bool
 {
     return !is_lvalue_expr(expr);
+}
+
+auto to_string(const node_type& node) -> std::string
+{
+    return "TODO: to_string(const node_type&)";
 }
 
 }

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -172,18 +172,6 @@ auto resolve_type(const compiler& com, const node_type& type) -> type_name
     }, type);
 }
 
-auto resolve_sig(const compiler& com, const node_signature& sig) -> signature
-{
-    auto new_sig = signature{};
-    new_sig.return_type = resolve_type(com, *sig.return_type);
-    for (const auto& p : sig.params) {
-        new_sig.params.emplace_back(
-            signature::parameter{ .name=p.name, .type=resolve_type(com, *p.type) }
-        );
-    }
-    return new_sig;
-}
-
 auto resolve_type_fields(const compiler& com, const node_type_fields& fields) -> type_fields
 {
     auto new_fields = type_fields{};
@@ -1246,6 +1234,7 @@ void compile_stmt(compiler& com, const node_member_function_def_stmt& node)
     const auto struct_type = make_type(node.struct_name);
     const auto sig = compile_function_body(com, node.token, name, node.sig, node.body);
 
+    // Verification code
     node.token.assert(sig.params.size() >= 1, "member functions must have at least one arg");
 
     const auto actual = sig.params.front().type;

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -330,6 +330,16 @@ auto parse_type(tokenstream& tokens) -> type_name
 
 auto parse_type_node(tokenstream& tokens) -> node_type_ptr
 {
+    if (tokens.peek(tk_typeof)) {
+        auto node = std::make_unique<node_type>();
+        auto& inner = node->emplace<node_expr_type>();
+        inner.token = tokens.consume();
+        tokens.consume_only(tk_lparen);
+        inner.expr = parse_expression(tokens);
+        tokens.consume_only(tk_rparen);
+        return node;
+    }
+
     const auto type = parse_type(tokens);
     return std::make_unique<node_type>(node_named_type{type});
 }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -83,6 +83,7 @@ auto parse_char(const token& tok) -> object
 auto parse_expression(tokenstream& tokens) -> node_expr_ptr;
 auto parse_statement(tokenstream& tokens) -> node_stmt_ptr;
 auto parse_type(tokenstream& tokens) -> type_name;
+auto parse_type_node(tokenstream& tokens) -> node_type_ptr;
 
 auto parse_literal(tokenstream& tokens) -> object
 {
@@ -234,7 +235,7 @@ auto parse_single_factor(tokenstream& tokens) -> node_expr_ptr
     else if (tokens.peek(tk_new)) {
         auto& expr = node->emplace<node_new_expr>();
         expr.token = tokens.consume();
-        expr.type = parse_type(tokens);
+        expr.type = parse_type_node(tokens);
         if (tokens.consume_maybe(tk_colon)) {
             expr.size = parse_expression(tokens);
         } else {
@@ -327,6 +328,12 @@ auto parse_type(tokenstream& tokens) -> type_name
     return type;
 }
 
+auto parse_type_node(tokenstream& tokens) -> node_type_ptr
+{
+    const auto type = parse_type(tokens);
+    return std::make_unique<node_type>(node_named_type{type});
+}
+
 auto parse_function_def_stmt(tokenstream& tokens) -> node_stmt_ptr
 {
     auto node = std::make_unique<node_stmt>();
@@ -336,16 +343,16 @@ auto parse_function_def_stmt(tokenstream& tokens) -> node_stmt_ptr
     stmt.name = parse_name(tokens);
     tokens.consume_only(tk_lparen);
     tokens.consume_comma_separated_list(tk_rparen, [&]{
-        auto param = signature::parameter{};
+        auto param = node_signature::parameter{};
         param.name = parse_name(tokens);
         tokens.consume_only(tk_colon);
-        param.type = parse_type(tokens);
-        stmt.sig.params.push_back(param);
+        param.type = parse_type_node(tokens);
+        stmt.sig.params.push_back(std::move(param));
     });    
     if (tokens.consume_maybe(tk_rarrow)) {
-        stmt.sig.return_type = parse_type(tokens);
+        stmt.sig.return_type = parse_type_node(tokens);
     } else {
-        stmt.sig.return_type = null_type();
+        stmt.sig.return_type = std::make_unique<node_type>(node_named_type{null_type()});
     }
     stmt.body = parse_statement(tokens);
     return node;
@@ -382,16 +389,16 @@ auto parse_member_function_def_stmt(
     
     tokens.consume_only(tk_lparen);
     tokens.consume_comma_separated_list(tk_rparen, [&]{
-        auto param = signature::parameter{};
+        auto param = node_signature::parameter{};
         param.name = parse_name(tokens);
         tokens.consume_only(tk_colon);
-        param.type = parse_type(tokens);
-        stmt.sig.params.push_back(param);
+        param.type = parse_type_node(tokens);
+        stmt.sig.params.push_back(std::move(param));
     });
     if (tokens.consume_maybe(tk_rarrow)) {
-        stmt.sig.return_type = parse_type(tokens);
+        stmt.sig.return_type = parse_type_node(tokens);
     } else {
-        stmt.sig.return_type = null_type();
+        stmt.sig.return_type = std::make_unique<node_type>(node_named_type{null_type()});
     }
     stmt.body = parse_statement(tokens);
     return node;
@@ -479,7 +486,7 @@ auto parse_struct_stmt(tokenstream& tokens) -> node_stmt_ptr
             auto& f = stmt.fields.back();
             f.name = parse_name(tokens);
             tokens.consume_only(tk_colon);
-            f.type = parse_type(tokens);
+            f.type = parse_type_node(tokens);
             tokens.consume_only(tk_semicolon);
         }
     }

--- a/src/vocabulary.cpp
+++ b/src/vocabulary.cpp
@@ -10,7 +10,7 @@ auto is_keyword(std::string_view token) -> bool
     static const std::unordered_set<std::string_view> tokens = {
         tk_break, tk_continue, tk_else, tk_false, tk_for, tk_if, tk_in, tk_null, tk_true,
         tk_while, tk_bool, tk_function, tk_return, tk_struct, tk_sizeof, tk_char,
-        tk_i32, tk_i64, tk_u64, tk_f64, tk_new, tk_delete, tk_default, tk_loop
+        tk_i32, tk_i64, tk_u64, tk_f64, tk_new, tk_delete, tk_default, tk_loop, tk_typeof
     };
     return tokens.contains(token);
 }

--- a/src/vocabulary.hpp
+++ b/src/vocabulary.hpp
@@ -24,6 +24,7 @@ constexpr auto tk_new       = sv{"new"};
 constexpr auto tk_delete    = sv{"delete"};
 constexpr auto tk_default   = sv{"default"};
 constexpr auto tk_loop      = sv{"loop"};
+constexpr auto tk_typeof    = sv{"typeof"};
 
 // Builtin Types
 constexpr auto tk_i32       = sv{"i32"};


### PR DESCRIPTION
* Added `typeof`, which works similarly to `decltype` in C++, can be used in the code wherever a type is expected.
* Implemented by replacing `type_name` in the ast with a variant containing either a `type_name` or a `node_expr_ptr` (both wrapped in structs for now). We resolve these back to `type_name`s in the compiler.
* Resolving of return types for functions occurs after the parameters have been declared, meaning the return type can depend on the args, for example `fn add(x: i64, y: i64) -> typeof(x + y)`.
* Implement `type_of_expr` in terms of `push_expr_val`. It now compiles the expression to get the type, then pops off the op codes to leave the program unchanged.
* This actually found a bug in the `feature_test`, where an `i64` was being used as an array subscript since the old `type_of` function didn't check the subscript expr and just assumed `u64` was being returned.