### PR TITLE
Fix Format Defects

### DIFF
--- a/examples/euler.az
+++ b/examples/euler.az
@@ -3,7 +3,7 @@
 count := 0;
 i := 0;
 
-while i < 10 {
+while i < 100000 {
     if i % 3 == 0 {
         count = count + i;
     } else if i % 5 == 0 {

--- a/src/bytecode.cpp
+++ b/src/bytecode.cpp
@@ -12,7 +12,7 @@ namespace anzu {
 namespace {
 
 template <typename ...Args>
-auto runtime_assert(bool condition, std::string_view msg, Args&&... args)
+auto runtime_assert(bool condition, std::format_string<Args...> msg, Args&&... args)
 {
     if (!condition) {
         anzu::print(msg, std::forward<Args>(args)...);
@@ -22,7 +22,7 @@ auto runtime_assert(bool condition, std::string_view msg, Args&&... args)
 
 
 template <typename ...Args>
-[[noreturn]] auto runtime_error(std::string_view message, Args&&... args)
+[[noreturn]] auto runtime_error(std::format_string<Args...> message, Args&&... args)
 {
     const auto msg = std::format(message, std::forward<Args>(args)...);
     print("Runtime assertion failed! {}\n", msg);
@@ -206,7 +206,7 @@ auto apply_op(const bytecode_program& prog, bytecode_context& ctx) -> void
             const auto size = read_advance<std::uint64_t>(prog, ctx.prog_ptr);
             if (!pop_value<bool>(ctx.stack)) {
                 const auto data = reinterpret_cast<const char*>(&prog.rom[index]);
-                runtime_error({data, size});
+                runtime_error("{}", std::string_view{data, size});
             }
         } break;
 

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -1220,8 +1220,8 @@ void push_stmt(compiler& com, const node_if_stmt& node)
 void push_stmt(compiler& com, const node_struct_stmt& node)
 {
     const auto message = std::format("type '{}' already defined", node.name);
-    node.token.assert(!com.types.contains(make_type(node.name)), message);
-    node.token.assert(!com.functions[global_namespace].contains(node.name), message);
+    node.token.assert(!com.types.contains(make_type(node.name)), "{}", message);
+    node.token.assert(!com.functions[global_namespace].contains(node.name), "{}", message);
 
     auto fields = type_fields{};
     for (const auto& p : node.fields) {

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -9,7 +9,7 @@ namespace {
 
 template <typename... Args>
 [[noreturn]] void lexer_error(
-    std::int64_t lineno, std::int64_t col, std::string_view msg, Args&&... args)
+    std::int64_t lineno, std::int64_t col, std::format_string<Args...> msg, Args&&... args)
 {
     const auto formatted_msg = std::format(msg, std::forward<Args>(args)...);
     anzu::print("[ERROR] ({}:{}) {}\n", lineno, col, formatted_msg);

--- a/src/token.hpp
+++ b/src/token.hpp
@@ -85,19 +85,19 @@ struct token
     [[noreturn]] void error(std::string_view msg) const;
 
     template <typename... Args>
-    [[noreturn]] void error(std::string_view msg, Args&&... args) const
+    [[noreturn]] void error(std::format_string<Args...> msg, Args&&... args) const
     {
         error(std::format(msg, std::forward<Args>(args)...));
     }
 
     template <typename... Args>
-    void assert(bool condition, std::string_view msg, Args&&... args) const
+    void assert(bool condition, std::format_string<Args...> msg, Args&&... args) const
     {
         if (!condition) error(std::format(msg, std::forward<Args>(args)...));
     }
 
     template <typename... Args>
-    void assert_eq(const auto& lhs, const auto& rhs, std::string_view msg, Args&&... args) const
+    void assert_eq(const auto& lhs, const auto& rhs, std::format_string<Args...> msg, Args&&... args) const
     {
         if (lhs != rhs) {
             const auto user_msg = std::format(msg, std::forward<Args>(args)...);
@@ -106,7 +106,7 @@ struct token
     }
 
     template <typename... Args>
-    void assert_type(token_type tt, std::string_view msg, Args&&... args) const
+    void assert_type(token_type tt, std::format_string<Args...> msg, Args&&... args) const
     {
         if (tt != type) {
             const auto user_msg = std::format(msg, std::forward<Args>(args)...);

--- a/src/utility/print.hpp
+++ b/src/utility/print.hpp
@@ -8,7 +8,7 @@
 namespace anzu {
 
 template <typename... Args>
-void print(std::string_view fmt, Args&&... args)
+void print(std::format_string<Args...> fmt, Args&&... args)
 {
     std::cout << std::format(fmt, std::forward<Args>(args)...);
 }


### PR DESCRIPTION
* I upgraded my compiler which landed the C++20 defect report to make an incorrect number of format args to `std::format` a compile time error, which resulted in compiler errors.
* Wrapper functions for `std::format` now take a `std::format_string<Args...>` instead of `std::string_view`.