### PR TITLE
Spans

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,15 +119,24 @@ Utility Modules (in src/utility)
 -- overloaded.hpp  : A helper class to make std::visit simpler
 -- peekstream.hpp  : A data structure used in the lexer
 -- print.hpp       : Wrapper for std::format, similar to {fmt}
--- score_timer.hpp : An RAII class for timing a block of code
+-- scope_timer.hpp : An RAII class for timing a block of code
 -- value_ptr.hpp   : A value-semantic smart pointer
 -- views.hpp       : A collection of some helper views not in C++20
 ```
 
-# Next Features (In ordoer of prio)
+# Next Features
 * Modules (in progress)
+* Spans
+    - Basic impl (Done)
+    - Have `new` and `delete` operate on spans instead of pointers for arrays (then ban pointer arithmetic).
+    - `.remove_prefix(count)` and `.remove_suffix(count)` functions to trim a span.
+    - A way to create subspans with syntax like `arr[0..2]` or `arr[0:2]`.
+    - Runtime bounds checking for arrays and spans, possibly adding debug-only op codes.
+    - Create spans from other spans.
+    - Turn string literals into spans instead of char arrays.
 * Templates
 * Function Pointers
 * Filesystem Support
 * Const
 * Variants
+* Static storage for string literals

--- a/README.md
+++ b/README.md
@@ -125,7 +125,10 @@ Utility Modules (in src/utility)
 ```
 
 # Next Features
-* Modules (in progress)
+* Modules
+    - Basic impl (Done)
+    - Namespacing
+    - No transitive includes
 * Spans
     - Basic impl (Done)
     - Have `new` and `delete` operate on spans instead of pointers for arrays (then ban pointer arithmetic).

--- a/README.md
+++ b/README.md
@@ -126,11 +126,11 @@ Utility Modules (in src/utility)
 
 # Next Features
 * Modules
-    - Basic impl (Done)
+    - ~~Basic impl~~
     - Namespacing
     - No transitive includes
 * Spans
-    - Basic impl (Done)
+    - ~~Basic impl~~
     - Have `new` and `delete` operate on spans instead of pointers for arrays (then ban pointer arithmetic).
     - `.remove_prefix(count)` and `.remove_suffix(count)` functions to trim a span.
     - A way to create subspans with syntax like `arr[0..2]` or `arr[0:2]`.

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,6 +1,9 @@
-fn print_string(str: char[])
+fn printegers(values: i64[])
 {
-    return null;
+    #for x in values {
+    #    println(*x);
+    #}
 }
 
-print_string("abc");
+x := [1, 2, 3, 4];
+printegers(x[]);

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,16 +1,4 @@
-import recursion.az;
-import nested/string.az;
-
-struct foo
+fn print_string(str: char[])
 {
-    fn bar(self: &foo, x: i64) -> i64
-    {
-        return x;
-    }
+    return null;
 }
-
-f := foo();
-
-y := f.bar(5);
-println(y);
-println(fibb(10));

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,7 +1,12 @@
-fn printegers(values: i64[])
+
+
+str := "hello world";
+
+fn strprint(str: char[])
 {
-    println(values[0u]);
+    for c in str {
+        print(*c);
+    }
 }
 
-x := [1, 2, 3, 4];
-printegers(x[]);
+strprint(str[]);

--- a/examples/test.az
+++ b/examples/test.az
@@ -2,3 +2,5 @@ fn print_string(str: char[])
 {
     return null;
 }
+
+print_string("abc");

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,8 +1,6 @@
 fn printegers(values: i64[])
 {
-    #for x in values {
-    #    println(*x);
-    #}
+    println(values[0u]);
 }
 
 x := [1, 2, 3, 4];

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -80,6 +80,10 @@ auto print_node(const node_expr& root, int indent) -> void
             print("{}New {}:\n", spaces, *node.type);
             print("{}- Size:\n", spaces);
             print_node(*node.size, indent + 1);
+        },
+        [&](const node_span_expr& node) {
+            print("{}Span:\n", spaces);
+            print_node(*node.expr, indent + 1);
         }
     }, root);
 }

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -215,7 +215,14 @@ auto is_rvalue_expr(const node_expr& expr) -> bool
 
 auto to_string(const node_type& node) -> std::string
 {
-    return "TODO: to_string(const node_type&)";
+    return std::visit(overloaded{
+        [&](const node_named_type& n) {
+            return to_string(n.type);
+        },
+        [&](const node_expr_type& n) {
+            return std::string{"typeof(TODO)"};
+        }
+    }, node);
 }
 
 }

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -148,6 +148,13 @@ struct node_new_expr
     anzu::token token;
 };
 
