### PR TITLE
Fixed Size Builtin Op Code

### DIFF
--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -820,7 +820,7 @@ auto push_expr_val(compiler& com, const node_call_expr& node) -> type_name
                 .id=b.value(),
                 .args_size=args_size
             });
-            return get_builtin_return_type(*b);
+            return get_builtin(*b).return_type;
         }
     }
 

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -815,15 +815,12 @@ auto push_expr_val(compiler& com, const node_call_expr& node) -> type_name
             args_size += com.types.size_of(param_types.back());
         }
 
-        if (is_builtin(inner.name, param_types)) {
-            const auto& builtin = fetch_builtin(inner.name, param_types);
-
+        if (const auto b = get_builtin_id(inner.name, param_types); b.has_value()) {
             com.program.emplace_back(op_builtin_call{
-                .name=inner.name,
-                .ptr=builtin.ptr,
+                .id=b.value(),
                 .args_size=args_size
             });
-            return builtin.return_type;
+            return get_builtin_return_type(*b);
         }
     }
 

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -144,148 +144,62 @@ auto builtin_fputs(runtime_context& ctx) -> void
 
 }
 
-auto construct_builtin_map() -> builtin_map
+auto construct_builtin_array() -> std::vector<builtin>
 {
-    auto builtins = builtin_map{};
-
-    builtins.emplace(
-        builtin_key{ .name = "sqrt", .args = { f64_type() } },
-        builtin_val{ .ptr = builtin_sqrt, .return_type = f64_type() }
-    );
-
-    builtins.emplace(
-        builtin_key{ .name = "print", .args = { u64_type() } },
-        builtin_val{ .ptr = builtin_print<std::uint64_t>, .return_type = null_type() }
-    );
-    builtins.emplace(
-        builtin_key{ .name = "println", .args = { u64_type() } },
-        builtin_val{ .ptr = builtin_println<std::uint64_t>, .return_type = null_type() }
-    );
-
-    builtins.emplace(
-        builtin_key{ .name = "print", .args = { char_type() } },
-        builtin_val{ .ptr = builtin_print<char>, .return_type = null_type() }
-    );
-    builtins.emplace(
-        builtin_key{ .name = "println", .args = { char_type() } },
-        builtin_val{ .ptr = builtin_println<char>, .return_type = null_type() }
-    );
-
-    builtins.emplace(
-        builtin_key{ .name = "print", .args = { f64_type() } },
-        builtin_val{ .ptr = builtin_print<double>, .return_type = null_type() }
-    );
-    builtins.emplace(
-        builtin_key{ .name = "println", .args = { f64_type() } },
-        builtin_val{ .ptr = builtin_println<double>, .return_type = null_type() }
-    );
-
-    builtins.emplace(
-        builtin_key{ .name = "print", .args = { bool_type() } },
-        builtin_val{ .ptr = builtin_print<bool>, .return_type = null_type() }
-    );
-    builtins.emplace(
-        builtin_key{ .name = "println", .args = { bool_type() } },
-        builtin_val{ .ptr = builtin_println<bool>, .return_type = null_type() }
-    );
-
-    builtins.emplace(
-        builtin_key{ .name = "print", .args = { null_type() } },
-        builtin_val{ .ptr = builtin_print<std::byte>, .return_type = null_type() }
-    );
-    builtins.emplace(
-        builtin_key{ .name = "println", .args = { null_type() } },
-        builtin_val{ .ptr = builtin_println<std::byte>, .return_type = null_type() }
-    );
-
-    builtins.emplace(
-        builtin_key{ .name = "print", .args = { i32_type() } },
-        builtin_val{ .ptr = builtin_print<std::int32_t>, .return_type = null_type() }
-    );
-    builtins.emplace(
-        builtin_key{ .name = "println", .args = { i32_type() } },
-        builtin_val{ .ptr = builtin_println<std::int32_t>, .return_type = null_type() }
-    );
-
-    builtins.emplace(
-        builtin_key{ .name = "print", .args = { i64_type() } },
-        builtin_val{ .ptr = builtin_print<std::int64_t>, .return_type = null_type() }
-    );
-    builtins.emplace(
-        builtin_key{ .name = "println", .args = { i64_type() } },
-        builtin_val{ .ptr = builtin_println<std::int64_t>, .return_type = null_type() }
-    );
-
     const auto char_span = concrete_span_type(char_type());
 
-    builtins.emplace(
-        builtin_key{ .name = "print", .args = { char_span } },
-        builtin_val{ .ptr = builtin_print_char_span, .return_type = null_type() }
-    );
-    builtins.emplace(
-        builtin_key{ .name = "println", .args = { char_span } },
-        builtin_val{ .ptr = builtin_println_char_span, .return_type = null_type() }
-    );
+    auto b = std::vector<builtin>{};
 
-    builtins.emplace(
-        builtin_key{ .name = "fopen", .args = { char_span, char_span }},
-        builtin_val{ .ptr = builtin_fopen, .return_type = u64_type() }
-    );
+    b.push_back(builtin{"sqrt", builtin_sqrt, {f64_type()}, f64_type()});
 
-    builtins.emplace(
-        builtin_key{ .name = "fclose", .args = { u64_type() }},
-        builtin_val{ .ptr = builtin_fclose, .return_type = null_type() }
-    );
+    b.push_back(builtin{"print", builtin_print<std::int32_t>,  {i32_type()},  null_type()});
+    b.push_back(builtin{"print", builtin_print<std::int64_t>,  {i64_type()},  null_type()});
+    b.push_back(builtin{"print", builtin_print<std::uint64_t>, {u64_type()},  null_type()});
+    b.push_back(builtin{"print", builtin_print<double>,        {f64_type()},  null_type()});
+    b.push_back(builtin{"print", builtin_print_char,           {char_type()}, null_type()});
+    b.push_back(builtin{"print", builtin_print_bool,           {bool_type()}, null_type()});
+    b.push_back(builtin{"print", builtin_print_null,           {null_type()}, null_type()});
+    b.push_back(builtin{"print", builtin_print_char_span,      {char_span},   null_type()});
 
-    builtins.emplace(
-        builtin_key{ .name = "fputs", .args = { u64_type(), char_span }},
-        builtin_val{ .ptr = builtin_fputs, .return_type = null_type() }
-    );
+    b.push_back(builtin{"println", builtin_println<std::int32_t>,  {i32_type()},  null_type()});
+    b.push_back(builtin{"println", builtin_println<std::int64_t>,  {i64_type()},  null_type()});
+    b.push_back(builtin{"println", builtin_println<std::uint64_t>, {u64_type()},  null_type()});
+    b.push_back(builtin{"println", builtin_println<double>,        {f64_type()},  null_type()});
+    b.push_back(builtin{"println", builtin_println_char,           {char_type()}, null_type()});
+    b.push_back(builtin{"println", builtin_println_bool,           {bool_type()}, null_type()});
+    b.push_back(builtin{"println", builtin_println_null,           {null_type()}, null_type()});
+    b.push_back(builtin{"println", builtin_println_char_span,      {char_span},   null_type()});
 
-    return builtins;
+    b.push_back(builtin{"fopen", builtin_fopen, {char_span, char_span}, u64_type()});
+    b.push_back(builtin{"fclose", builtin_fclose, {u64_type()}, null_type()});
+    b.push_back(builtin{"fputs", builtin_fputs, {u64_type(), char_span}, null_type()});
+
+    return b;
 }
 
