### PR TITLE
Improve Function Storage

### DIFF
--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -19,7 +19,7 @@
 namespace anzu {
 namespace {
 
-static const auto global_namespace = make_type("::");
+static const auto global_namespace = make_type("<global>");
 
 struct var_info
 {
@@ -213,13 +213,6 @@ public:
     scope_guard(const scope_guard&) = delete;
     scope_guard& operator=(const scope_guard&) = delete;
 };
-
-void verify_unused_name(compiler& com, const token& tok, const std::string& name)
-{
-    const auto message = std::format("type '{}' already defined", name);
-    tok.assert(!com.types.contains(make_type(name)), message);
-    tok.assert(!com.functions[global_namespace].contains(name), message);
-}
 
 template <typename T>
 auto push_literal(compiler& com, const T& value) -> void
@@ -948,7 +941,9 @@ void push_stmt(compiler& com, const node_if_stmt& node)
 
 void push_stmt(compiler& com, const node_struct_stmt& node)
 {
-    verify_unused_name(com, node.token, node.name);
+    const auto message = std::format("type '{}' already defined", node.name);
+    node.token.assert(!com.types.contains(make_type(node.name)), message);
+    node.token.assert(!com.functions[global_namespace].contains(node.name), message);
 
     auto fields = type_fields{};
     for (const auto& p : node.fields) {

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -44,6 +44,8 @@ struct type_name : public std::variant<
     using variant::variant;
 };
 
+using type_names = std::vector<type_name>;
+
 struct object
 {
     std::vector<std::byte> data;


### PR DESCRIPTION
* We previously had a map and a set, with the former being keyed on name and params, and the latter being used to verify that a struct doesn't get named the same as a function.
* This was even worse because the function name, contained the struct name, which wasn't great design.
* Now it's all replaced by a multi-layer map where the keys go `struct_name -> function_name -> params -> info`. Global functions are now stored as member functions of a `<global>` struct, but this is an implementation detail only used for accessing the function map.
* It also turns out the compiler didn't prevent `break` and `continue` being used outside of loops, and would crash if that was the case, this has been fixed.