### PR TITLE
Call Frame Op Code

### DIFF
--- a/examples/test.az
+++ b/examples/test.az
@@ -1,4 +1,16 @@
 
-x := '\n';
+fn print_name(name: char[])
+{
+    println(name);
+}
 
-print(x);
+fn do_twice(
+    func: (char[]) -> null,
+    input: char[]
+)
+{
+    func(input);
+    func(input);
+}
+
+do_twice(print_name, "hello");

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,13 +1,4 @@
-import std/string.az;
 
-str1 := new_string();
+x := '\n';
 
-str1.append("hello ");
-str1.append("world");
-
-str2 := str1;
-str2.append(" abc");
-str2.set("this is a replacement string");
-
-println(str1.get());
-println(str2.get());
+print(x);

--- a/src/bytecode.cpp
+++ b/src/bytecode.cpp
@@ -95,6 +95,10 @@ auto apply_op(const bytecode_program& prog, bytecode_context& ctx) -> void
             const auto offset = read<std::uint64_t>(prog, ctx.prog_ptr);
             push_value(ctx.stack, ctx.base_ptr + offset);
         } break;
+        case op::push_literal_call_frame: {
+            push_value(ctx.stack, std::uint64_t{0});
+            push_value(ctx.stack, std::uint64_t{0});
+        } break;
         case op::load: {
             const auto size = read<std::uint64_t>(prog, ctx.prog_ptr);
 
@@ -339,6 +343,9 @@ auto print_op(const bytecode_program& prog, std::size_t ptr) -> std::size_t
             const auto offset = read<std::uint64_t>(prog, ptr);
             print("PUSH_LITERAL_PTR_REL: base_ptr + {}\n", offset);
         } break;