-static const auto builtins = construct_builtin_map();
+static const auto builtins = construct_builtin_array();
 
-auto is_builtin(const std::string& name, const std::vector<type_name>& args) -> bool
+auto get_builtin_id(const std::string& name, const std::vector<type_name>& args)
+    -> std::optional<std::size_t>
 {
-    // Hack, generalise later
-    if ((name == "print" || name == "println") &&
-        args.size() == 1 &&
-        std::holds_alternative<type_ptr>(args[0])
-    ) {
-        return true;
+    auto index = std::size_t{0};
+    for (const auto& b : builtins) {
+        if (name == b.name && args == b.args) {
+            return index;
+        }
+        ++index;
     }
-    return builtins.contains({name, args});
+    return std::nullopt;
 }
 
-auto fetch_builtin(const std::string& name, const std::vector<type_name>& args) -> builtin_val
+auto get_builtin_return_type(std::size_t id) -> type_name
 {
-    // Hack, generalise later
-    if ((name == "print" || name == "println") &&
-        args.size() == 1 &&
-        std::holds_alternative<type_ptr>(args[0])
-    ) {
-        const auto newline = name == "println";
-        return builtin_val{
-            .ptr = [=](runtime_context& ctx) -> void {
-                const auto ptr = pop_value<std::uint64_t>(ctx.stack);
-                print("{}", ptr);
-                if (newline) {
-                    print("\n");
-                }
-                ctx.stack.push_back(std::byte{0}); // Return null
-            },
-            .return_type = null_type()
-        };
-    }
+    return builtins[id].return_type;
+}
 
-    auto it = builtins.find({name, args});
-    if (it == builtins.end()) {
-        anzu::print("builtin error: could not find function '{}({})'\n", name, format_comma_separated(args));
-        std::exit(1);
-    }
-    return it->second;
+auto get_builtin_function_ptr(std::size_t id) -> builtin_function
+{
+    return builtins[id].ptr;
 }
 
 }

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -192,14 +192,9 @@ auto get_builtin_id(const std::string& name, const std::vector<type_name>& args)
     return std::nullopt;
 }
 
-auto get_builtin_return_type(std::size_t id) -> type_name
+auto get_builtin(std::size_t id) -> const builtin&
 {
-    return builtins[id].return_type;
-}
-
-auto get_builtin_function_ptr(std::size_t id) -> builtin_function
-{
-    return builtins[id].ptr;
+    return builtins[id];
 }
 
 }

