### PR TITLE
String Literal Op Code

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,7 @@
             "program": "${workspaceFolder}/build/src/Debug/anzu.exe",
             "args": [
                 "${workspaceFolder}/examples/test.az",
-                "run"
+                "com"
             ],
             "stopAtEntry": false,
             "cwd": "${fileDirname}",

--- a/examples/std/string.az
+++ b/examples/std/string.az
@@ -55,6 +55,14 @@ struct string
         self->append(value);
     }
 
+    fn transform(self: &string, func: (&char) -> null)
+    {
+        span := self->get();
+        for c in span {
+            func(c);
+        }
+    }
+
     # SPECIAL MEMBER FUNCTIONS
 
     fn drop(self: &string)

--- a/examples/std/string.az
+++ b/examples/std/string.az
@@ -101,3 +101,10 @@ fn new_string() -> string
     # We don't have nullptr yet, so we must allocate some space here for now
     return string(new char : 1u, 0u);
 }
+
+fn new_string(data: char[]) -> string
+{
+    str := new_string();
+    str.append(data);
+    return str;
+}

--- a/examples/std/string.az
+++ b/examples/std/string.az
@@ -55,14 +55,6 @@ struct string
         self->append(value);
     }
 
-    fn transform(self: &string, func: (&char) -> null)
-    {
-        span := self->get();
-        for c in span {
-            func(c);
-        }
-    }
-
     # SPECIAL MEMBER FUNCTIONS
 
     fn drop(self: &string)

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,23 +1,4 @@
 import std/string.az;
 
-fn replace_a(c: &char)
-{
-    if (*c == 'a') {
-        *c = 'X';
-    }
-}
-
-fn transform_string(s: &string, func: (&char) -> null)
-{
-    span := s->get();
-    for c in span {
-        func(c);
-    }
-}
-
-str := new_string();
-str.append("this is a temporary string for testing");
+str := new_string("hello world");
 println(str.get());
-
-msg := "HERE WE ARE";
-println(msg);

--- a/examples/test.az
+++ b/examples/test.az
@@ -16,7 +16,8 @@ fn transform_string(s: &string, func: (&char) -> null)
 }
 
 str := new_string();
-str.set("this is a temporary string for testing");
-transform_string(&str, replace_a);
+str.append("this is a temporary string for testing");
+println(str.get());
 
-"HERE WE ARE";
+msg := "HERE WE ARE";
+println(msg);

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,16 +1,22 @@
+import std/string.az;
 
-fn print_name(name: char[])
+fn replace_a(c: &char)
 {
-    println(name);
+    if (*c == 'a') {
+        *c = 'X';
+    }
 }
 
-fn do_twice(
-    func: (char[]) -> null,
-    input: char[]
-)
+fn transform_string(s: &string, func: (&char) -> null)
 {
-    func(input);
-    func(input);
+    span := s->get();
+    for c in span {
+        func(c);
+    }
 }
 
-do_twice(print_name, "hello");
+str := new_string();
+str.set("this is a temporary string for testing");
+transform_string(&str, replace_a);
+
+"HERE WE ARE";