+        case op::push_literal_call_frame: {
+            print("PUSH_CALL_FRAME\n");
+        } break;
         case op::load: {
             const auto size = read<std::uint64_t>(prog, ptr);
             print("LOAD: {}\n", size);
@@ -382,11 +389,11 @@ auto print_op(const bytecode_program& prog, std::size_t ptr) -> std::size_t
         case op::function_call: {
             const auto func_ptr = read<std::uint64_t>(prog, ptr);
             const auto args_size = read<std::uint64_t>(prog, ptr);
-            print("FUNCTION_CALL: func_ptr={} args_size={}\n", func_ptr, args_size - 2 * sizeof(std::uint64_t));
+            print("FUNCTION_CALL: func_ptr={} args_size={}\n", func_ptr, args_size);
         } break;
         case op::call: {
             const auto args_size = read<std::uint64_t>(prog, ptr);
-            print("RETURN: args_size={}\n", args_size);
+            print("CALL: args_size={}\n", args_size);
         } break;
         case op::builtin_call: {
             const auto id = read<std::uint64_t>(prog, ptr);

--- a/src/bytecode.cpp
+++ b/src/bytecode.cpp
@@ -344,7 +344,7 @@ auto print_op(const bytecode_program& prog, std::size_t ptr) -> std::size_t
             print("PUSH_LITERAL_PTR_REL: base_ptr + {}\n", offset);
         } break;
         case op::push_literal_call_frame: {
-            print("PUSH_CALL_FRAME\n");
+            print("PUSH_LITERAL_CALL_FRAME (16 bytes)\n");
         } break;
         case op::load: {
             const auto size = read<std::uint64_t>(prog, ptr);

--- a/src/bytecode.hpp
+++ b/src/bytecode.hpp
@@ -18,6 +18,8 @@ enum class op : std::uint8_t
 
     push_literal_ptr,
     push_literal_ptr_rel,
+    push_literal_call_frame,
+    
     load,
     save,
     pop,

--- a/src/bytecode.hpp
+++ b/src/bytecode.hpp
@@ -16,8 +16,8 @@ enum class op : std::uint8_t
     push_literal_bool,
     push_literal_null,
 
-    push_global_addr,
-    push_local_addr,
+    push_literal_ptr,
+    push_literal_ptr_rel,
     load,
     save,
     pop,

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -251,12 +251,6 @@ auto get_function(
     return std::nullopt;
 }
 
-auto push_function_call_begin(compiler& com) -> void
-{
-    push_value(com.program, op::push_literal_u64, std::uint64_t{0}); // base ptr
-    push_value(com.program, op::push_literal_u64, std::uint64_t{0}); // prog ptr
-}
-
 auto push_function_call(compiler& com, std::size_t ptr, const std::vector<type_name>& params) -> void
 {
     auto args_size = 2 * sizeof(std::uint64_t);
@@ -412,7 +406,7 @@ auto call_destructor(compiler& com, const type_name& type, compile_obj_ptr_cb pu
             const auto params = drop_fn_params(type);
             if (const auto func = get_function(com, type, "drop", params); func) {
                 // Push the args to the stack
-                push_function_call_begin(com);
+                push_value(com.program, op::push_literal_call_frame);
                 push_object_ptr(func->tok);
                 push_function_call(com, func->ptr, params);
                 push_value(com.program, op::pop, com.types.size_of(func->return_type));
@@ -434,7 +428,7 @@ auto call_destructor(compiler& com, const type_name& type, compile_obj_ptr_cb pu
             if (const auto drop = get_function(com, *list_type.inner_type, "drop", params)) {
                 for (std::size_t i = array_length(type); i != 0;) {
                     --i;
-                    push_function_call_begin(com);
+                    push_value(com.program, op::push_literal_call_frame);
                     push_object_ptr(drop->tok);
                     push_ptr_adjust(com, i * inner_size);
                     push_function_call(com, drop->ptr, params);
@@ -528,7 +522,7 @@ auto push_object_copy(compiler& com, const node_expr& expr, const token& tok) ->
         tok.assert(copy.has_value(), "{} cannot be copied", etype);
 
         for (std::size_t i = 0; i != array_length(type); ++i) {
-            push_function_call_begin(com);
+            push_value(com.program, op::push_literal_call_frame);
             push_expr_ptr(com, expr);
             push_ptr_adjust(com, i * inner_size);
             push_function_call(com, copy->ptr, params);
@@ -540,7 +534,7 @@ auto push_object_copy(compiler& com, const node_expr& expr, const token& tok) ->
         const auto copy = get_function(com, type, "copy", params);
         tok.assert(copy.has_value(), "{} cannot be copied", type);
 
-        push_function_call_begin(com);
+        push_value(com.program, op::push_literal_call_frame);
         push_expr_ptr(com, expr);
         push_function_call(com, copy->ptr, params);
     }
@@ -862,7 +856,7 @@ auto push_expr_val(compiler& com, const node_call_expr& node) -> type_name
         
         const auto struct_type = resolve_type(com, node.token, inner.struct_name);
         if (const auto func = get_function(com, struct_type, inner.name, params); func) {
-            push_function_call_begin(com);
+            push_value(com.program, op::push_literal_call_frame);
             for (const auto& arg : node.args) {
                 push_object_copy(com, *arg, node.token);
             }
@@ -887,13 +881,14 @@ auto push_expr_val(compiler& com, const node_call_expr& node) -> type_name
 
         // Fourth, it might be a builtin function
         auto param_types = std::vector<type_name>{};
-        auto args_size = std::size_t{0};
         for (const auto& arg : node.args) {
-            param_types.emplace_back(push_object_copy(com, *arg, node.token));
-            args_size += com.types.size_of(param_types.back());
+            param_types.emplace_back(type_of_expr(com, *arg));
         }
 
         if (const auto b = get_builtin_id(inner.name, param_types); b.has_value()) {
+            for (const auto& arg : node.args) {
+                push_object_copy(com, *arg, node.token);
+            }
             push_value(com.program, op::builtin_call, *b);
             return get_builtin(*b).return_type;
         }
@@ -908,7 +903,7 @@ auto push_expr_val(compiler& com, const node_call_expr& node) -> type_name
 
     const auto& sig = std::get<type_function_ptr>(type);
 
-    push_function_call_begin(com);
+    push_value(com.program, op::push_literal_call_frame);
     auto actual_types = std::vector<type_name>{};
     for (const auto& arg : node.args) {
         const auto type = push_object_copy(com, *arg, node.token);
@@ -1296,7 +1291,7 @@ void push_stmt(compiler& com, const node_assignment_stmt& node)
         node.token.assert(assign.has_value(), "{} cannot be assigned", etype);
 
         for (std::size_t i = 0; i != array_length(rhs); ++i) {
-            push_function_call_begin(com);
+            push_value(com.program, op::push_literal_call_frame);
 
             push_expr_ptr(com, *node.position); // i-th element of dst
             push_ptr_adjust(com, i * inner_size);
@@ -1314,7 +1309,7 @@ void push_stmt(compiler& com, const node_assignment_stmt& node)
     const auto assign = get_function(com, rhs, "assign", params);
     node.token.assert(assign.has_value(), "{} cannot be assigned", rhs);
 
-    push_function_call_begin(com);
+    push_value(com.program, op::push_literal_call_frame);
     push_expr_ptr(com, *node.position);
     push_expr_ptr(com, *node.expr);
     push_function_call(com, assign->ptr, params);

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -280,14 +280,14 @@ auto push_var_addr(compiler& com, const token& tok, const std::string& name) -> 
     if (com.current_func) {
         auto& locals = com.current_func->vars;
         if (const auto info = locals.find(name); info.has_value()) {
-            push_value(com.program, op::push_local_addr, info->location);
+            push_value(com.program, op::push_literal_ptr_rel, info->location);
             return info->type;
         }
     }
 
     auto& globals = com.globals;
     if (const auto info = globals.find(name); info.has_value()) {
-        push_value(com.program, op::push_global_addr, info->location);
+        push_value(com.program, op::push_literal_ptr, info->location);
         return info->type;
     }
 
@@ -504,7 +504,7 @@ auto pop_object(compiler& com, const type_name& type, const token& tok) -> void
     call_destructor(com, type, [&](const token&) {
         // Because the variable has not been delcared, the stack pointer has not
         // incremented, so it is currently pointing to our temp value.
-        push_value(com.program, op::push_local_addr, object_ptr);
+        push_value(com.program, op::push_literal_ptr_rel, object_ptr);
     });
     push_value(com.program, op::pop, com.types.size_of(type));
 }

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -896,10 +896,7 @@ auto push_expr_val(compiler& com, const node_call_expr& node) -> type_name
 
     // Otherwise, the expression must be a function pointer.
     const auto type = type_of_expr(com, *node.expr);
-    node.token.assert(
-        is_function_ptr_type(type),
-        "unable to call non-callable type {}", type
-    );
+    node.token.assert(is_function_ptr_type(type), "unable to call non-callable type {}", type);
 
     const auto& sig = std::get<type_function_ptr>(type);
 

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -714,7 +714,7 @@ auto push_expr_val(compiler& com, const node_literal_char_expr& node) -> type_na
 auto push_expr_val(compiler& com, const node_literal_string_expr& node) -> type_name
 {
     // Push the span onto the stack
-    push_value(com.program, op::push_literal_u64, insert_into_rom(com, node.value));
+    push_value(com.program, op::push_literal_ptr, insert_into_rom(com, node.value));
     push_value(com.program, op::push_literal_u64, node.value.size());
     return concrete_span_type(char_type());
 }

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -214,7 +214,7 @@ auto make_char(lex_context& ctx) -> token
 {
     const auto tok = make_literal(ctx, '\'', token_type::character);
     if (const auto size = tok.text.size(); size != 1) {
-        lexer_error(ctx.line, ctx.col, "Char literal is not one character! Got {} ({})", size);
+        lexer_error(ctx.line, ctx.col, "Char literal is not one character! Got '{}' ({})", tok.text, size);
     }
     return tok;
 }


### PR DESCRIPTION
* Added `push_literal_call_frame` which pushes two `u64`s onto the stack, replacing the two `push_literal_u64` for each function call. Makes it easier to see where function calls start.
* Renamed `push_global_addr` to `push_literal_ptr`.
* Renamed `push_local_addr` to `push_literal_ptr_rel`.
* Fixed a bug when calling function pointers. When we have a named variable containing a function pointer, it would first try and check to see if its the name of a builtin, but in doing so would push object copies to the stack, and would leave them there before moving onto loading everything for the ptr call. Now, we only evaluate the types to get the signature for the builtin check, with no extra stuff pushed to the stack. This was spotted when switching to the call frame op code, because we started crashing, which I still can't quite explain. Regardless, it appears to work now.
* Fixed a dodgy call to `lexer_error` where we didn't push enough values for the format string.