--- a/src/functions.hpp
+++ b/src/functions.hpp
@@ -23,7 +23,6 @@ struct builtin
 auto get_builtin_id(const std::string& name, const std::vector<type_name>& args)
     -> std::optional<std::size_t>;
 
-auto get_builtin_return_type(std::size_t id) -> type_name;
-auto get_builtin_function_ptr(std::size_t id) -> builtin_function;
+auto get_builtin(std::size_t id) -> const builtin&;
 
 }

--- a/src/functions.hpp
+++ b/src/functions.hpp
@@ -5,38 +5,25 @@
 #include <string>
 #include <vector>
 #include <span>
+#include <optional>
 
 namespace anzu {
 
 struct runtime_context;
 using builtin_function = std::function<void(runtime_context&)>;
 
-struct builtin_key
+struct builtin
 {
     std::string            name;
+    builtin_function       ptr;
     std::vector<type_name> args;
-    auto operator==(const builtin_key&) const -> bool = default;
+    type_name              return_type;
 };
 
-inline auto hash(const builtin_key& f) -> std::size_t
-{
-    auto hash_value = std::hash<std::string>{}(f.name);
-    for (const auto& arg : f.args) {
-        hash_value ^= hash(arg);
-    }
-    return hash_value;
-}
+auto get_builtin_id(const std::string& name, const std::vector<type_name>& args)
+    -> std::optional<std::size_t>;
 
-struct builtin_val
-{
-    builtin_function ptr;
-    type_name        return_type;
-};
+auto get_builtin_return_type(std::size_t id) -> type_name;
+auto get_builtin_function_ptr(std::size_t id) -> builtin_function;
 
-using builtin_hash = decltype([](const builtin_key& x) { return hash(x); });
-using builtin_map = std::unordered_map<builtin_key, builtin_val, builtin_hash>;
-
-auto is_builtin(const std::string& name, const std::vector<type_name>& args) -> bool;
-auto fetch_builtin(const std::string& name, const std::vector<type_name>& args) -> builtin_val;
-    
 }

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -102,7 +102,13 @@ auto to_string(const op& op_code) -> std::string
             return std::format(FORMAT2, func_str, jump_str);
         },
         [](op_call op) { return std::format("CALL({})", op.args_size); },
-        [](const op_builtin_call& op) { return std::format("BUILTIN_CALL()"); },
+        [](const op_builtin_call& op) {
+            const auto& b = get_builtin(op.id);
+            return std::format(
+                "BUILTIN_CALL({}({}) -> {})",
+                b.name, format_comma_separated(b.args), b.return_type
+            );
+        },
         [](const op_debug& op) { return std::format("DEBUG({})", op.message); },
         [](const op_assert& op) { return std::format("ASSERT({})", op.message); },
     }, op_code);

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -102,7 +102,7 @@ auto to_string(const op& op_code) -> std::string
             return std::format(FORMAT2, func_str, jump_str);
         },
         [](op_call op) { return std::format("CALL({})", op.args_size); },
-        [](const op_builtin_call& op) { return std::format("BUILTIN_CALL({})", op.name); },
+        [](const op_builtin_call& op) { return std::format("BUILTIN_CALL()"); },
         [](const op_debug& op) { return std::format("DEBUG({})", op.message); },
         [](const op_assert& op) { return std::format("ASSERT({})", op.message); },
     }, op_code);

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -114,9 +114,8 @@ struct op_call
 
 struct op_builtin_call
 {
-    std::string      name;
-    builtin_function ptr;
-    std::size_t      args_size;
+    std::size_t id;
+    std::size_t args_size;
 };
 
 struct op_return

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -199,7 +199,7 @@ auto apply_op(runtime_context& ctx, const op& op_code) -> void
             ctx.prog_ptr = ptr; // Jump into the function
         },
         [&](const op_builtin_call& op) {
-            get_builtin_function_ptr(op.id)(ctx);
+            get_builtin(op.id).ptr(ctx);
             ++ctx.prog_ptr;
         },
         [&](const op_debug& op) {

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -1,5 +1,6 @@
 #include "runtime.hpp"
 #include "object.hpp"
+#include "functions.hpp"
 #include "utility/print.hpp"
 #include "utility/overloaded.hpp"
 #include "utility/scope_timer.hpp"
@@ -198,7 +199,7 @@ auto apply_op(runtime_context& ctx, const op& op_code) -> void
             ctx.prog_ptr = ptr; // Jump into the function
         },
         [&](const op_builtin_call& op) {
-            op.ptr(ctx);
+            get_builtin_function_ptr(op.id)(ctx);
             ++ctx.prog_ptr;
         },
         [&](const op_debug& op) {


### PR DESCRIPTION
* `op_builtin_call` now stores an id to lookup the builtin function at runtime, meaning it is now trivial to turn into bytecode.
* The builtin map has been replaced by a builtin array.
* Printing builtin op codes now shows the signature of the function as well as just the name.
* Removed the ability to print pointers since it was hacked into the builtins system. We should implement this properly with untyped points and casting if we really want it.