### PR TITLE
Read-Only Memory

### DIFF
--- a/examples/feature_test.az
+++ b/examples/feature_test.az
@@ -1,4 +1,5 @@
 # tests all language features, here is a comment
+import stdlib.az;
 
 # declaring variables from literals
 {

--- a/examples/stdlib.az
+++ b/examples/stdlib.az
@@ -11,5 +11,3 @@ fn print(str: char[]) {
         print(*c);
     }
 }
-
-println("hello world");

--- a/examples/stdlib.az
+++ b/examples/stdlib.az
@@ -1,0 +1,13 @@
+
+fn println(str: char[]) {
+    for c in str {
+        print(*c);
+    }
+    print('\n');
+}
+
+fn print(str: char[]) {
+    for c in str {
+        print(*c);
+    }
+}

--- a/examples/stdlib.az
+++ b/examples/stdlib.az
@@ -11,3 +11,5 @@ fn print(str: char[]) {
         print(*c);
     }
 }
+
+println("hello world");

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,9 +1,6 @@
 
-x := [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
-y := x[];
+fn print_string(str: char[]) {
+    
+}
 
-p := y[2u];
-
-println(p);
-
-
+print_string("hello");

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,9 +1,3 @@
+import stdlib.az;
 
-fn print_string(str: char[]) {
-    for c in str {
-        print(*c);
-    }
-    println("");
-}
-
-print_string("hello");
+println("hello");

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,2 +1,1 @@
 import stdlib.az;
-println("hello world");

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,3 +1,2 @@
-
-x := "hello world";
-x[0u] = 'd';
+import stdlib.az;
+println("hello world");

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,8 +1,3 @@
 
-y := "hello there";
-x := "hello";
-
-size(2);
-
-t := [1, 2, 3];
-print(t[0u]); # this isn't working,
+x := "hello world";
+x[0u] = 'd';

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,6 +1,9 @@
 
 fn print_string(str: char[]) {
-    
+    for c in str {
+        print(*c);
+    }
+    println("");
 }
 
 print_string("hello");

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,1 +1,2 @@
 import stdlib.az;
+println("hello world");

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,3 +1,8 @@
-import stdlib.az;
 
-println("hello");
+y := "hello there";
+x := "hello";
+
+size(2);
+
+t := [1, 2, 3];
+print(t[0u]); # this isn't working,

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -672,7 +672,7 @@ auto insert_into_rom(compiler& com, const std::vector<std::byte>& data) -> std::
     if (index != std::string::npos) {
         return set_rom_bit(index);
     }
-    const auto ptr = set_rom_bit(com.read_only_data.size());
+    const auto ptr = com.read_only_data.size();
     for (const auto b : data) {
         com.read_only_data.push_back(b);
     }

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -141,10 +141,10 @@ using function_iter = typename function_param_map::const_iterator;
 // as well as information such as function definitions.
 struct compiler
 {
-    program program;
-    bool debug = false;
-
+    std::vector<op>   program;
     std::vector<char> read_only_data;
+
+    bool debug = false;
 
     // namespace (type_name) -> function_name -> signatures -> function_info
     std::unordered_map<type_name, function_map, type_name_hash> functions;
@@ -1313,7 +1313,7 @@ auto compile(
         }
     }
 
-    return com.program;
+    return { com.program, com.read_only_data };
 }
 
 }

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -649,17 +649,16 @@ auto push_expr_ptr(compiler& com, const node_expr& node) -> type_name
     return std::visit([&](const auto& expr) { return push_expr_ptr(com, expr); }, node);
 }
 
