### PR TITLE
Move Assert Messages into ROM

### DIFF
--- a/examples/test.az
+++ b/examples/test.az
@@ -1,5 +1,4 @@
 
 
-for p in [1, 2, 3] {
-    println(*p);
-}
+x := [1, 2, 3];
+println(x[5u]);

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,1 +1,5 @@
-x := "hello";
+
+
+for p in [1, 2, 3] {
+    println(*p);
+}

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -473,7 +473,6 @@ auto destruct_on_break_or_continue(compiler& com) -> void
     for (const auto& scope : current_vars(com).scopes() | std::views::reverse) {
         for (const auto& [name, info] : scope.vars | std::views::reverse) {
             call_destructor_named_var(com, name, info.type);
-            com.program.emplace_back(op_debug{std::format("destructing {}", name)});
         }
         if (scope.type == var_scope::scope_type::loop) {
             return;

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -565,6 +565,25 @@ auto type_of_expr(compiler& com, const node_expr& node) -> type_name
     return type;
 }
 
+// Fetches the given literal from read only memory, or adds it if it is not there, and
+// returns the pointer.
+auto insert_into_rom(compiler& com, std::string_view data) -> std::size_t
+{
+    const auto index = com.read_only_data.find(data);
+    if (index != std::string::npos) {
+        return set_rom_bit(index);
+    }
+    const auto ptr = com.read_only_data.size();
+    com.read_only_data.append(data);
+    return set_rom_bit(ptr);
+}
+
+auto push_assert(compiler& com, std::string_view message) -> void
+{
+    const auto index = unset_rom_bit(insert_into_rom(com, message));
+    com.program.emplace_back(op_assert{ .index=index, .size=message.size() });
+}
+
 auto push_expr_ptr(compiler& com, const node_name_expr& node) -> type_name
 {
     auto& global_fns = com.functions[global_namespace];
@@ -647,7 +666,7 @@ auto push_expr_ptr(compiler& com, const node_subscript_expr& expr) -> type_name
             com.program.emplace_back(op_load{ .size = com.types.size_of(u64_type()) }); // load the size
         }
         com.program.emplace_back(op_u64_lt{});
-        com.program.emplace_back(op_assert{"index out of range"});
+        push_assert(com, "index out of range");
     }
 
     // Offset pointer by (index * size)
@@ -668,19 +687,6 @@ auto push_expr_ptr(compiler& com, const node_subscript_expr& expr) -> type_name
 auto push_expr_ptr(compiler& com, const node_expr& node) -> type_name
 {
     return std::visit([&](const auto& expr) { return push_expr_ptr(com, expr); }, node);
-}
-
-// Fetches the given literal from read only memory, or adds it if it is not there, and
-// returns the pointer.
-auto insert_into_rom(compiler& com, const std::string& data) -> std::size_t
-{
-    const auto index = com.read_only_data.find(data);
-    if (index != std::string::npos) {
-        return set_rom_bit(index);
-    }
-    const auto ptr = com.read_only_data.size();
-    com.read_only_data.append(data);
-    return set_rom_bit(ptr);
 }
 
 auto push_expr_val(compiler& com, const node_literal_i32_expr& node) -> type_name
@@ -903,12 +909,12 @@ auto push_expr_val(compiler& com, const node_span_expr& node) -> type_name
         node.token.assert_eq(lower_bound_type, u64_type(), "subspan indices must be u64");
         node.token.assert_eq(upper_bound_type, u64_type(), "subspan indices must be u64");
         com.program.emplace_back(op_u64_lt{});
-        com.program.emplace_back(op_assert{"lower bound must be stricly less than the upper bound"});
+        push_assert(com, "lower bound must be stricly less than the upper bound");
 
         push_expr_val(com, *node.upper_bound);
         com.program.emplace_back(op_push_literal_u64{array_length(expr_type)});
         com.program.emplace_back(op_u64_lt{});
-        com.program.emplace_back(op_assert{"upper bound must be strictly less than the array size"});
+        push_assert(com, "upper bound must be strictly less than the array size");
     }
 
     push_expr_ptr(com, *node.expr);
@@ -1352,8 +1358,7 @@ void push_stmt(compiler& com, const node_assert_stmt& node)
 
     if (com.debug) {
         push_expr_val(com, *node.expr);
-        const auto message = std::format("line {}", node.token.line);
-        com.program.emplace_back(op_assert{message});
+        push_assert(com, std::format("line {}", node.token.line));
     }
 }
 

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -109,7 +109,7 @@ auto to_string(const op& op_code) -> std::string
                 b.name, format_comma_separated(b.args), b.return_type
             );
         },
-        [](const op_assert& op) { return std::format("ASSERT({})", op.message); },
+        [](const op_assert& op) { return std::string{"ASSERT"}; },
     }, op_code);
 }
 

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -109,7 +109,6 @@ auto to_string(const op& op_code) -> std::string
                 b.name, format_comma_separated(b.args), b.return_type
             );
         },
-        [](const op_debug& op) { return std::format("DEBUG({})", op.message); },
         [](const op_assert& op) { return std::format("ASSERT({})", op.message); },
     }, op_code);
 }

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -123,11 +123,6 @@ struct op_return
     std::size_t size;
 };
 
-struct op_debug
-{
-    std::string message;
-};
-
 struct op_assert
 {
     std::string message;
@@ -218,7 +213,6 @@ struct op : std::variant<
     op_call,
     op_builtin_call,
     op_assert,
-    op_debug,
 
     op_char_eq,
     op_char_ne,

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -125,7 +125,9 @@ struct op_return
 
 struct op_assert
 {
-    std::string message;
+    // Describes a position in read only memory
+    std::size_t index;
+    std::size_t size;
 };
 
 struct op_char_eq {};

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -202,10 +202,6 @@ auto apply_op(runtime_context& ctx, const op& op_code) -> void
             get_builtin(op.id).ptr(ctx);
             ++ctx.prog_ptr;
         },
-        [&](const op_debug& op) {
-            print(op.message);
-            ++ctx.prog_ptr;
-        },
         [&](const op_assert& op) {
             if (!pop_value<bool>(ctx.stack)) {
                 runtime_error(op.message);

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -204,7 +204,11 @@ auto apply_op(runtime_context& ctx, const op& op_code) -> void
         },
         [&](const op_assert& op) {
             if (!pop_value<bool>(ctx.stack)) {
-                runtime_error(op.message);
+                const auto m = std::string_view(
+                    reinterpret_cast<const char*>(&ctx.rom[op.index]),
+                    op.size
+                );
+                runtime_error(m);
             }
             ++ctx.prog_ptr;
         },


### PR DESCRIPTION
* `op_assert` messages are now stored in read only memory, reducing a lot of potentially duplicated messages in the op codes. Also makes the op code a known size.
* It is now possible to convert to a true bytecode; all op codes only are trivial structs.