### PR TITLE
Unified Function Calls

### DIFF
--- a/examples/euler.az
+++ b/examples/euler.az
@@ -3,7 +3,7 @@
 count := 0;
 i := 0;
 
-while i < 1000 {
+while i < 100000 {
     if i % 3 == 0 {
         count = count + i;
     } else if i % 5 == 0 {

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,5 +1,13 @@
 
-x := 5;
+struct foo
+{
+    fn bar(self: &foo, x: i64) -> i64
+    {
+        return x;
+    }
+}
 
-arr := new typeof(x) : 5u;
-delete arr;
+f := foo();
+
+f.bar();
+typeof(f)::bar(&f);

--- a/examples/vector.az
+++ b/examples/vector.az
@@ -5,6 +5,11 @@ struct vector
     size:     u64;
     capacity: u64;
 
+    fn create() -> vector
+    {
+        return vector(new i64, 0u, 1u);
+    }
+
     fn at(self: &vector, idx: u64) -> i64
     {
         return *(self->data + idx);

--- a/examples/vector.az
+++ b/examples/vector.az
@@ -5,11 +5,6 @@ struct vector
     size:     u64;
     capacity: u64;
 
-    fn create() -> vector
-    {
-        return vector(new i64, 0u, 1u);
-    }
-
     fn at(self: &vector, idx: u64) -> i64
     {
         return *(self->data + idx);

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -44,15 +44,6 @@ auto print_node(const node_expr& root, int indent) -> void
                 print_node(*arg, indent + 1);
             }
         },
-        [&](const node_member_function_call_expr& node) {
-            print("{}MemberFunctionCall: {}\n", spaces, node.function_name);
-            print("{}- Object:\n", spaces);
-            print_node(*node.expr, indent + 1);
-            print("{}- Args:\n", spaces);
-            for (const auto& arg : node.args) {
-                print_node(*arg, indent + 1);
-            }
-        },
         [&](const node_list_expr& node) {
             print("{}List:\n", spaces);
             print("{}- Elements:\n", spaces);

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -89,15 +89,7 @@ struct node_binary_op_expr
 
 struct node_function_call_expr
 {
-    std::string                function_name;
-    std::vector<node_expr_ptr> args;
-
-    anzu::token token;
-};
-
-struct node_member_function_call_expr
-{
-    node_expr_ptr              expr;
+    node_type_ptr              struct_type;
     std::string                function_name;
     std::vector<node_expr_ptr> args;
 
@@ -162,7 +154,6 @@ struct node_expr : std::variant<
     node_unary_op_expr,
     node_binary_op_expr,
     node_function_call_expr,
-    node_member_function_call_expr,
     node_list_expr,
     node_repeat_list_expr,
     node_addrof_expr,

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -10,10 +10,13 @@
 namespace anzu {
 
 struct node_expr;
-using node_expr_ptr = std::unique_ptr<node_expr>;
+using node_expr_ptr = std::shared_ptr<node_expr>;
 
 struct node_type;
-using node_type_ptr = std::unique_ptr<node_type>;
+using node_type_ptr = std::shared_ptr<node_type>;
+
+struct node_stmt;
+using node_stmt_ptr = std::shared_ptr<node_stmt>;
 
 struct node_named_type
 {
@@ -174,12 +177,6 @@ struct node_expr : std::variant<
 {
 };
 
-auto is_lvalue_expr(const node_expr& expr) -> bool;
-auto is_rvalue_expr(const node_expr& expr) -> bool;
-
-struct node_stmt;
-using node_stmt_ptr = std::unique_ptr<node_stmt>;
-
 struct node_sequence_stmt
 {
     std::vector<node_stmt_ptr> sequence;
@@ -313,6 +310,9 @@ struct node_stmt : std::variant<
     node_delete_stmt>
 {
 };
+
+auto is_lvalue_expr(const node_expr& expr) -> bool;
+auto is_rvalue_expr(const node_expr& expr) -> bool;
 
 auto print_node(const anzu::node_expr& root, int indent = 0) -> void;
 auto print_node(const anzu::node_stmt& root, int indent = 0) -> void;

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -677,7 +677,8 @@ auto push_expr_val(compiler& com, const node_function_call_expr& node) -> type_n
         params.push_back(type_of_expr(com, *arg));
     }
     
-    if (const auto func = get_function(com, resolve_type(com, node.token, node.struct_type), node.function_name, params); func.has_value()) {
+    const auto type = resolve_type(com, node.token, node.struct_type);
+    if (const auto func = get_function(com, type, node.function_name, params); func.has_value()) {
         push_function_call_begin(com);
         for (const auto& arg : node.args) {
             push_object_copy(com, *arg, node.token);

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -138,7 +138,7 @@ static const auto bin_ops_table = precedence_table();
 
 auto parse_function_call(tokenstream& tokens) -> node_expr_ptr
 {
-    auto node = std::make_unique<node_expr>();
+    auto node = std::make_shared<node_expr>();
     auto& out = node->emplace<node_function_call_expr>();
     out.token = tokens.consume();
 
@@ -152,7 +152,7 @@ auto parse_function_call(tokenstream& tokens) -> node_expr_ptr
 
 auto parse_member_access(tokenstream& tokens, node_expr_ptr& node)
 {
-    auto new_node = std::make_unique<node_expr>();
+    auto new_node = std::make_shared<node_expr>();
     const auto tok = tokens.consume();
     if (tokens.peek_next(tk_lparen)) {
         auto& expr = new_node->emplace<node_member_function_call_expr>();
@@ -174,7 +174,7 @@ auto parse_member_access(tokenstream& tokens, node_expr_ptr& node)
 
 auto parse_single_factor(tokenstream& tokens) -> node_expr_ptr
 {
-    auto node = std::make_unique<node_expr>();
+    auto node = std::make_shared<node_expr>();
     
     if (tokens.consume_maybe(tk_lparen)) {
         node = parse_expression(tokens);
@@ -239,7 +239,7 @@ auto parse_single_factor(tokenstream& tokens) -> node_expr_ptr
         if (tokens.consume_maybe(tk_colon)) {
             expr.size = parse_expression(tokens);
         } else {
-            expr.size = std::make_unique<node_expr>();
+            expr.size = std::make_shared<node_expr>();
             auto& inner = expr.size->emplace<node_literal_expr>();
             inner.value = parse_u64(token{.text="1u"});
         }
@@ -257,7 +257,7 @@ auto parse_single_factor(tokenstream& tokens) -> node_expr_ptr
         
         // For x->y, parse as (*x).y by first wrapping x in a node_deref_expr
         else if (tokens.peek(tk_rarrow)) {
-            auto deref_node = std::make_unique<node_expr>();
+            auto deref_node = std::make_shared<node_expr>();
             auto& deref_inner = deref_node->emplace<node_deref_expr>();
             deref_inner.token = std::visit([](auto&& n) { return n.token; }, *node);
             deref_inner.expr = std::move(node);
@@ -266,7 +266,7 @@ auto parse_single_factor(tokenstream& tokens) -> node_expr_ptr
         }
         
         else {
-            auto new_node = std::make_unique<node_expr>();
+            auto new_node = std::make_shared<node_expr>();
             auto& expr = new_node->emplace<node_subscript_expr>();
             expr.token = tokens.consume();
             expr.index = parse_expression(tokens);
@@ -288,7 +288,7 @@ auto parse_compound_factor(tokenstream& tokens, std::int64_t level) -> node_expr
 
     auto factor = parse_compound_factor(tokens, level - 1);
     while (tokens.valid() && bin_ops_table[level].contains(tokens.curr().text)) {
-        auto node = std::make_unique<node_expr>();
+        auto node = std::make_shared<node_expr>();
         auto& expr = node->emplace<node_binary_op_expr>();
         expr.lhs = std::move(factor);
         expr.token = tokens.consume();
@@ -331,7 +331,7 @@ auto parse_type(tokenstream& tokens) -> type_name
 auto parse_type_node(tokenstream& tokens) -> node_type_ptr
 {
     if (tokens.peek(tk_typeof)) {
-        auto node = std::make_unique<node_type>();
+        auto node = std::make_shared<node_type>();
         auto& inner = node->emplace<node_expr_type>();
         inner.token = tokens.consume();
         tokens.consume_only(tk_lparen);
@@ -341,12 +341,12 @@ auto parse_type_node(tokenstream& tokens) -> node_type_ptr
     }
 
     const auto type = parse_type(tokens);
-    return std::make_unique<node_type>(node_named_type{type});
+    return std::make_shared<node_type>(node_named_type{type});
 }
 
 auto parse_function_def_stmt(tokenstream& tokens) -> node_stmt_ptr
 {
-    auto node = std::make_unique<node_stmt>();
+    auto node = std::make_shared<node_stmt>();
     auto& stmt = node->emplace<node_function_def_stmt>();
 
     stmt.token = tokens.consume_only(tk_function);
@@ -362,7 +362,7 @@ auto parse_function_def_stmt(tokenstream& tokens) -> node_stmt_ptr
     if (tokens.consume_maybe(tk_rarrow)) {
         stmt.sig.return_type = parse_type_node(tokens);
     } else {
-        stmt.sig.return_type = std::make_unique<node_type>(node_named_type{null_type()});
+        stmt.sig.return_type = std::make_shared<node_type>(node_named_type{null_type()});
     }
     stmt.body = parse_statement(tokens);
     return node;
@@ -373,7 +373,7 @@ auto parse_member_function_def_stmt(
 )
     -> node_stmt_ptr
 {
-    auto node = std::make_unique<node_stmt>();
+    auto node = std::make_shared<node_stmt>();
     auto& stmt = node->emplace<node_member_function_def_stmt>();
 
     stmt.token = tokens.consume_only(tk_function);
@@ -392,7 +392,7 @@ auto parse_member_function_def_stmt(
     //        stmt.token.error("can only =delete a function");
     //    }
     //    stmt.sig.return_type = null_type();
-    //    stmt.body = std::make_unique<node_stmt>(node_sequence_stmt{});
+    //    stmt.body = std::make_shared<node_stmt>(node_sequence_stmt{});
     //    tokens.consume_only(tk_semicolon);
     //    return node;
     //}
@@ -408,7 +408,7 @@ auto parse_member_function_def_stmt(
     if (tokens.consume_maybe(tk_rarrow)) {
         stmt.sig.return_type = parse_type_node(tokens);
     } else {
-        stmt.sig.return_type = std::make_unique<node_type>(node_named_type{null_type()});
+        stmt.sig.return_type = std::make_shared<node_type>(node_named_type{null_type()});
     }
     stmt.body = parse_statement(tokens);
     return node;
@@ -416,12 +416,12 @@ auto parse_member_function_def_stmt(
 
 auto parse_return_stmt(tokenstream& tokens) -> node_stmt_ptr
 {
-    auto node = std::make_unique<node_stmt>();
+    auto node = std::make_shared<node_stmt>();
     auto& stmt = node->emplace<node_return_stmt>();
     
     stmt.token = tokens.consume_only(tk_return);
     if (tokens.peek(tk_semicolon)) {
-        stmt.return_value = std::make_unique<node_expr>();
+        stmt.return_value = std::make_shared<node_expr>();
         auto& ret_expr = stmt.return_value->emplace<node_literal_expr>();
         ret_expr.value = object{ .data={std::byte{0}}, .type=null_type() };
         ret_expr.token = stmt.token;
@@ -434,7 +434,7 @@ auto parse_return_stmt(tokenstream& tokens) -> node_stmt_ptr
 
 auto parse_loop_stmt(tokenstream& tokens) -> node_stmt_ptr
 {
-    auto node = std::make_unique<node_stmt>();
+    auto node = std::make_shared<node_stmt>();
     auto& stmt = node->emplace<node_loop_stmt>();
 
     stmt.token = tokens.consume_only(tk_loop);
@@ -444,7 +444,7 @@ auto parse_loop_stmt(tokenstream& tokens) -> node_stmt_ptr
 
 auto parse_while_stmt(tokenstream& tokens) -> node_stmt_ptr
 {
-    auto node = std::make_unique<node_stmt>();
+    auto node = std::make_shared<node_stmt>();
     auto& stmt = node->emplace<node_while_stmt>();
 
     stmt.token = tokens.consume_only(tk_while);
@@ -455,7 +455,7 @@ auto parse_while_stmt(tokenstream& tokens) -> node_stmt_ptr
 
 auto parse_for_stmt(tokenstream& tokens) -> node_stmt_ptr
 {
-    auto node = std::make_unique<node_stmt>();
+    auto node = std::make_shared<node_stmt>();
     auto& stmt = node->emplace<node_for_stmt>();
 
     stmt.token = tokens.consume_only(tk_for);
@@ -468,7 +468,7 @@ auto parse_for_stmt(tokenstream& tokens) -> node_stmt_ptr
 
 auto parse_if_stmt(tokenstream& tokens) -> node_stmt_ptr
 {
-    auto node = std::make_unique<node_stmt>();
+    auto node = std::make_shared<node_stmt>();
     auto& stmt = node->emplace<node_if_stmt>();
 
     stmt.token = tokens.consume_only(tk_if);
@@ -482,7 +482,7 @@ auto parse_if_stmt(tokenstream& tokens) -> node_stmt_ptr
 
 auto parse_struct_stmt(tokenstream& tokens) -> node_stmt_ptr
 {
-    auto node = std::make_unique<node_stmt>();
+    auto node = std::make_shared<node_stmt>();
     auto& stmt = node->emplace<node_struct_stmt>();
 
     stmt.token = tokens.consume_only(tk_struct);
@@ -506,7 +506,7 @@ auto parse_struct_stmt(tokenstream& tokens) -> node_stmt_ptr
 
 auto parse_declaration_stmt(tokenstream& tokens) -> node_stmt_ptr
 {
-    auto node = std::make_unique<node_stmt>();
+    auto node = std::make_shared<node_stmt>();
     auto& stmt = node->emplace<node_declaration_stmt>();
 
     stmt.name = parse_name(tokens);
@@ -518,7 +518,7 @@ auto parse_declaration_stmt(tokenstream& tokens) -> node_stmt_ptr
 
 auto parse_braced_statement_list(tokenstream& tokens) -> node_stmt_ptr
 {
-    auto node = std::make_unique<node_stmt>();
+    auto node = std::make_shared<node_stmt>();
     auto& stmt = node->emplace<node_sequence_stmt>();
     
     stmt.token = tokens.consume_only(tk_lbrace);
@@ -531,7 +531,7 @@ auto parse_braced_statement_list(tokenstream& tokens) -> node_stmt_ptr
 
 auto parse_delete_stmt(tokenstream& tokens) -> node_stmt_ptr
 {
-    auto node = std::make_unique<node_stmt>();
+    auto node = std::make_shared<node_stmt>();
     auto& stmt = node->emplace<node_delete_stmt>();
 
     stmt.token = tokens.consume_only(tk_delete);
@@ -563,12 +563,12 @@ auto parse_statement(tokenstream& tokens) -> node_stmt_ptr
         return parse_if_stmt(tokens);
     }
     if (tokens.peek(tk_break)) {
-        auto ret = std::make_unique<node_stmt>(node_break_stmt{ tokens.consume() });
+        auto ret = std::make_shared<node_stmt>(node_break_stmt{ tokens.consume() });
         tokens.consume_only(tk_semicolon);
         return ret;
     }
     if (tokens.peek(tk_continue)) {
-        auto ret = std::make_unique<node_stmt>(node_continue_stmt{ tokens.consume() });
+        auto ret = std::make_shared<node_stmt>(node_continue_stmt{ tokens.consume() });
         tokens.consume_only(tk_semicolon);
         return ret;
     }
@@ -582,7 +582,7 @@ auto parse_statement(tokenstream& tokens) -> node_stmt_ptr
         return parse_delete_stmt(tokens);
     }
 
-    auto node = std::make_unique<node_stmt>();
+    auto node = std::make_shared<node_stmt>();
     auto expr = parse_expression(tokens);
     if (tokens.peek(tk_assign)) {
         auto& stmt = node->emplace<node_assignment_stmt>();
@@ -617,7 +617,7 @@ auto parse(const std::vector<token>& tokens) -> node_stmt_ptr
 {
     auto stream = tokenstream{tokens};
 
-    auto root = std::make_unique<node_stmt>();
+    auto root = std::make_shared<node_stmt>();
     auto& seq = root->emplace<node_sequence_stmt>();
     while (stream.valid()) {
         seq.sequence.push_back(parse_top_level_statement(stream));


### PR DESCRIPTION
* Remove `node_member_function_call_expr`; now that we have `typeof` in the language, member function calls `x.f(...)` can now be parsed as `typeof(x)::f(&x, ...)` (although this syntax is not currently allowed in the language yet, this is purely a parsing change).
* Because the above change refers to `x` twice, the expr node that represents it must be held in two places in the ast, so switched from `unique_ptr` to `shared_ptr`. There may be a better way to do this.