-auto to_string(const std::vector<std::byte>& vec) -> std::string
-{
-    auto ret = std::string{};
-    for (const auto b : vec) {
-        ret += static_cast<char>(b);
-    }
-    return ret;
-}
-
 auto subvector_find(const std::vector<std::byte>& sub, const std::vector<std::byte>& all) -> std::size_t
 {
+    const auto to_string = [](const std::vector<std::byte>& vec) {
+        auto ret = std::string{};
+        for (const auto b : vec) {
+            ret += static_cast<char>(b);
+        }
+        return ret;
+    };
+
     const auto substr = to_string(sub);
     const auto allstr = to_string(all);
     return allstr.find(substr);
@@ -1127,7 +1126,7 @@ void push_stmt(compiler& com, const node_assignment_stmt& node)
         node.token.assert_eq(lhs, rhs, "invalid assignment");
 
         // this is a hack for now until we have the concept of const. when we have const,
-        // we can make it part of the type system and make it a compile time error, 
+        // we can turn this into a compile time error
         com.program.emplace_back(op_assert_writable{}); // verify we can write to the pointer
 
         com.program.emplace_back(op_save{ .size=com.types.size_of(lhs) });

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -666,14 +666,14 @@ auto subvector_find(const std::vector<std::byte>& sub, const std::vector<std::by
 
 // Fetches the given literal from read only memory, or adds it if it is not there, and
 // returns the pointer.
-auto fetch_from_read_only(compiler& com, const node_literal_expr& node) -> std::size_t
+auto insert_into_rom(compiler& com, const std::vector<std::byte>& data) -> std::size_t
 {
-    const auto index = subvector_find(node.value.data, com.read_only_data);
+    const auto index = subvector_find(data, com.read_only_data);
     if (index != std::string::npos) {
         return set_rom_bit(index);
     }
     const auto ptr = set_rom_bit(com.read_only_data.size());
-    for (const auto b : node.value.data) {
+    for (const auto b : data) {
         com.read_only_data.push_back(b);
     }
     return set_rom_bit(ptr);
@@ -683,7 +683,7 @@ auto push_expr_val(compiler& com, const node_literal_expr& node) -> type_name
 {
     // Handle string literals differently; put them into read only memory
     if (is_list_type(node.value.type) && inner_type(node.value.type) == char_type()) {
-        const auto ptr = fetch_from_read_only(com, node);
+        const auto ptr = insert_into_rom(com, node.value.data);
 
         // Push the span onto the stack
         const auto ptr_bytes = as_bytes(ptr);

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -1125,10 +1125,6 @@ void push_stmt(compiler& com, const node_assignment_stmt& node)
         const auto lhs = push_expr_ptr(com, *node.position);
         node.token.assert_eq(lhs, rhs, "invalid assignment");
 
-        // this is a hack for now until we have the concept of const. when we have const,
-        // we can turn this into a compile time error
-        com.program.emplace_back(op_assert_writable{}); // verify we can write to the pointer
-
         com.program.emplace_back(op_save{ .size=com.types.size_of(lhs) });
         return;
     }
@@ -1145,7 +1141,6 @@ void push_stmt(compiler& com, const node_assignment_stmt& node)
             push_function_call_begin(com);
 
             push_expr_ptr(com, *node.position); // i-th element of dst
-            com.program.emplace_back(op_assert_writable{});
             push_ptr_adjust(com, i * inner_size);
             push_expr_ptr(com, *node.expr); // i-th element of src
             push_ptr_adjust(com, i * inner_size);
@@ -1163,7 +1158,6 @@ void push_stmt(compiler& com, const node_assignment_stmt& node)
 
     push_function_call_begin(com);
     push_expr_ptr(com, *node.position);
-    com.program.emplace_back(op_assert_writable{});
     push_expr_ptr(com, *node.expr);
     push_function_call(com, assign->ptr, params);
     pop_object(com, assign->return_type, node.token);

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -1105,6 +1105,7 @@ void push_stmt(compiler& com, const node_assignment_stmt& node)
             push_function_call_begin(com);
 
             push_expr_ptr(com, *node.position); // i-th element of dst
+            com.program.emplace_back(op_assert_writable{});
             push_ptr_adjust(com, i * inner_size);
             push_expr_ptr(com, *node.expr); // i-th element of src
             push_ptr_adjust(com, i * inner_size);
@@ -1122,6 +1123,7 @@ void push_stmt(compiler& com, const node_assignment_stmt& node)
 
     push_function_call_begin(com);
     push_expr_ptr(com, *node.position);
+    com.program.emplace_back(op_assert_writable{});
     push_expr_ptr(com, *node.expr);
     push_function_call(com, assign->ptr, params);
     pop_object(com, assign->return_type, node.token);

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -144,6 +144,8 @@ struct compiler
     program program;
     bool debug = false;
 
+    std::vector<char> read_only_data;
+
     // namespace (type_name) -> function_name -> signatures -> function_info
     std::unordered_map<type_name, function_map, type_name_hash> functions;
 
@@ -649,6 +651,10 @@ auto push_expr_ptr(compiler& com, const node_expr& node) -> type_name
 
 auto push_expr_val(compiler& com, const node_literal_expr& node) -> type_name
 {
+    // Handle string literals differently; put them into read only memory
+    if (is_list_type(node.value.type) && inner_type(node.value.type) == char_type()) {
+        print("String literal!\n");
+    }
     com.program.emplace_back(op_load_bytes{node.value.data});
     return node.value.type;
 }

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -1084,6 +1084,11 @@ void push_stmt(compiler& com, const node_assignment_stmt& node)
         const auto rhs = push_expr_val(com, *node.expr);
         const auto lhs = push_expr_ptr(com, *node.position);
         node.token.assert_eq(lhs, rhs, "invalid assignment");
+
+        // this is a hack for now until we have the concept of const. when we have const,
+        // we can make it part of the type system and make it a compile time error, 
+        com.program.emplace_back(op_assert_writable{}); // verify we can write to the pointer
+
         com.program.emplace_back(op_save{ .size=com.types.size_of(lhs) });
         return;
     }

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -150,67 +150,11 @@ static const auto builtins = construct_builtin_map();
 
 auto is_builtin(const std::string& name, const std::vector<type_name>& args) -> bool
 {
-    // Hack, generalise later
-    if ((name == "print" || name == "println") &&
-        args.size() == 1 &&
-        std::holds_alternative<type_list>(args[0]) &&
-        inner_type(args[0]) == char_type()
-    ) {
-        return true;
-    }
-    else if ((name == "print" || name == "println") &&
-        args.size() == 1 &&
-        std::holds_alternative<type_ptr>(args[0])
-    ) {
-        return true;
-    }
     return builtins.contains({name, args});
 }
 
 auto fetch_builtin(const std::string& name, const std::vector<type_name>& args) -> builtin_val
 {
-    // Hack, generalise later
-    if ((name == "print" || name == "println") &&
-        args.size() == 1 &&
-        std::holds_alternative<type_list>(args[0]) &&
-        inner_type(args[0]) == char_type()
-    ) {
-        const auto newline = name == "println";
-        const auto length = std::get<type_list>(args[0]).count;
-        return builtin_val{
-            .ptr = [=](std::vector<std::byte>& mem) -> void {
-                auto it = mem.end();
-                std::advance(it, -1 * length);
-                for (; it != mem.end(); ++it) {
-                    print("{}", static_cast<char>(*it));
-                }
-                if (newline) {
-                    print("\n");
-                }
-                pop_n(mem, length);
-                mem.push_back(std::byte{0}); // Return null
-            },
-            .return_type = null_type()
-        };
-    }
-    else if ((name == "print" || name == "println") &&
-        args.size() == 1 &&
-        std::holds_alternative<type_ptr>(args[0])
-    ) {
-        const auto newline = name == "println";
-        return builtin_val{
-            .ptr = [=](std::vector<std::byte>& mem) -> void {
-                const auto ptr = pop_value<std::uint64_t>(mem);
-                print("{}", ptr);
-                if (newline) {
-                    print("\n");
-                }
-                mem.push_back(std::byte{0}); // Return null
-            },
-            .return_type = null_type()
-        };
-    }
-
     auto it = builtins.find({name, args});
     if (it == builtins.end()) {
         anzu::print("builtin error: could not find function '{}({})'\n", name, format_comma_separated(args));

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -150,11 +150,37 @@ static const auto builtins = construct_builtin_map();
 
 auto is_builtin(const std::string& name, const std::vector<type_name>& args) -> bool
 {
+    // Hack, generalise later
+    if ((name == "print" || name == "println") &&
+        args.size() == 1 &&
+        std::holds_alternative<type_ptr>(args[0])
+    ) {
+        return true;
+    }
     return builtins.contains({name, args});
 }
 
 auto fetch_builtin(const std::string& name, const std::vector<type_name>& args) -> builtin_val
 {
+    // Hack, generalise later
+    if ((name == "print" || name == "println") &&
+        args.size() == 1 &&
+        std::holds_alternative<type_ptr>(args[0])
+    ) {
+        const auto newline = name == "println";
+        return builtin_val{
+            .ptr = [=](std::vector<std::byte>& mem) -> void {
+                const auto ptr = pop_value<std::uint64_t>(mem);
+                print("{}", ptr);
+                if (newline) {
+                    print("\n");
+                }
+                mem.push_back(std::byte{0}); // Return null
+            },
+            .return_type = null_type()
+        };
+    }
+
     auto it = builtins.find({name, args});
     if (it == builtins.end()) {
         anzu::print("builtin error: could not find function '{}({})'\n", name, format_comma_separated(args));

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -136,6 +136,18 @@ auto to_string(const type_ptr& type) -> std::string;
 auto to_string(const type_span& type) -> std::string;
 auto to_string(const type_simple& type) -> std::string;
 
+// Runtime pointer helpers to determine if the pointer is in stack, heap or read-only memory.
+static constexpr auto heap_bit = std::uint64_t{1} << 63;
+static constexpr auto rom_bit  = std::uint64_t{1} << 62;
+
+inline auto set_heap_bit(std::uint64_t x)   -> std::uint64_t { return x | heap_bit; }
+inline auto unset_heap_bit(std::uint64_t x) -> std::uint64_t { return x & ~heap_bit; }
+inline auto is_heap_ptr(std::uint64_t x)    -> bool          { return x & heap_bit; }
+ 
+inline auto set_rom_bit(std::uint64_t x)   -> std::uint64_t { return x | rom_bit; }
+inline auto unset_rom_bit(std::uint64_t x) -> std::uint64_t { return x & ~rom_bit; }
+inline auto is_rom_ptr(std::uint64_t x)    -> bool          { return x & rom_bit; }
+
 }
 
 template <> struct std::formatter<std::byte> : std::formatter<std::string> {

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -106,7 +106,7 @@ auto to_string(const op& op_code) -> std::string
 auto print_program(const anzu::program& program) -> void
 {
     int lineno = 0;
-    for (const auto& op : program) {
+    for (const auto& op : program.code) {
         anzu::print("{:>4} - {}\n", lineno++, op);
     }
 }

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -99,7 +99,6 @@ auto to_string(const op& op_code) -> std::string
         [](const op_builtin_call& op) { return std::format("BUILTIN_CALL({})", op.name); },
         [](const op_debug& op) { return std::format("DEBUG({})", op.message); },
         [](const op_assert& op) { return std::format("ASSERT({})", op.message); },
-        [](op_assert_writable) { return std::string{"ASSERT_WRITABLE"}; }
     }, op_code);
 }
 

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -91,7 +91,6 @@ auto to_string(const op& op_code) -> std::string
         [](op_jump op) { return std::format("JUMP({})", op.jump); },
         [](op_jump_if_false op) { return std::format("JUMP_IF_FALSE({})", op.jump); },
         [](op_return op) { return std::format("RETURN({})", op.size); },
-
         [](const op_function_call& op) {
             const auto func_str = std::format("FUNCTION_CALL");
             const auto jump_str = std::format("JUMP -> {}", op.ptr);
@@ -99,7 +98,8 @@ auto to_string(const op& op_code) -> std::string
         },
         [](const op_builtin_call& op) { return std::format("BUILTIN_CALL({})", op.name); },
         [](const op_debug& op) { return std::format("DEBUG({})", op.message); },
-        [](const op_assert& op) { return std::format("ASSERT({})", op.message); }
+        [](const op_assert& op) { return std::format("ASSERT({})", op.message); },
+        [](op_assert_writable) { return std::string{"ASSERT_WRITABLE"}; }
     }, op_code);
 }
 

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -107,8 +107,14 @@ auto print_program(const anzu::program& program) -> void
 {
     int lineno = 0;
     for (const auto& op : program.code) {
-        anzu::print("{:>4} - {}\n", lineno++, op);
+        print("{:>4} - {}\n", lineno++, op);
     }
+
+    print("ROM:\n");
+    for (const auto b : program.rom) {
+        print("{}", static_cast<char>(b));
+    }
+    print("\n");
 }
 
 }

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -159,12 +159,6 @@ struct op_assert
     std::string message;
 };
 
-// TODO: This is a temporary solution until we have const in the language, for now
-// we will make writing into read only memory a runtime error, when we have const then
-// read only memory can be of type const char[]
-struct op_assert_writable
-{};
-
 struct op : std::variant<
     op_load_bytes,
     op_push_global_addr,
@@ -243,7 +237,6 @@ struct op : std::variant<
     op_function_call,
     op_builtin_call,
     op_assert,
-    op_assert_writable,
     op_debug
 >
 {};

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -250,8 +250,8 @@ struct op : std::variant<
 
 struct program
 {
-    std::vector<op>   code;
-    std::vector<char> rom;
+    std::vector<op>        code;
+    std::vector<std::byte> rom;
 };
 
 auto to_string(const op& op_code) -> std::string;

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -241,7 +241,11 @@ struct op : std::variant<
 >
 {};
 
-using program = std::vector<op>;
+struct program
+{
+    std::vector<op>   code;
+    std::vector<char> rom;
+};
 
 auto to_string(const op& op_code) -> std::string;
 auto print_program(const anzu::program& program) -> void;

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -159,6 +159,12 @@ struct op_assert
     std::string message;
 };
 