+struct node_span_expr
+{
+    node_expr_ptr expr;
+    
+    anzu::token token;
+};
+
 struct node_expr : std::variant<
     // Rvalue expressions
     node_literal_expr,
@@ -164,7 +171,8 @@ struct node_expr : std::variant<
     node_variable_expr,
     node_field_expr,
     node_deref_expr,
-    node_subscript_expr>
+    node_subscript_expr,
+    node_span_expr>
 {
 };
 

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -609,11 +609,6 @@ auto push_expr_ptr(compiler& com, const node_subscript_expr& expr) -> type_name
     return etype;
 }
 
-auto push_expr_ptr(compiler& com, const node_span_expr& expr) -> type_name
-{
-    return null_type();
-}
-
 [[noreturn]] auto push_expr_ptr(compiler& com, const auto& node) -> type_name
 {
     node.token.error("cannot take address of a non-lvalue\n");
@@ -753,6 +748,15 @@ auto push_expr_val(compiler& com, const node_sizeof_expr& node) -> type_name
     const auto size = com.types.size_of(type);
     push_literal(com, size);
     return u64_type();
+}
+
+auto push_expr_val(compiler& com, const node_span_expr& node) -> type_name
+{
+    const auto expr_type = type_of_expr(com, *node.expr);
+    node.token.assert(is_list_type(expr_type), "can only span an array");
+    push_expr_ptr(com, *node.expr);
+    push_literal(com, array_length(expr_type));
+    return concrete_span_type(inner_type(expr_type));
 }
 
 auto push_expr_val(compiler& com, const node_new_expr& node) -> type_name

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -609,6 +609,11 @@ auto push_expr_ptr(compiler& com, const node_subscript_expr& expr) -> type_name
     return etype;
 }
 