--- a/src/bytecode.cpp
+++ b/src/bytecode.cpp
@@ -333,7 +333,7 @@ auto print_op(const bytecode_program& prog, std::size_t ptr) -> std::size_t
             print("PUSH_LITERAL_NULL\n");
         } break;
         case op::push_literal_string: {
-            const auto index = read<std::uint64_t>(prog, ptr);
+            const auto index = unset_rom_bit(read<std::uint64_t>(prog, ptr));
             const auto size = read<std::uint64_t>(prog, ptr);
             const auto m = std::string_view( // UB?
                 reinterpret_cast<const char*>(&prog.rom[index]), size

--- a/src/bytecode.cpp
+++ b/src/bytecode.cpp
@@ -71,36 +71,36 @@ auto apply_op(const bytecode_program& prog, bytecode_context& ctx) -> void
 {
     const auto op_code = static_cast<op>(prog.code[ctx.prog_ptr++]);
     switch (op_code) {
-        case op::push_literal_i32: {
+        case op::push_i32: {
             for (std::size_t i = 0; i != 4; ++i) {
                 ctx.stack.push_back(prog.code[ctx.prog_ptr++]);
             }
         } break;
-        case op::push_literal_i64:
-        case op::push_literal_u64:
-        case op::push_literal_f64:
-        case op::push_literal_ptr: {
+        case op::push_i64:
+        case op::push_u64:
+        case op::push_f64:
+        case op::push_ptr: {
             for (std::size_t i = 0; i != 8; ++i) {
                 ctx.stack.push_back(prog.code[ctx.prog_ptr++]);
             }
         } break;
-        case op::push_literal_char:
-        case op::push_literal_bool: {
+        case op::push_char:
+        case op::push_bool: {
             ctx.stack.push_back(prog.code[ctx.prog_ptr++]);
         } break;
-        case op::push_literal_null: {
+        case op::push_null: {
             push_value(ctx.stack, std::byte{0});
         } break;
-        case op::push_literal_string: {
+        case op::push_string_literal: {
             for (std::size_t i = 0; i != 16; ++i) {
                 ctx.stack.push_back(prog.code[ctx.prog_ptr++]);
             }
         } break;
-        case op::push_literal_ptr_rel: {
+        case op::push_ptr_rel: {
             const auto offset = read<std::uint64_t>(prog, ctx.prog_ptr);
             push_value(ctx.stack, ctx.base_ptr + offset);
         } break;
-        case op::push_literal_call_frame: {
+        case op::push_call_frame: {
             push_value(ctx.stack, std::uint64_t{0});
             push_value(ctx.stack, std::uint64_t{0});
         } break;
@@ -305,59 +305,59 @@ auto print_op(const bytecode_program& prog, std::size_t ptr) -> std::size_t
     switch (op_code) {
         // TODO: Pushing literals can just be memcpy's without casting, because we're
         // going from bytes to bytes
-        case op::push_literal_i32: {
+        case op::push_i32: {
             const auto value = read<std::int32_t>(prog, ptr);
-            print("PUSH_LITERAL_I32: {}\n", value);
+            print("PUSH_I32: {}\n", value);
         } break;
-        case op::push_literal_i64: {
+        case op::push_i64: {
             const auto value = read<std::int64_t>(prog, ptr);
-            print("PUSH_LITERAL_I64: {}\n", value);
+            print("PUSH_I64: {}\n", value);
         } break;
-        case op::push_literal_u64: {
+        case op::push_u64: {
             const auto value = read<std::uint64_t>(prog, ptr);
-            print("PUSH_LITERAL_U64: {}\n", value);
+            print("PUSH_U64: {}\n", value);
         } break;
-        case op::push_literal_f64: {
+        case op::push_f64: {
             const auto value = read<double>(prog, ptr);
-            print("PUSH_LITERAL_F64: {}\n", value);
+            print("PUSH_F64: {}\n", value);
         } break;
-        case op::push_literal_char: {
+        case op::push_char: {
             const auto value = read<char>(prog, ptr);
-            print("PUSH_LITERAL_CHAR: {}\n", value);
+            print("PUSH_CHAR: {}\n", value);
         } break;
-        case op::push_literal_bool: {
+        case op::push_bool: {
             const auto value = read<bool>(prog, ptr);
-            print("PUSH_LITERAL_BOOL: {}\n", value);
+            print("PUSH_BOOL: {}\n", value);
         } break;
-        case op::push_literal_null: {
-            print("PUSH_LITERAL_NULL\n");
+        case op::push_null: {
+            print("PUSH_NULL\n");
         } break;
-        case op::push_literal_string: {
+        case op::push_string_literal: {
             const auto index = unset_rom_bit(read<std::uint64_t>(prog, ptr));
             const auto size = read<std::uint64_t>(prog, ptr);
             const auto m = std::string_view( // UB?
                 reinterpret_cast<const char*>(&prog.rom[index]), size
             );
-            print("PUSH_LITERAL_STRING: '{}'\n", m);
+            print("PUSH_STRING_LITERAL: '{}'\n", m);
         } break;
-        case op::push_literal_ptr: {
+        case op::push_ptr: {
             const auto pos = read<std::uint64_t>(prog, ptr);
             if (is_heap_ptr(pos)) {
-                print("PUSH_LITERAL_PTR: {} (HEAP)\n", unset_heap_bit(pos));
+                print("PUSH_PTR: {} (HEAP)\n", unset_heap_bit(pos));
             }
             else if (is_rom_ptr(pos)) {
-                print("PUSH_LITERAL_PTR: {} (ROM)\n", unset_rom_bit(pos));
+                print("PUSH_PTR: {} (ROM)\n", unset_rom_bit(pos));
             }
             else {
-                print("PUSH_LITERAL_PTR: {} (STACK)\n", pos);
+                print("PUSH_PTR: {} (STACK)\n", pos);
             }
         } break;
-        case op::push_literal_ptr_rel: {
+        case op::push_ptr_rel: {
             const auto offset = read<std::uint64_t>(prog, ptr);
-            print("PUSH_LITERAL_PTR_REL: base_ptr + {}\n", offset);
+            print("PUSH_PTR_REL: base_ptr + {}\n", offset);
         } break;
-        case op::push_literal_call_frame: {
-            print("PUSH_LITERAL_CALL_FRAME (16 bytes)\n");
+        case op::push_call_frame: {
+            print("PUSH_CALL_FRAME\n");
         } break;
         case op::load: {
             const auto size = read<std::uint64_t>(prog, ptr);

--- a/src/bytecode.cpp
+++ b/src/bytecode.cpp
@@ -91,6 +91,11 @@ auto apply_op(const bytecode_program& prog, bytecode_context& ctx) -> void
         case op::push_literal_null: {
             push_value(ctx.stack, std::byte{0});
         } break;
+        case op::push_literal_string: {
+            for (std::size_t i = 0; i != 16; ++i) {
+                ctx.stack.push_back(prog.code[ctx.prog_ptr++]);
+            }
+        } break;
         case op::push_literal_ptr_rel: {
             const auto offset = read<std::uint64_t>(prog, ctx.prog_ptr);
             push_value(ctx.stack, ctx.base_ptr + offset);
@@ -326,6 +331,14 @@ auto print_op(const bytecode_program& prog, std::size_t ptr) -> std::size_t
         } break;
         case op::push_literal_null: {
             print("PUSH_LITERAL_NULL\n");
+        } break;
+        case op::push_literal_string: {
+            const auto index = read<std::uint64_t>(prog, ptr);
+            const auto size = read<std::uint64_t>(prog, ptr);
+            const auto m = std::string_view( // UB?
+                reinterpret_cast<const char*>(&prog.rom[index]), size
+            );
+            print("PUSH_LITERAL_STRING: '{}'\n", m);
         } break;
         case op::push_literal_ptr: {
             const auto pos = read<std::uint64_t>(prog, ptr);

--- a/src/bytecode.hpp
+++ b/src/bytecode.hpp
@@ -8,18 +8,18 @@ namespace anzu {
 
 enum class op : std::uint8_t
 {
-    push_literal_i32,
-    push_literal_i64,
-    push_literal_u64,
-    push_literal_f64,
-    push_literal_char,
-    push_literal_bool,
-    push_literal_null,
-    push_literal_string,
+    push_i32,
+    push_i64,
+    push_u64,
+    push_f64,
+    push_char,
+    push_bool,
+    push_null,
 
-    push_literal_ptr,
-    push_literal_ptr_rel,
-    push_literal_call_frame,
+    push_string_literal,
+    push_call_frame,
+    push_ptr,
+    push_ptr_rel,
     
     load,
     save,

--- a/src/bytecode.hpp
+++ b/src/bytecode.hpp
@@ -15,6 +15,7 @@ enum class op : std::uint8_t
     push_literal_char,
     push_literal_bool,
     push_literal_null,
+    push_literal_string,
 
     push_literal_ptr,
     push_literal_ptr_rel,

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -707,8 +707,8 @@ auto push_expr_val(compiler& com, const node_literal_char_expr& node) -> type_na
 
 auto push_expr_val(compiler& com, const node_literal_string_expr& node) -> type_name
 {
-    const auto rom_ptr = insert_into_rom(com, node.value);
-    push_value(com.program, op::push_literal_string, unset_rom_bit(rom_ptr), node.value.size());
+    push_value(com.program, op::push_literal_string);
+    push_value(com.program, insert_into_rom(com, node.value), node.value.size());
     return concrete_span_type(char_type());
 }
 

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -707,9 +707,8 @@ auto push_expr_val(compiler& com, const node_literal_char_expr& node) -> type_na
 
 auto push_expr_val(compiler& com, const node_literal_string_expr& node) -> type_name
 {
-    // Push the span onto the stack
-    push_value(com.program, op::push_literal_ptr, insert_into_rom(com, node.value));
-    push_value(com.program, op::push_literal_u64, node.value.size());
+    const auto rom_ptr = insert_into_rom(com, node.value);
+    push_value(com.program, op::push_literal_string, unset_rom_bit(rom_ptr), node.value.size());
     return concrete_span_type(char_type());
 }
 


### PR DESCRIPTION
* Rename all `push_literal_*` op codes to `push_*`.
* Added `push_string_literal`, which is equivalent to pushing a pointer + size. Alternate name could have been `push_char_span`, but named it string literal because it is assumed that the pointer always points to read-only memory.
* Add a constructor to `string` that accepts a `char[]`.