+// TODO: This is a temporary solution until we have const in the language, for now
+// we will make writing into read only memory a runtime error, when we have const then
+// read only memory can be of type const char[]
+struct op_assert_writable
+{};
+
 struct op : std::variant<
     op_load_bytes,
     op_push_global_addr,
@@ -237,6 +243,7 @@ struct op : std::variant<
     op_function_call,
     op_builtin_call,
     op_assert,
+    op_assert_writable,
     op_debug
 >
 {};

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -229,6 +229,13 @@ auto apply_op(runtime_context& ctx, const op& op_code) -> void
             }
             ++ctx.prog_ptr;
         },
+        [&](op_assert_writable) {
+            const auto ptr = read_top<std::uint64_t>(ctx.stack);
+            if (is_rom_ptr(ptr)) {
+                runtime_error("cannot assign into read only memory");
+            }
+            ++ctx.prog_ptr;
+        }
     }, op_code);
 }
 

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -156,9 +156,7 @@ auto apply_op(runtime_context& ctx, const op& op_code) -> void
                 ctx.stack.resize(ctx.stack.size() - op.size);
             }
             else if (is_rom_ptr(ptr)) {
-                const auto rom_ptr = unset_rom_bit(ptr);
-                std::memcpy(&ctx.rom[rom_ptr], &ctx.stack[ctx.stack.size() - op.size], op.size);
-                ctx.stack.resize(ctx.stack.size() - op.size);
+                runtime_error("cannot assign into read only memory");
             }
             else {
                 runtime_assert(ptr + op.size <= ctx.stack.size(), "tried to access invalid memory address {}", ptr);
@@ -238,13 +236,6 @@ auto apply_op(runtime_context& ctx, const op& op_code) -> void
         [&](const op_assert& op) {
             if (!pop_value<bool>(ctx.stack)) {
                 runtime_error(op.message);
-            }
-            ++ctx.prog_ptr;
-        },
-        [&](op_assert_writable) {
-            const auto ptr = read_top<std::uint64_t>(ctx.stack);
-            if (is_rom_ptr(ptr)) {
-                runtime_error("cannot assign into read only memory");
             }
             ++ctx.prog_ptr;
         }

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -237,8 +237,8 @@ auto run_program(const anzu::program& program) -> void
     const auto timer = scope_timer{};
 
     runtime_context ctx;
-    while (ctx.prog_ptr < program.size()) {
-        apply_op(ctx, program[ctx.prog_ptr]);
+    while (ctx.prog_ptr < program.code.size()) {
+        apply_op(ctx, program.code[ctx.prog_ptr]);
     }
 
     if (ctx.allocator.bytes_allocated() > 0) {
@@ -251,10 +251,10 @@ auto run_program_debug(const anzu::program& program) -> void
     const auto timer = scope_timer{};
 
     runtime_context ctx;
-    while (ctx.prog_ptr < program.size()) {
-        const auto& op = program[ctx.prog_ptr];
+    while (ctx.prog_ptr < program.code.size()) {
+        const auto& op = program.code[ctx.prog_ptr];
         anzu::print("{:>4} - {}\n", ctx.prog_ptr, op);
-        apply_op(ctx, program[ctx.prog_ptr]);
+        apply_op(ctx, program.code[ctx.prog_ptr]);
         anzu::print("Stack: {}\n", format_comma_separated(ctx.stack));
         anzu::print("Heap: allocated={}\n", ctx.allocator.bytes_allocated());
     }

--- a/src/runtime.hpp
+++ b/src/runtime.hpp
@@ -14,6 +14,7 @@ struct runtime_context
 
     std::vector<std::byte> stack;
     std::vector<std::byte> heap;
+    std::vector<std::byte> rom;
 
     memory_allocator allocator;
 

--- a/src/utility/memory.hpp
+++ b/src/utility/memory.hpp
@@ -30,6 +30,14 @@ auto pop_value(std::vector<std::byte>& mem) -> T
 }
 
 template <typename T>
+auto read_top(std::vector<std::byte>& mem) -> T
+{
+    auto ret = T{};
+    std::memcpy(&ret, &mem[mem.size() - sizeof(T)], sizeof(T));
+    return ret;
+}
+
+template <typename T>
 auto write_value(std::vector<std::byte>& mem, std::size_t ptr, const T& value) -> void
 {
     std::memcpy(&mem[ptr], &value, sizeof(T));


### PR DESCRIPTION
* The compiler now also outputs an extra `std::vector<std::byte>` containing all string literals in the program.
* String literals in a program are now of type `char[]` and span over read only memory.
* Now able to remove the hacked in `print` and `println` builtin functions for printing strings, these are replaced by functions in the new `stdlib.az` which accept `char[]`. Implemented using the builtin functions for `char`.
* Currently, trying to write into read only memory results in a runtime error, but when we have `const` we can make this a compile time error.
* In the future, if we turn this into a true bytecode, the read only memory can exist within the program bytecode, for now this is a simpler solution.
* If a newly declared string literal is a substring of an existing literal, it will use the same memory and not create a copy in the read only memory.
* There is still some duplication, for example declaring "hello" then "hello world" will result in the rom looking like "hellohello world", we could potentially due an extra pass over all string literals first to reduce the size further, but it's unlikely to be worth it.