+auto push_expr_ptr(compiler& com, const node_span_expr& expr) -> type_name
+{
+    return null_type();
+}
+
 [[noreturn]] auto push_expr_ptr(compiler& com, const auto& node) -> type_name
 {
     node.token.error("cannot take address of a non-lvalue\n");

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -151,14 +151,14 @@ static const auto builtins = construct_builtin_map();
 auto is_builtin(const std::string& name, const std::vector<type_name>& args) -> bool
 {
     // Hack, generalise later
-    if (name.starts_with("print") &&
+    if ((name == "print" || name == "println") &&
         args.size() == 1 &&
         std::holds_alternative<type_list>(args[0]) &&
         inner_type(args[0]) == char_type()
     ) {
         return true;
     }
-    else if (name.starts_with("print") &&
+    else if ((name == "print" || name == "println") &&
         args.size() == 1 &&
         std::holds_alternative<type_ptr>(args[0])
     ) {

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -170,7 +170,7 @@ auto is_builtin(const std::string& name, const std::vector<type_name>& args) -> 
 auto fetch_builtin(const std::string& name, const std::vector<type_name>& args) -> builtin_val
 {
     // Hack, generalise later
-    if (name.starts_with("print") &&
+    if ((name == "print" || name == "println") &&
         args.size() == 1 &&
         std::holds_alternative<type_list>(args[0]) &&
         inner_type(args[0]) == char_type()
@@ -193,7 +193,7 @@ auto fetch_builtin(const std::string& name, const std::vector<type_name>& args) 
             .return_type = null_type()
         };
     }
-    else if (name.starts_with("print") &&
+    else if ((name == "print" || name == "println") &&
         args.size() == 1 &&
         std::holds_alternative<type_ptr>(args[0])
     ) {

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -11,6 +11,8 @@
 namespace anzu {
 namespace {
 
+static constexpr auto PTR_SIZE = std::size_t{8};
+
 auto format_error(const std::string& str) -> void
 {
     anzu::print("format error: could not format special chars in '{}'\n", str);
@@ -172,6 +174,11 @@ auto array_length(const type_name& t) -> std::size_t
     return {};
 }
 
+auto size_of_ptr() -> std::size_t
+{
+    return PTR_SIZE;
+}
+
 auto is_type_fundamental(const type_name& type) -> bool
 {
     return type == i32_type()
@@ -240,7 +247,7 @@ auto type_store::size_of(const type_name& type) const -> std::size_t
             return size_of(*t.inner_type) * t.count;
         },
         [](const type_ptr&) {
-            return std::size_t{8};
+            return PTR_SIZE;
         },
         [](const type_span&) {
             return std::size_t{16};

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -44,6 +44,11 @@ auto to_string(const type_ptr& type) -> std::string
     return std::format("&{}", to_string(*type.inner_type));
 }
 
+auto to_string(const type_span& type) -> std::string
+{
+    return std::format("{}[]", to_string(*type.inner_type));
+}
+
 auto hash(const type_name& type) -> std::size_t
 {
     return std::visit([](const auto& t) { return hash(t); }, type);
@@ -61,8 +66,14 @@ auto hash(const type_list& type) -> std::size_t
 
 auto hash(const type_ptr& type) -> std::size_t
 {
-    static const auto ptr_offset = std::hash<std::string_view>{}("ptr_offset");
-    return hash(*type.inner_type) ^ ptr_offset;
+    static const auto base = std::hash<std::string_view>{}("type_ptr");
+    return hash(*type.inner_type) ^ base;
+}
+
+auto hash(const type_span& type) -> std::size_t
+{
+    static const auto base = std::hash<std::string_view>{}("type_span");
+    return hash(*type.inner_type) ^ base;
 }
 
 auto i32_type() -> type_name
@@ -125,6 +136,16 @@ auto is_ptr_type(const type_name& t) -> bool
     return std::holds_alternative<type_ptr>(t);
 }
 
+auto concrete_span_type(const type_name& t) -> type_name
+{
+    return {type_span{ .inner_type = { t } }};
+}
+
+auto is_span_type(const type_name& t) -> bool
+{
+    return std::holds_alternative<type_span>(t);
+}
+
 auto inner_type(const type_name& t) -> type_name
 {
     if (is_list_type(t)) {
@@ -132,6 +153,9 @@ auto inner_type(const type_name& t) -> type_name
     }
     if (is_ptr_type(t)) {
         return *std::get<type_ptr>(t).inner_type;
+    }
+    if (is_span_type(t)) {
+        return *std::get<type_span>(t).inner_type; 
     }
     print("OH NO MY TYPE\n");
     std::exit(1);
@@ -163,7 +187,8 @@ auto is_type_trivially_copyable(const type_name& type) -> bool
 {
     return is_type_fundamental(type)
         || is_ptr_type(type)
-        || (is_list_type(type) && is_type_trivially_copyable(inner_type(type)));
+        || (is_list_type(type) && is_type_trivially_copyable(inner_type(type)))
+        || is_span_type(type);
 }
 
 auto type_store::add(const type_name& name, const type_fields& fields) -> bool
@@ -180,7 +205,8 @@ auto type_store::contains(const type_name& type) const -> bool
     return d_classes.contains(type)
         || is_type_fundamental(type)
         || is_list_type(type)
-        || is_ptr_type(type);
+        || is_ptr_type(type)
+        || is_span_type(type);
 }
 
 auto type_store::size_of(const type_name& type) const -> std::size_t
@@ -190,10 +216,10 @@ auto type_store::size_of(const type_name& type) const -> std::size_t
         std::exit(1);
     }
 
-    if (is_ptr_type(type)) {
-        return 8; // Two unsigned ints, ptr and size
+    if (type == null_type() || type == char_type() || type == bool_type()) {
+        return 1;
     }
-
+    
     if (type == i32_type()) {
         return 4;
     }
@@ -202,10 +228,6 @@ auto type_store::size_of(const type_name& type) const -> std::size_t
         return 8;
     }
 
-    if (is_type_fundamental(type)) {
-        return 1;
-    }
-    
     return std::visit(overloaded{
         [&](const type_simple& t) {
             auto size = std::size_t{0};
@@ -218,7 +240,10 @@ auto type_store::size_of(const type_name& type) const -> std::size_t
             return size_of(*t.inner_type) * t.count;
         },
         [](const type_ptr&) {
-            return std::size_t{1};
+            return std::size_t{8};
+        },
+        [](const type_span&) {
+            return std::size_t{16};
         }
     }, type);
 }

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -36,10 +36,17 @@ struct type_ptr
     auto operator==(const type_ptr&) const -> bool = default;
 };
 
+struct type_span
+{
+    value_ptr<type_name> inner_type;
+    auto operator==(const type_span&) const -> bool = default;
+};
+
 struct type_name : public std::variant<
     type_simple,
     type_list,
-    type_ptr>
+    type_ptr,
+    type_span>
 {
     using variant::variant;
 };
@@ -74,6 +81,7 @@ struct type_info
 auto hash(const type_name& type) -> std::size_t;
 auto hash(const type_list& type) -> std::size_t;
 auto hash(const type_ptr& type) -> std::size_t;
+auto hash(const type_span& type) -> std::size_t;
 auto hash(const type_simple& type) -> std::size_t;
 
 auto i32_type() -> type_name;
@@ -91,6 +99,9 @@ auto is_list_type(const type_name& t) -> bool;
 
 auto concrete_ptr_type(const type_name& t) -> type_name;
 auto is_ptr_type(const type_name& t) -> bool;
+
+auto concrete_span_type(const type_name& t) -> type_name;
+auto is_span_type(const type_name& t) -> bool;
 
 // Extracts the single inner type of the given t. Undefined if the given t is not a compound
 // type with a single subtype.
@@ -120,6 +131,7 @@ auto to_string(const object& object) -> std::string;
 auto to_string(const type_name& type) -> std::string;
 auto to_string(const type_list& type) -> std::string;
 auto to_string(const type_ptr& type) -> std::string;
+auto to_string(const type_span& type) -> std::string;
 auto to_string(const type_simple& type) -> std::string;
 
 }

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -103,6 +103,8 @@ auto is_ptr_type(const type_name& t) -> bool;
 auto concrete_span_type(const type_name& t) -> type_name;
 auto is_span_type(const type_name& t) -> bool;
 
+auto size_of_ptr() -> std::size_t;
+
 // Extracts the single inner type of the given t. Undefined if the given t is not a compound
 // type with a single subtype.
 auto inner_type(const type_name& t) -> type_name;

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -271,13 +271,22 @@ auto parse_single_factor(tokenstream& tokens) -> node_expr_ptr
         }
         
         else {
+            const auto token = tokens.consume();
             auto new_node = std::make_shared<node_expr>();
-            auto& expr = new_node->emplace<node_subscript_expr>();
-            expr.token = tokens.consume();
-            expr.index = parse_expression(tokens);
-            tokens.consume_only(tk_rbracket);
-            expr.expr = std::move(node);
-            node = std::move(new_node);
+            if (tokens.peek(tk_rbracket)) {
+                auto& expr = new_node->emplace<node_span_expr>();
+                expr.token = token;
+                expr.expr = std::move(node);
+                node = std::move(new_node);
+                tokens.consume_only(tk_rbracket);
+            } else {
+                auto& expr = new_node->emplace<node_subscript_expr>();
+                expr.token = token;
+                expr.index = parse_expression(tokens);
+                expr.expr = std::move(node);
+                node = std::move(new_node);
+                tokens.consume_only(tk_rbracket);
+            }
         }
     }
 

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -324,11 +324,16 @@ auto parse_type(tokenstream& tokens) -> type_name
     }
     auto type = type_name{type_simple{.name=tokens.consume().text}};
     while (tokens.consume_maybe(tk_lbracket)) {
-        auto new_type = type_name{type_list{
-            .inner_type=type, .count=static_cast<std::size_t>(tokens.consume_i64())
-        }};
-        tokens.consume_only(tk_rbracket);
-        type = new_type;
+        if (tokens.consume_maybe(tk_rbracket)) {
+            auto new_type = type_name{type_span{ .inner_type=type }};
+            type = new_type;
+        } else {
+            auto new_type = type_name{type_list{
+                .inner_type=type, .count=static_cast<std::size_t>(tokens.consume_i64())
+            }};
+            type = new_type;
+            tokens.consume_only(tk_rbracket);
+        }
     }
     return type;
 }


### PR DESCRIPTION
* Adds the concept of a `span` to the language, inspired by C++20s `std::span`. Essentially it is a fat pointer; a pointer and a size.
* Syntax for a span is `i64[]`. Creating a span from an array is simple: if `arr` is an array, `arr[]` is a span over the array.
* The size can be retrieved by `arr.size()`.
* For loops are supported, but currently only for lvalue spans.
* Subscripting is supported for spans.
* Partially implemented `to_string` for `node_type`, still needs to be done for `typeof` expressions.
* The `.size()` function is hacked in currently; we need a better way of adding builtin member functions for primitive types.
* FUTURE PR: this will be used in the language more; `new` will return a span for arrays instead of a pointer, and pointer arithmetic can then be banned. It will also simplify the runtime since the bookkeeping won't need to be built in to the allocate op code.
* FUTURE PR: the ability to trim off the start and end with `.remove_prefix(count)` and `.remove_suffix(count)` functions.
* FUTURE PR: the ability to specify subspans of arrays with the syntax `arr[0..2]` for example.
* FUTURE PR: proper bounds checks on spans and arrays. This is an interpreted language so I don't mind about the performance hit of doing these checks at runtime, though maybe we can have some debug-only op codes in the future.
* FUTURE PR: the ability to create a span from another span.
* FUTURE PR: turn string literals into spans. Need `const` and static storage first. A cool way to do the static storage would be to turn the language into a true byte code and storing the code in the stack vector at the start.