### PR TITLE
Modules

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -79,6 +79,7 @@
         "*.rh": "cpp",
         "memory_resource": "cpp",
         "mutex": "cpp",
-        "numeric": "cpp"
+        "numeric": "cpp",
+        "filesystem": "cpp"
     }
 }

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Utility Modules (in src/utility)
 ```
 
 # Next Features (In ordoer of prio)
-* Modules
+* Modules (in progress)
 * Templates
 * Function Pointers
 * Filesystem Support

--- a/anzu-lang/syntaxes/anzu.tmLanguage.json
+++ b/anzu-lang/syntaxes/anzu.tmLanguage.json
@@ -17,7 +17,7 @@
 		},
 		{
 			"name": "keyword.other.anzu",
-			"match": "\\b(in|fn|struct|sizeof|typeof|new|delete|default)\\b"
+			"match": "\\b(in|fn|struct|sizeof|typeof|new|delete|default|import)\\b"
 		},
 		{
 			"name": "storage.type.anzu",

--- a/examples/nested/string.az
+++ b/examples/nested/string.az
@@ -1,0 +1,9 @@
+struct string
+{
+
+};
+
+fn print_string(str: &string)
+{
+    println("string");
+}

--- a/examples/recursion.az
+++ b/examples/recursion.az
@@ -1,12 +1,12 @@
 # fibbonacci to demonstrate functions and recursion
 
-fn fibb(n: i32) -> i32
+fn fibb(n: i64) -> i64
 {
-    if n == 0i32 {
-        return 0i32;
-    } else if n == 1i32 {
-        return 1i32;
+    if n == 0 {
+        return 0;
+    } else if n == 1 {
+        return 1;
     }
 
-    return fibb(n - 1i32) + fibb(n - 2i32);
+    return fibb(n - 1) + fibb(n - 2);
 }

--- a/examples/recursion.az
+++ b/examples/recursion.az
@@ -1,5 +1,5 @@
 # fibbonacci to demonstrate functions and recursion
-
+import nested/string.az;
 fn fibb(n: i64) -> i64
 {
     if n == 0 {

--- a/examples/recursion.az
+++ b/examples/recursion.az
@@ -10,5 +10,3 @@ fn fibb(n: i32) -> i32
 
     return fibb(n - 1i32) + fibb(n - 2i32);
 }
-
-println(fibb(5i32));

--- a/examples/test.az
+++ b/examples/test.az
@@ -9,4 +9,5 @@ struct foo
 
 f := foo();
 
-y := f.bar();
+y := f.bar(5);
+println(y);

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,4 +1,4 @@
-import examples/recursion.az;
+import recursion.az;
 
 struct foo
 {

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,4 +1,4 @@
-import vector;
+import ./examples/recursion.az;
 
 struct foo
 {
@@ -12,3 +12,4 @@ f := foo();
 
 y := f.bar(5);
 println(y);
+println(fibb(10i32));

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,4 +1,4 @@
-import ./examples/recursion.az;
+import examples/recursion.az;
 
 struct foo
 {
@@ -12,4 +12,4 @@ f := foo();
 
 y := f.bar(5);
 println(y);
-println(fibb(10i32));
+println(fibb(10));

--- a/examples/test.az
+++ b/examples/test.az
@@ -9,5 +9,4 @@ struct foo
 
 f := foo();
 
-f.bar();
-typeof(f)::bar(&f);
+y := f.bar();

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,4 +1,5 @@
 import recursion.az;
+import nested/string.az;
 
 struct foo
 {

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,3 +1,4 @@
+import vector;
 
 struct foo
 {

--- a/src/anzu.m.cpp
+++ b/src/anzu.m.cpp
@@ -77,7 +77,7 @@ auto main(const int argc, const char* argv[]) -> int
     }
 
     anzu::print("-> Compiling\n");
-    const auto program = anzu::compile(parsed_program[file].root);
+    const auto program = anzu::compile(parsed_program);
     if (mode == "com") {
         anzu::print_program(program);
         return 0;

--- a/src/anzu.m.cpp
+++ b/src/anzu.m.cpp
@@ -81,7 +81,7 @@ auto main(const int argc, const char* argv[]) -> int
     }
 
     anzu::print("-> Compiling\n");
-    const auto program = anzu::compile(parsed_program);
+    const auto program = anzu::compile(root, parsed_program);
     if (mode == "com") {
         anzu::print_program(program);
         return 0;

--- a/src/anzu.m.cpp
+++ b/src/anzu.m.cpp
@@ -13,11 +13,12 @@ void print_usage()
     anzu::print("usage: anzu.exe <program_file> <option>\n\n");
     anzu::print("The Anzu Programming Language\n\n");
     anzu::print("options:\n");
-    anzu::print("    lex   - runs the lexer and prints the tokens\n");
-    anzu::print("    parse - runs the parser and prints the AST\n");
-    anzu::print("    com   - runs the compiler and prints the bytecode\n");
-    anzu::print("    debug - runs the program and prints each op code executed\n");
-    anzu::print("    run   - runs the program\n");
+    anzu::print("    lex      - runs the lexer and prints the tokens for a single file\n");
+    anzu::print("    parse    - runs the parser and prints the AST for a single file\n");
+    anzu::print("    discover - runs the parser and prints all modules\n");
+    anzu::print("    com      - runs the compiler and prints the bytecode\n");
+    anzu::print("    debug    - runs the program and prints each op code executed\n");
+    anzu::print("    run      - runs the program\n");
 }
 
 auto main(const int argc, const char* argv[]) -> int
@@ -62,6 +63,17 @@ auto main(const int argc, const char* argv[]) -> int
             }
         }
         parsed_program.emplace(file, std::move(ast));
+    }
+
+    if (mode == "discover") {
+        anzu::print("\nFound modules:\n");
+        for (const auto& [file, mod] : parsed_program) {
+            anzu::print("- {}\n", file);
+            for (const auto& dep : mod.required_modules) {
+                anzu::print("  | - {}\n", dep);
+            }
+        }
+        return 0;
     }
 
     anzu::print("-> Compiling\n");

--- a/src/anzu.m.cpp
+++ b/src/anzu.m.cpp
@@ -37,14 +37,14 @@ auto main(const int argc, const char* argv[]) -> int
     }
 
     anzu::print("-> Parsing\n");
-    const auto ast = anzu::parse(tokens);
+    const auto mod = anzu::parse(tokens);
     if (mode == "parse") {
-        print_node(*ast);
+        print_node(*mod.root);
         return 0;
     }
 
     anzu::print("-> Compiling\n");
-    const auto program = anzu::compile(ast);
+    const auto program = anzu::compile(mod.root);
     if (mode == "com") {
         anzu::print_program(program);
         return 0;

--- a/src/anzu.m.cpp
+++ b/src/anzu.m.cpp
@@ -61,6 +61,7 @@ auto main(const int argc, const char* argv[]) -> int
                 modules.emplace(m);
             }
         }
+        parsed_program.emplace(file, std::move(ast));
     }
 
     anzu::print("-> Compiling\n");

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -707,9 +707,10 @@ auto push_expr_val(compiler& com, const node_function_call_expr& node) -> type_n
         });
         return builtin.return_type;
     }
-
-    const auto function_str = std::format("{}", node.function_name);
-    node.token.error("(3) could not find function '{}'", function_str);
+    
+    const auto sig = format_comma_separated(params);
+    const auto function_str = std::format("{}({})", node.function_name, sig);
+    node.token.error("could not find function '{}'", function_str);
 }
 
 auto push_expr_val(compiler& com, const node_list_expr& node) -> type_name

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -1142,7 +1142,7 @@ auto push_stmt(compiler& com, const node_stmt& root) -> void
 
 }
 
-auto compiled_all_requirements(const file_ast& module, const std::set<std::string>& compiled) -> bool
+auto compiled_all_requirements(const file_ast& module, const std::set<std::filesystem::path>& compiled) -> bool
 {
     for (const auto& requirement : module.required_modules) {
         if (!compiled.contains(requirement)) {
@@ -1152,20 +1152,20 @@ auto compiled_all_requirements(const file_ast& module, const std::set<std::strin
     return true;
 }
 
-auto compile(const std::map<std::string, file_ast>& modules) -> program
+auto compile(const std::map<std::filesystem::path, file_ast>& modules) -> program
 {
     auto com = compiler{};
-    auto done = std::set<std::string>{};
-    auto remaining = std::set<std::string>{}; 
+    auto done = std::set<std::filesystem::path>{};
+    auto remaining = std::set<std::filesystem::path>{}; 
     for (const auto& [file, mod] : modules) {
         remaining.emplace(file);
     }
     while (!remaining.empty()) {
         const auto before = remaining.size();
-        std::erase_if(remaining, [&](const std::string& curr) {
+        std::erase_if(remaining, [&](const std::filesystem::path& curr) {
             const auto& mod = modules.at(curr);
             if (compiled_all_requirements(mod, done)) {
-                print("    {}\n", curr);
+                print("    {}\n", curr.string());
                 push_stmt(com, *mod.root);
                 done.emplace(curr);
                 return true;

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -1142,6 +1142,10 @@ auto push_stmt(compiler& com, const node_stmt& root) -> void
 
 auto compile(const node_stmt_ptr& root) -> program
 {
+    if (!root) {
+        print("AST passed to compiler is a null pointer :(\n");
+        exit(1);
+    }
     auto com = compiler{};
     push_stmt(com, *root);
     return com.program;

--- a/src/compiler.hpp
+++ b/src/compiler.hpp
@@ -3,11 +3,12 @@
 #include "program.hpp"
 #include "parser.hpp"
 
+#include <filesystem>
 #include <map>
 #include <string>
 
 namespace anzu {
 
-auto compile(const std::map<std::string, file_ast>& moduiles) -> program;
+auto compile(const std::map<std::filesystem::path, file_ast>& moduiles) -> program;
 
 }

--- a/src/compiler.hpp
+++ b/src/compiler.hpp
@@ -9,6 +9,9 @@
 
 namespace anzu {
 
-auto compile(const std::map<std::filesystem::path, file_ast>& moduiles) -> program;
+auto compile(
+    const std::filesystem::path& main_dir,
+    const std::map<std::filesystem::path, file_ast>& modules
+) -> program;
 
 }

--- a/src/compiler.hpp
+++ b/src/compiler.hpp
@@ -1,9 +1,13 @@
 #pragma once
 #include "ast.hpp"
 #include "program.hpp"
+#include "parser.hpp"
+
+#include <map>
+#include <string>
 
 namespace anzu {
 
-auto compile(const node_stmt_ptr& root) -> anzu::program;
+auto compile(const std::map<std::string, file_ast>& moduiles) -> program;
 
 }

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -204,16 +204,16 @@ auto lex_line(
 
 }
 
-auto lex(const std::string& file) -> std::vector<anzu::token>
+auto lex(const std::filesystem::path& file) -> std::vector<anzu::token>
 {
     // Loop over the lines in the program, and then split each line into tokens.
     // If a '//' comment symbol is hit, the rest of the line is ignored.
     std::vector<anzu::token> tokens;
     std::ifstream file_stream{file};
     if (!file_stream) {
-        lexer_error(0, 0, "Could not find module {}\n", file);
+        lexer_error(0, 0, "Could not find module {}\n", file.string());
     }
-    
+
     std::string line;
     std::int64_t lineno = 1;
     while (std::getline(file_stream, line)) {

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -210,6 +210,10 @@ auto lex(const std::string& file) -> std::vector<anzu::token>
     // If a '//' comment symbol is hit, the rest of the line is ignored.
     std::vector<anzu::token> tokens;
     std::ifstream file_stream{file};
+    if (!file_stream) {
+        lexer_error(0, 0, "Could not find module {}\n", file);
+    }
+    
     std::string line;
     std::int64_t lineno = 1;
     while (std::getline(file_stream, line)) {

--- a/src/lexer.hpp
+++ b/src/lexer.hpp
@@ -1,11 +1,11 @@
 #pragma once
 #include <vector>
-#include <string>
+#include <filesystem>
 
 #include "token.hpp"
 
 namespace anzu {
 
-auto lex(const std::string& file) -> std::vector<anzu::token>;
+auto lex(const std::filesystem::path& file) -> std::vector<anzu::token>;
 
 }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -618,7 +618,11 @@ auto parse_top_level_statement(tokenstream& tokens) -> node_stmt_ptr
 
 }
 
-auto parse(const std::vector<token>& tokens) -> file_ast
+auto parse(
+    const std::filesystem::path& file,
+    const std::vector<anzu::token>& tokens
+)
+    -> file_ast
 {
     auto stream = tokenstream{tokens};
     auto mod = file_ast{};
@@ -631,7 +635,7 @@ auto parse(const std::vector<token>& tokens) -> file_ast
             while (!stream.peek(tk_semicolon)) {
                 module_name += stream.consume().text;
             }
-            mod.required_modules.emplace(module_name);
+            mod.required_modules.emplace(std::filesystem::absolute(file.parent_path() / module_name));
             stream.consume_only(tk_semicolon);
         } else {
             seq.sequence.push_back(parse_top_level_statement(stream));

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -618,10 +618,10 @@ auto parse_top_level_statement(tokenstream& tokens) -> node_stmt_ptr
 
 }
 
-auto parse(const std::vector<token>& tokens) -> anzu_module
+auto parse(const std::vector<token>& tokens) -> file_ast
 {
     auto stream = tokenstream{tokens};
-    auto mod = anzu_module{};
+    auto mod = file_ast{};
     mod.root = std::make_shared<node_stmt>();
     auto& seq = mod.root->emplace<node_sequence_stmt>();
     while (stream.valid()) {

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -627,7 +627,11 @@ auto parse(const std::vector<token>& tokens) -> file_ast
     while (stream.valid()) {
         while (stream.consume_maybe(tk_semicolon));
         if (stream.consume_maybe(tk_import)) {
-            mod.required_modules.emplace(parse_name(stream));
+            auto module_name = std::string{};
+            while (!stream.peek(tk_semicolon)) {
+                module_name += stream.consume().text;
+            }
+            mod.required_modules.emplace(module_name);
             stream.consume_only(tk_semicolon);
         } else {
             seq.sequence.push_back(parse_top_level_statement(stream));

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -618,16 +618,22 @@ auto parse_top_level_statement(tokenstream& tokens) -> node_stmt_ptr
 
 }
 
-auto parse(const std::vector<token>& tokens) -> node_stmt_ptr
+auto parse(const std::vector<token>& tokens) -> anzu_module
 {
     auto stream = tokenstream{tokens};
-
-    auto root = std::make_shared<node_stmt>();
-    auto& seq = root->emplace<node_sequence_stmt>();
+    auto mod = anzu_module{};
+    mod.root = std::make_shared<node_stmt>();
+    auto& seq = mod.root->emplace<node_sequence_stmt>();
     while (stream.valid()) {
-        seq.sequence.push_back(parse_top_level_statement(stream));
+        while (stream.consume_maybe(tk_semicolon));
+        if (stream.consume_maybe(tk_import)) {
+            mod.required_modules.emplace(parse_name(stream));
+            stream.consume_only(tk_semicolon);
+        } else {
+            seq.sequence.push_back(parse_top_level_statement(stream));
+        }
     }
-    return root;
+    return mod;
 }
 
 }

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -3,9 +3,17 @@
 #include "ast.hpp"
 
 #include <vector>
+#include <unordered_set>
+#include <string>
 
 namespace anzu {
 
-auto parse(const std::vector<anzu::token>& tokens) -> anzu::node_stmt_ptr;
+struct anzu_module
+{
+    node_stmt_ptr                   root;
+    std::unordered_set<std::string> required_modules;
+};
+
+auto parse(const std::vector<anzu::token>& tokens) -> anzu_module;
 
 }

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -3,17 +3,22 @@
 #include "ast.hpp"
 
 #include <vector>
-#include <unordered_set>
+#include <set>
 #include <string>
+#include <filesystem>
 
 namespace anzu {
 
 struct file_ast
 {
-    node_stmt_ptr                   root;
-    std::unordered_set<std::string> required_modules;
+    node_stmt_ptr root;
+
+    std::set<std::filesystem::path> required_modules;
 };
 
-auto parse(const std::vector<anzu::token>& tokens) -> file_ast;
+auto parse(
+    const std::filesystem::path& file,
+    const std::vector<anzu::token>& token
+) -> file_ast;
 
 }

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -8,12 +8,12 @@
 
 namespace anzu {
 
-struct anzu_module
+struct file_ast
 {
     node_stmt_ptr                   root;
     std::unordered_set<std::string> required_modules;
 };
 
-auto parse(const std::vector<anzu::token>& tokens) -> anzu_module;
+auto parse(const std::vector<anzu::token>& tokens) -> file_ast;
 
 }

--- a/src/vocabulary.cpp
+++ b/src/vocabulary.cpp
@@ -11,7 +11,7 @@ auto is_keyword(std::string_view token) -> bool
         tk_break, tk_continue, tk_else, tk_false, tk_for, tk_if, tk_in, tk_null, tk_true,
         tk_while, tk_bool, tk_function, tk_return, tk_struct, tk_sizeof, tk_char,
         tk_i32, tk_i64, tk_u64, tk_f64, tk_new, tk_delete, tk_default, tk_loop, tk_typeof,
-        tk_module
+        tk_import
     };
     return tokens.contains(token);
 }

--- a/src/vocabulary.cpp
+++ b/src/vocabulary.cpp
@@ -10,7 +10,8 @@ auto is_keyword(std::string_view token) -> bool
     static const std::unordered_set<std::string_view> tokens = {
         tk_break, tk_continue, tk_else, tk_false, tk_for, tk_if, tk_in, tk_null, tk_true,
         tk_while, tk_bool, tk_function, tk_return, tk_struct, tk_sizeof, tk_char,
-        tk_i32, tk_i64, tk_u64, tk_f64, tk_new, tk_delete, tk_default, tk_loop, tk_typeof
+        tk_i32, tk_i64, tk_u64, tk_f64, tk_new, tk_delete, tk_default, tk_loop, tk_typeof,
+        tk_module
     };
     return tokens.contains(token);
 }

--- a/src/vocabulary.hpp
+++ b/src/vocabulary.hpp
@@ -25,6 +25,7 @@ constexpr auto tk_delete    = sv{"delete"};
 constexpr auto tk_default   = sv{"default"};
 constexpr auto tk_loop      = sv{"loop"};
 constexpr auto tk_typeof    = sv{"typeof"};
+constexpr auto tk_import    = sv{"import"};
 
 // Builtin Types
 constexpr auto tk_i32       = sv{"i32"};


### PR DESCRIPTION
* Added `import` statement.
* Modified parser and compiler to account for module discovery.
* After parsing the first module, we loop through the required modules that it imports and repeat the process, continuing until all modules have been discovered.
* We then compile by looping through the modules and compiling all the ones where the requirements have already been compiled. If we have a pass where no modules are compiled, there is a circular dependency and we fail to compile.
* Currently no namespacing, the system is essentially like copying and pasting all the files into a single file in the correct order, except we do it as the AST level rather than the source level. This will be added in a later PR.
* Currently no checking that modules are explicitly imported when using functions from them; so transitive imports are possible. This will be fixed in a later PR.
* As with all major features, the code is a bit of a mess and will need a clean up.
* Added `discover` command line mode to print all discovered modules and their dependencies as well as compile order.
* `lex` and `parse` tools now only apply to a single file, whereas all other tools will do the module discovery. `parse` needs to be updated to show import statements.