### PR TITLE
Function Pointer Calling Fix

### DIFF
--- a/examples/std/string.az
+++ b/examples/std/string.az
@@ -55,6 +55,14 @@ struct string
         self->append(value);
     }
 
+    fn transform(self: &string, func: (&char) -> null)
+    {
+        span := self->get();
+        for c in span {
+            func(c);
+        }
+    }
+
     # SPECIAL MEMBER FUNCTIONS
 
     fn drop(self: &string)

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,4 +1,12 @@
 import std/string.az;
 
 str := new_string("hello world");
+str.append(" ian");
+
+fn replace_a(c: &char)
+{
+    if (*c == 'a') { *c = 'X'; }
+}
+
+str.transform(replace_a);
 println(str.get());

--- a/src/bytecode.cpp
+++ b/src/bytecode.cpp
@@ -203,7 +203,7 @@ auto apply_op(const bytecode_program& prog, bytecode_context& ctx) -> void
             // the function.
             const auto new_base_ptr = ctx.stack.size() - args_size;
             write_value(ctx.stack, new_base_ptr, ctx.base_ptr);
-            write_value(ctx.stack, new_base_ptr + sizeof(std::uint64_t), ctx.prog_ptr); // Pos after function call
+            write_value(ctx.stack, new_base_ptr + sizeof(std::uint64_t), ctx.prog_ptr);
             
             ctx.base_ptr = new_base_ptr;
             ctx.prog_ptr = ptr; // Jump into the function
@@ -216,7 +216,7 @@ auto apply_op(const bytecode_program& prog, bytecode_context& ctx) -> void
             // the function.
             const auto new_base_ptr = ctx.stack.size() - args_size;
             write_value(ctx.stack, new_base_ptr, ctx.base_ptr);
-            write_value(ctx.stack, new_base_ptr + sizeof(std::uint64_t), ctx.prog_ptr + 1); // Pos after function call
+            write_value(ctx.stack, new_base_ptr + sizeof(std::uint64_t), ctx.prog_ptr);
             
             ctx.base_ptr = new_base_ptr;
             ctx.prog_ptr = ptr; // Jump into the function

--- a/src/bytecode.cpp
+++ b/src/bytecode.cpp
@@ -195,19 +195,6 @@ auto apply_op(const bytecode_program& prog, bytecode_context& ctx) -> void
             ctx.base_ptr = prev_base_ptr;
             ctx.prog_ptr = prev_prog_ptr;
         } break;
-        case op::function_call: {
-            const auto ptr = read<std::uint64_t>(prog, ctx.prog_ptr);
-            const auto args_size = read<std::uint64_t>(prog, ctx.prog_ptr);
-
-            // Store the old base_ptr and prog_ptr so that they can be restored at the end of
-            // the function.
-            const auto new_base_ptr = ctx.stack.size() - args_size;
-            write_value(ctx.stack, new_base_ptr, ctx.base_ptr);
-            write_value(ctx.stack, new_base_ptr + sizeof(std::uint64_t), ctx.prog_ptr);
-            
-            ctx.base_ptr = new_base_ptr;
-            ctx.prog_ptr = ptr; // Jump into the function
-        } break;
         case op::call: {
             const auto args_size = read<std::uint64_t>(prog, ctx.prog_ptr);
 
@@ -400,11 +387,6 @@ auto print_op(const bytecode_program& prog, std::size_t ptr) -> std::size_t
         case op::ret: {
             const auto type_size = read<std::uint64_t>(prog, ptr);
             print("RETURN: type_size={}\n", type_size);
-        } break;
-        case op::function_call: {
-            const auto func_ptr = read<std::uint64_t>(prog, ptr);
-            const auto args_size = read<std::uint64_t>(prog, ptr);
-            print("FUNCTION_CALL: func_ptr={} args_size={}\n", func_ptr, args_size);
         } break;
         case op::call: {
             const auto args_size = read<std::uint64_t>(prog, ptr);

--- a/src/bytecode.hpp
+++ b/src/bytecode.hpp
@@ -30,7 +30,6 @@ enum class op : std::uint8_t
     dealloc_ptr,
     jump,
     jump_if_false,
-    function_call,
     call,
     builtin_call,
     ret,

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -258,8 +258,7 @@ auto push_function_call(compiler& com, std::size_t ptr, const std::vector<type_n
         args_size += com.types.size_of(param);
     }
 
-    push_value(com.program, op::push_u64, ptr);
-    push_value(com.program, op::call, args_size);
+    push_value(com.program, op::push_u64, ptr, op::call, args_size);
 }
 
 // Registers the given name in the current scope

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -258,7 +258,8 @@ auto push_function_call(compiler& com, std::size_t ptr, const std::vector<type_n
         args_size += com.types.size_of(param);
     }
 
-    push_value(com.program, op::function_call, ptr, args_size);
+    push_value(com.program, op::push_u64, ptr);
+    push_value(com.program, op::call, args_size);
 }
 
 // Registers the given name in the current scope


### PR DESCRIPTION
* The bug with function pointers was in `op::call`; storing the next position of the program pointer still had a +1 left over, causing the bad read. This was fixed in `op::function_call` but not here.
* Removed `op::function_call`, just use `op::call` everywhere now since it's equivalent to a `op::push_u64` followed by `op::call`.
* Implemented the `transform` function on the `string` class, which was the original way I noticed this bug.
* Remove some unused functions from the bytecode module.
* Renamed `read` to `read_advance`.
* The `reinterpret_cast` uses in the bytecode to convert from bytes to a `string_view` is not undefined behaviour, so those comments have been removed and the code has been cleaned up a bit.