### PR TITLE
Fix Function Overloading

### DIFF
--- a/examples/feature_test.az
+++ b/examples/feature_test.az
@@ -127,7 +127,7 @@ fn println(v: vec2) -> null
     print(v.x);
     print(", ");
     print(v.y);
-    println("}");
+    println('}');
 }
 
 # Attribute access
@@ -247,3 +247,22 @@ fn typeof_example2(a: u64) -> typeof(a)
     return a * a;
 }
 println(typeof_example2(6u));
+
+
+
+# test destructors
+struct destructible
+{
+    val: i64;
+
+    fn drop(self: &destructible)
+    {
+        print("dropping ");
+        println(self->val);
+    }
+}
+
+{
+    a := destructible(1);
+    b := destructible(2);
+}

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,2 +1,1 @@
 import stdlib.az;
-println("hello world");


### PR DESCRIPTION
* Currently only one function is allowed per name by mistake since it clears the signature map in the compiler for that name when a new one is given. This removes that line allowing for the map to have multiple functions again.
* This fixes the error in `feature_test` where it couldn't find `println(char[])` despite the standard library being imported. This was because further down it implemented `println(vec2)` which deleted the `char[]` function pointer from the compiler.
* Refactors `call_destructor` to use visitation instead of the janky `is_*_type` which I want to move away from.
* Refactors `type_store::size_of` to use visitation at the top level, with the rest of the implementation moving into the case for `type_simple`.