### PR TITLE
References

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,3 +149,6 @@ Utility Modules (in src/utility)
     - reading/readlines
 * Const
 * Variants
+
+# Known Issues
+* If trying to call a builtin function with an unknown type, it doesn't say that it couldn't find the function; it instead tries to lookup the function name as a variable, and reports that it couldn't find it.

--- a/examples/test.az
+++ b/examples/test.az
@@ -9,3 +9,11 @@ fn increment(val: i64~)
 
 # TODO: Assignment from a reference produces a copy
 # TODO: Allow operators to convert with binary operations
+
+
+increment(x);
+increment(x);
+increment(x);
+increment(x);
+
+println(x);

--- a/examples/test.az
+++ b/examples/test.az
@@ -15,10 +15,5 @@ struct copyable
 a := copyable(1, 1.0);
 b := ref a.i;
 
-b = 6;
-
-c := ref a;
-c.i = 8;
-
 println(4);
 println(b);

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,4 +1,11 @@
 
-x := true;
-r := x~;
- println(r);
+x := 5;
+
+fn increment(val: i64~)
+{
+    copy := val;
+    val = copy + 1;
+}
+
+# TODO: Assignment from a reference produces a copy
+# TODO: Allow operators to convert with binary operations

--- a/examples/test.az
+++ b/examples/test.az
@@ -13,8 +13,12 @@ struct copyable
 }
 
 a := copyable(1, 1.0);
-b := ref a;
+b := ref a.i;
 
-b.i = 5;
+b = 6;
 
-println(a.i);
+c := ref a;
+c.i = 8;
+
+println(4);
+println(b);

--- a/examples/test.az
+++ b/examples/test.az
@@ -6,7 +6,12 @@ println(ir);
 
 fn print_int(x: i64) -> null
 {
-    println(x);
+    println("value");
+}
+
+fn print_int(x: i64) -> null
+{
+    println("value2");
 }
 
 print_int(ir);

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,4 +1,19 @@
-import std/string.az;
 
-str := new_string("hello world");
-print(str.get());
+struct foo
+{
+    x: i64;
+    
+    fn bar(self: foo&, val: i64) -> i64
+    {
+        return self@.x + val;
+    }
+}
+
+fn bar(self: foo&, val: i64) -> i64
+{
+    return 2 * self@.x + val;
+}
+
+
+f := foo(5);
+println(f.bar(6));

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,11 +1,11 @@
 
-a := 1;
-ar := a~;
+x := 5;
+y := 6;
 
-b := 2;
-br := b~;
+xr := x~;
+yr := y~;
 
-ar = br;
-br = 5;
+xr = yr;
+xr = 8;
 
-println(a);
+println(x);

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,13 +1,20 @@
 
 i := 5;
+println(i);
 ir := ref i;
-i = 6;
+ir = 6;
+println(i);
+irr := ref ir;
+irr = 7;
+println(i);
+irrr := ref irr;
+irrr = 8;
+println(irrr);
 
 fn print_int(x: i64) -> null
 {
     println(x);
 }
 
-ptr := print_int;
 
-ptr(ir);
+print_int(irrr);

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,6 +1,20 @@
-x := 5;
 
-y := ref x;
-y = 6;
 
-println(x);
+struct copyable
+{
+    i: i64;
+    f: f64;
+
+    fn assign(self: copyable&, other: copyable&) -> null
+    {
+        other@.i = self@.i;
+        other@.f = self@.f;
+    }
+}
+
+a := copyable(1, 1.0);
+b := ref a;
+
+b.i = 5;
+
+println(a.i);

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,20 +1,5 @@
 
-i := 5;
-println(i);
-ir := ref i;
-ir = 6;
-println(i);
-irr := ref ir;
-irr = 7;
-println(i);
-irrr := ref irr;
-irrr = 8;
-println(irrr);
+x := true;
+r := ref x;
 
-fn print_int(x: i64) -> null
-{
-    println(x);
-}
-
-
-print_int(irrr);
+print(sizeof(r));

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,5 +1,3 @@
-
-
 struct copyable
 {
     i: i64;
@@ -14,6 +12,8 @@ struct copyable
 
 a := copyable(1, 1.0);
 b := ref a.i;
+
+a.i = 6;
 
 println(4);
 println(b);

--- a/examples/test.az
+++ b/examples/test.az
@@ -19,3 +19,4 @@ i := 5;
 ir := ref i;
 
 c := copyable(ir, 6.0);
+println(c.i);

--- a/examples/test.az
+++ b/examples/test.az
@@ -9,9 +9,4 @@ fn print_int(x: i64) -> null
     println("value");
 }
 
-fn print_int(x: i64) -> null
-{
-    println("value2");
-}
-
 print_int(ir);

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,22 +1,23 @@
 struct copyable
 {
-    i: i64;
-    f: f64;
+    arr: i64[2u];
 
     fn assign(self: copyable&, other: copyable&) -> null
     {
-        other@.i = self@.i;
-        other@.f = self@.f;
+        other@.arr = self@.arr;
     }
 
     fn copy(self: copyable&) -> copyable
     {
-        return copyable(self@.i, self@.f);
+        return copyable(self@.arr);
     }
 }
 
-i := 5;
-ir := ref i;
+a := [1, 2];
+ar := ref a;
 
-c := copyable(ir, 6.0);
-println(c.i);
+c := copyable(ar);
+a[0u] = 3;
+
+println(c.arr[0u]);
+println(c.arr[1u]);

--- a/examples/test.az
+++ b/examples/test.az
@@ -16,7 +16,7 @@ struct copyable
 a := [1, 2];
 ar := ref a;
 
-c := copyable(ar);
+c := copyable(a);
 a[0u] = 3;
 
 println(c.arr[0u]);

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,8 +1,4 @@
 
 x := true;
-r := ref x;
-
-fn foo() -> typeof(r)
-{
-    return 5;
-}
+r := x~;
+ println(r);

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,11 +1,34 @@
 
-x := 5;
-y := 6;
+struct copyable
+{
+    val: i64;
 
-xr := x~;
-yr := y~;
+    fn assign(self: copyable&, other: copyable&)
+    {
+        other@.val = self@.val;
+        println("Assign called!");
+    }
 
-xr = yr;
-xr = 8;
+    fn copy(self: copyable&) -> copyable
+    {
+        println("Copy called!");
+        return copyable(self@.val);
+    }
 
-println(x);
+    fn drop(self: copyable&) 
+    {
+        println("Drop called!");
+    }
+}
+
+
+fn foo(c: copyable~) {
+    c.val = 20;
+    println(c.val);
+}
+
+x := copyable(10);
+ref := x~;
+foo(ref);
+println("After foo call");
+println(x.val);

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,19 +1,11 @@
 
-x := 5;
+a := 1;
+ar := a~;
 
-fn increment(val: i64~)
-{
-    copy := val;
-    val = copy + 1;
-}
+b := 2;
+br := b~;
 
-# TODO: Assignment from a reference produces a copy
-# TODO: Allow operators to convert with binary operations
+ar = br;
+br = 5;
 
-
-increment(x);
-increment(x);
-increment(x);
-increment(x);
-
-println(x);
+println(a);

--- a/examples/test.az
+++ b/examples/test.az
@@ -22,13 +22,16 @@ struct copyable
 }
 
 
-fn foo(c: copyable~) {
-    c.val = 20;
-    println(c.val);
+x := copyable(1);
+r := x~;
+y := [r, r, copyable(20)];
+r = copyable(5);
+
+fn print_copyable_array(values: copyable[])
+{
+    for ptr in values {
+        println(ptr@.val);
+    }
 }
 
-x := copyable(10);
-ref := x~;
-foo(ref);
-println("After foo call");
-println(x.val);
+print_copyable_array(y[]);

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,6 +1,7 @@
 
 i := 5;
 ir := ref i;
+i = 6;
 
 println(ir);
 

--- a/examples/test.az
+++ b/examples/test.az
@@ -3,11 +3,11 @@ i := 5;
 ir := ref i;
 i = 6;
 
-println(ir);
-
 fn print_int(x: i64) -> null
 {
-    println("value");
+    println(x);
 }
 
-print_int(ir);
+ptr := print_int;
+
+ptr(ir);

--- a/examples/test.az
+++ b/examples/test.az
@@ -8,12 +8,14 @@ struct copyable
         other@.i = self@.i;
         other@.f = self@.f;
     }
+
+    fn copy(self: copyable&) -> copyable
+    {
+        return copyable(self@.i, self@.f);
+    }
 }
 
-a := copyable(1, 1.0);
-b := ref a.i;
+i := 5;
+ir := ref i;
 
-a.i = 6;
-
-println(4);
-println(b);
+c := copyable(ir, 6.0);

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,19 +1,5 @@
+x := 5;
 
-struct foo
-{
-    x: i64;
-    
-    fn bar(self: foo&, val: i64) -> i64
-    {
-        return self@.x + val;
-    }
-}
+y := ref x;
 
-fn bar(self: foo&, val: i64) -> i64
-{
-    return 2 * self@.x + val;
-}
-
-
-f := foo(5);
-println(f.bar(6));
+y = 6;

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,23 +1,12 @@
-struct copyable
+
+i := 5;
+ir := ref i;
+
+println(ir);
+
+fn print_int(x: i64) -> null
 {
-    arr: i64[2u];
-
-    fn assign(self: copyable&, other: copyable&) -> null
-    {
-        other@.arr = self@.arr;
-    }
-
-    fn copy(self: copyable&) -> copyable
-    {
-        return copyable(self@.arr);
-    }
+    println(x);
 }
 
-a := [1, 2];
-ar := ref a;
-
-c := copyable(a);
-a[0u] = 3;
-
-println(c.arr[0u]);
-println(c.arr[1u]);
+print_int(ir);

--- a/examples/test.az
+++ b/examples/test.az
@@ -2,4 +2,7 @@
 x := true;
 r := ref x;
 
-print(sizeof(r));
+fn foo() -> typeof(r)
+{
+    return 5;
+}

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,5 +1,6 @@
 x := 5;
 
 y := ref x;
-
 y = 6;
+
+println(x);

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -117,6 +117,10 @@ auto print_node(const node_expr& root, int indent) -> void
                 print("{}LowerBound:\n", spaces);
                 print_node(*node.upper_bound, indent + 1);
             }
+        },
+        [&](const node_reference_expr& node) {
+            print("{}Reference:\n", spaces);
+            print_node(*node.expr, indent + 1);
         }
     }, root);
 }

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -188,19 +188,19 @@ struct node_new_expr
     anzu::token token;
 };
 
+struct node_reference_expr
+{
+    node_expr_ptr expr;
+
+    anzu::token token;
+};
+
 struct node_span_expr
 {
     node_expr_ptr expr;
     node_expr_ptr lower_bound;
     node_expr_ptr upper_bound;
     
-    anzu::token token;
-};
-
-struct node_reference_expr
-{
-    node_expr_ptr expr;
-
     anzu::token token;
 };
 
@@ -222,14 +222,14 @@ struct node_expr : std::variant<
     node_addrof_expr,
     node_sizeof_expr,
     node_new_expr,
+    node_reference_expr,
 
     // Lvalue expressions
     node_name_expr,
     node_field_expr,
     node_deref_expr,
     node_subscript_expr,
-    node_span_expr,
-    node_reference_expr>
+    node_span_expr>
 {
 };
 

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -197,6 +197,13 @@ struct node_span_expr
     anzu::token token;
 };
 
+struct node_reference_expr
+{
+    node_expr_ptr expr;
+
+    anzu::token token;
+};
+
 struct node_expr : std::variant<
     // Rvalue expressions
     node_literal_i32_expr,
@@ -221,7 +228,8 @@ struct node_expr : std::variant<
     node_field_expr,
     node_deref_expr,
     node_subscript_expr,
-    node_span_expr>
+    node_span_expr,
+    node_reference_expr>
 {
 };
 

--- a/src/bytecode.cpp
+++ b/src/bytecode.cpp
@@ -279,8 +279,6 @@ auto print_op(const bytecode_program& prog, std::size_t ptr) -> std::size_t
     print("[{:>3}] ", ptr);
     const auto op_code = static_cast<op>(prog.code[ptr++]);
     switch (op_code) {
-        // TODO: Pushing literals can just be memcpy's without casting, because we're
-        // going from bytes to bytes
         case op::push_i32: {
             const auto value = read_advance<std::int32_t>(prog, ptr);
             print("PUSH_I32: {}\n", value);

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -435,14 +435,17 @@ auto call_destructor(compiler& com, const type_name& type, compile_obj_ptr_cb pu
                 }
             }
         },
-        [&](const type_ptr&) {
-            // pointers have no destructors
+        [](const type_ptr&) {
+            // pointers do not own anything to cloean up
         },
-        [&](const type_span&) {
-            // spans have no destructors
+        [](const type_span&) {
+            // spans do not own anything to cloean up
         },
-        [&](const type_function_ptr&) {
-            // functions pointers have no destructors
+        [](const type_function_ptr&) {
+            // functions pointers do not own anything to cloean up
+        },
+        [](const type_reference&) {
+            // references do not own anything to cloean up
         }
     }, type);
 }

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -1376,6 +1376,7 @@ auto is_assignable(const type_name& lhs, const type_name& rhs) -> bool
     return true;
 }
 
+// TODO: Fix assigning from a ref to a ref (currentl)
 void push_stmt(compiler& com, const node_assignment_stmt& node)
 {
     const auto rhs = type_of_expr(com, *node.expr);

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -902,11 +902,17 @@ auto push_expr_val(compiler& com, const node_call_expr& node) -> type_name
                 }
                 // In this case, we have a reference but the function accepts a value,
                 // so push the value of the reference, which is an address, then load
-                // the value (TODO: This bypasses constructors, so needs fixing)
+                // the value. Note: this skips calling constructors, which is fine for
+                // builtin types, but a more general solution is needed for passing references
+                // to user functions.
                 else if (is_reference_type(param_types[i])) {
                     push_expr_val(com, *node.args.at(i));
                     push_value(com.program, op::load, com.types.size_of(inner_type(param_types[i])));
                 }
+                // TODO: Handle the case where the function itself takes a reference and we
+                // have passed a value. First need a way of expressing that a function takes
+                // references, which requires a way to spell reference types. Either do this
+                // or go straight to specifying mut/copy (and eventually in when we have const).
                 else {
                     node.token.error("TODO: Loading references into builtin functions");
                 }

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -513,6 +513,9 @@ auto pop_object(compiler& com, const type_name& type, const token& tok) -> void
 auto push_object_copy(compiler& com, const node_expr& expr, const token& tok) -> type_name
 {
     const auto type = type_of_expr(com, expr);
+    if (is_reference_type(type)) {
+        tok.error("TODO: Implement push_object_copy for references, if that's meaningful");
+    }
 
     if (is_rvalue_expr(expr) || is_type_trivially_copyable(type)) {
         push_expr_val(com, expr);

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -513,9 +513,6 @@ auto pop_object(compiler& com, const type_name& type, const token& tok) -> void
 auto push_object_copy(compiler& com, const node_expr& expr, const token& tok) -> type_name
 {
     const auto type = type_of_expr(com, expr);
-    if (is_reference_type(type)) {
-        tok.error("TODO: Implement push_object_copy for references, if that's meaningful");
-    }
 
     if (is_rvalue_expr(expr) || is_type_trivially_copyable(type)) {
         push_expr_val(com, expr);
@@ -891,7 +888,7 @@ auto push_expr_val(compiler& com, const node_call_expr& node) -> type_name
             return u64_type();
         }
 
-        // Fourth, it might be a builtin function
+        // Lastly, it might be a builtin function
         auto param_types = std::vector<type_name>{};
         for (const auto& arg : node.args) {
             param_types.emplace_back(type_of_expr(com, *arg));
@@ -904,6 +901,9 @@ auto push_expr_val(compiler& com, const node_call_expr& node) -> type_name
             push_value(com.program, op::builtin_call, *b);
             return get_builtin(*b).return_type;
         }
+
+        node.token.error("Could not find function {}({})\n",
+                         inner.name, format_comma_separated(param_types));
     }
 
     // Otherwise, the expression must be a function pointer.

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -1086,6 +1086,15 @@ auto push_expr_val(compiler& com, const node_new_expr& node) -> type_name
 auto push_expr_val(compiler& com, const node_reference_expr& node) -> type_name
 {
     const auto type = push_expr_ptr(com, *node.expr);
+
+    // Trying to take a reference of a reference just returns the original reference, ie-
+    // creating a reference from a reference is the same as creating a new reference to the
+    // original object. Here we have a pointer to a pointer, so dereference it to get a pointer
+    // to the original value.
+    if (is_reference_type(type)) {
+        push_value(com.program, op::load, size_of_reference());
+        return type;
+    }
     return concrete_reference_type(type);
 }
 

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -178,7 +178,8 @@ auto resolve_type(compiler& com, const token& tok, const node_type_ptr& type) ->
             return node.type;
         },
         [&](const node_expr_type& node) {
-            return type_of_expr(com, *node.expr);
+            // References act like aliases, so taking the typeof a reference strips the reference away.
+            return remove_reference(type_of_expr(com, *node.expr));
         }
     }, *type);
 
@@ -1003,7 +1004,10 @@ auto push_expr_val(compiler& com, const node_addrof_expr& node) -> type_name
 auto push_expr_val(compiler& com, const node_sizeof_expr& node) -> type_name
 {
     const auto type = type_of_expr(com, *node.expr);
-    push_value(com.program, op::push_u64, com.types.size_of(type));
+
+    // References act like aliases, so calling sizeof on a reference returns the size
+    // of the inner type. References will not be directly spellable eventually.
+    push_value(com.program, op::push_u64, com.types.size_of(remove_reference(type)));
     return u64_type();
 }
 

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -179,34 +179,12 @@ auto construct_builtin_array() -> std::vector<builtin>
 
 static const auto builtins = construct_builtin_array();
 
-auto is_convertible_to(const type_name& type, const type_name& expected) -> bool
-{
-    return type == expected
-        || is_reference_type(type) && inner_type(type) == expected
-        || is_reference_type(expected) && inner_type(expected) == type;
-}
-
-// Checks if the set of given args is convertible to the signature for a function.
-// Type A is convertible to B is A == ref B or B == ref A. TODO: Consider value categories,
-// rvalues should not be bindable to references
-auto is_convertible_to(const std::vector<type_name>& args,
-                       const std::vector<type_name>& actuals) -> bool
-{
-    if (args.size() != actuals.size()) return false;
-    for (std::size_t i = 0; i != args.size(); ++i) {
-        if (!is_convertible_to(args[i], actuals[i])) {
-            return false;
-        }
-    }
-    return true;
-}
-
 auto get_builtin_id(const std::string& name, const std::vector<type_name>& args)
     -> std::optional<std::size_t>
 {
     auto index = std::size_t{0};
     for (const auto& b : builtins) {
-        if (name == b.name && is_convertible_to(args, b.args)) {
+        if (name == b.name && are_types_convertible_to(args, b.args)) {
             return index;
         }
         ++index;

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -75,7 +75,6 @@ auto identifier_type(std::string_view token) -> token_type
     if (token == "loop")     return token_type::kw_loop;
     if (token == "new")      return token_type::kw_new;
     if (token == "null")     return token_type::kw_null;
-    if (token == "ref")      return token_type::kw_ref;
     if (token == "return")   return token_type::kw_return;
     if (token == "sizeof")   return token_type::kw_sizeof;
     if (token == "struct")   return token_type::kw_struct;
@@ -232,6 +231,7 @@ auto lexer::get_token() -> token
         case '/': return make_token(token_type::slash);
         case '*': return make_token(token_type::star);
         case '%': return make_token(token_type::percent);
+        case '~': return make_token(token_type::tilde);
         case '!': return make_token(
             match("=") ? token_type::bang_equal : token_type::bang);
         case '=': return make_token(

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -75,6 +75,7 @@ auto identifier_type(std::string_view token) -> token_type
     if (token == "loop")     return token_type::kw_loop;
     if (token == "new")      return token_type::kw_new;
     if (token == "null")     return token_type::kw_null;
+    if (token == "ref")      return token_type::kw_ref;
     if (token == "return")   return token_type::kw_return;
     if (token == "sizeof")   return token_type::kw_sizeof;
     if (token == "struct")   return token_type::kw_struct;

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -23,7 +23,7 @@ auto format_error(const std::string& str) -> void
 
 auto to_string(const type_name& type) -> std::string
 {
-    return std::visit([](const auto& t) { return to_string(t); }, type);
+    return std::visit([](const auto& t) { return ::anzu::to_string(t); }, type);
 }
 
 auto to_string(const type_simple& type) -> std::string

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -273,6 +273,11 @@ auto are_types_convertible_to(const std::vector<type_name>& args,
     return true;
 }
 
+auto remove_reference(const type_name& type) -> type_name
+{
+    return is_reference_type(type) ? inner_type(type) : type;
+}
+
 auto type_store::add(const type_name& name, const type_fields& fields) -> bool
 {
     if (d_classes.contains(name)) {

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -51,6 +51,11 @@ auto to_string(const type_function_ptr& type) -> std::string
     return std::format("({}) -> {}", format_comma_separated(type.param_types), *type.return_type);
 }
 
+auto to_string(const type_reference& type) -> std::string
+{
+    return std::format("ref-{}", to_string(*type.inner_type));
+}
+
 auto hash(const type_name& type) -> std::size_t
 {
     return std::visit([](const auto& t) { return hash(t); }, type);

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -53,7 +53,7 @@ auto to_string(const type_function_ptr& type) -> std::string
 
 auto to_string(const type_reference& type) -> std::string
 {
-    return std::format("ref-{}", to_string(*type.inner_type));
+    return std::format("{}~", to_string(*type.inner_type));
 }
 
 auto hash(const type_name& type) -> std::size_t

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -247,8 +247,7 @@ auto is_type_trivially_copyable(const type_name& type) -> bool
         || is_ptr_type(type)
         || is_function_ptr_type(type)
         || (is_list_type(type) && is_type_trivially_copyable(inner_type(type)))
-        || is_span_type(type)
-        || is_reference_type(type); // is just a pointer
+        || is_span_type(type);
 }
 
 auto is_type_convertible_to(const type_name& type, const type_name& expected) -> bool

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -251,6 +251,28 @@ auto is_type_trivially_copyable(const type_name& type) -> bool
         || is_reference_type(type); // is just a pointer
 }
 
+auto is_type_convertible_to(const type_name& type, const type_name& expected) -> bool
+{
+    return type == expected
+        || is_reference_type(type) && inner_type(type) == expected
+        || is_reference_type(expected) && inner_type(expected) == type;
+}
+
+// Checks if the set of given args is convertible to the signature for a function.
+// Type A is convertible to B is A == ref B or B == ref A. TODO: Consider value categories,
+// rvalues should not be bindable to references
+auto are_types_convertible_to(const std::vector<type_name>& args,
+                       const std::vector<type_name>& actuals) -> bool
+{
+    if (args.size() != actuals.size()) return false;
+    for (std::size_t i = 0; i != args.size(); ++i) {
+        if (!is_type_convertible_to(args[i], actuals[i])) {
+            return false;
+        }
+    }
+    return true;
+}
+
 auto type_store::add(const type_name& name, const type_fields& fields) -> bool
 {
     if (d_classes.contains(name)) {

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -241,11 +241,14 @@ auto is_type_fundamental(const type_name& type) -> bool
 
 auto is_type_trivially_copyable(const type_name& type) -> bool
 {
+    // TODO: Allow for trivially copyable user types
+    //   ie- classes with default copy/assign and all trivially copyable members
     return is_type_fundamental(type)
         || is_ptr_type(type)
         || is_function_ptr_type(type)
         || (is_list_type(type) && is_type_trivially_copyable(inner_type(type)))
-        || is_span_type(type);
+        || is_span_type(type)
+        || is_reference_type(type); // is just a pointer
 }
 
 auto type_store::add(const type_name& name, const type_fields& fields) -> bool
@@ -264,7 +267,8 @@ auto type_store::contains(const type_name& type) const -> bool
         || is_list_type(type)
         || is_ptr_type(type)
         || is_function_ptr_type(type)
-        || is_span_type(type);
+        || is_span_type(type)
+        || is_reference_type(type); // is just a pointer
 }
 
 // TODO: Refactor this mess

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -136,6 +136,14 @@ auto is_type_fundamental(const type_name& type) -> bool;
 
 auto is_type_trivially_copyable(const type_name& type) -> bool;
 
+// Checks if the set of given args is convertible to the signature for a function.
+// Type A is convertible to B is A == ref B or B == ref A. TODO: Consider value categories,
+// rvalues should not be bindable to references
+auto is_type_convertible_to(const type_name& lhs, const type_name& rhs) -> bool;
+
+auto are_types_convertible_to(const std::vector<type_name>& lhs,
+                              const std::vector<type_name>& rhs) -> bool;
+
 class type_store
 {
     using type_hash = decltype([](const type_name& t) { return anzu::hash(t); });

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -57,12 +57,19 @@ struct type_function_ptr
     auto operator==(const type_function_ptr&) const -> bool = default;
 };
 
+struct type_reference
+{
+    value_ptr<type_name> inner_type;
+    auto operator==(const type_reference&) const -> bool = default;
+};
+
 struct type_name : public std::variant<
     type_simple,
     type_list,
     type_ptr,
     type_span,
-    type_function_ptr>
+    type_function_ptr,
+    type_reference>
 {
     using variant::variant;
 };
@@ -88,6 +95,7 @@ auto hash(const type_ptr& type) -> std::size_t;
 auto hash(const type_span& type) -> std::size_t;
 auto hash(const type_simple& type) -> std::size_t;
 auto hash(const type_function_ptr& type) -> std::size_t;
+auto hash(const type_reference& type) -> std::size_t;
 
 auto i32_type() -> type_name;
 auto i64_type() -> type_name;
@@ -110,8 +118,12 @@ auto is_span_type(const type_name& t) -> bool;
 
 auto is_function_ptr_type(const type_name& t) -> bool;
 
+auto concrete_reference_type(const type_name& t) -> type_name;
+auto is_reference_type(const type_name& t) -> bool;
+
 auto size_of_ptr() -> std::size_t;
 auto size_of_span() -> std::size_t;
+auto size_of_reference() -> std::size_t;
 
 // Extracts the single inner type of the given t. Undefined if the given t is not a compound
 // type with a single subtype.

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -144,6 +144,9 @@ auto is_type_convertible_to(const type_name& lhs, const type_name& rhs) -> bool;
 auto are_types_convertible_to(const std::vector<type_name>& lhs,
                               const std::vector<type_name>& rhs) -> bool;
 
+// If the type is a reference, returns the inner type, otherwise returns the type.
+auto remove_reference(const type_name& type) -> type_name;
+
 class type_store
 {
     using type_hash = decltype([](const type_name& t) { return anzu::hash(t); });

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -137,8 +137,7 @@ auto is_type_fundamental(const type_name& type) -> bool;
 auto is_type_trivially_copyable(const type_name& type) -> bool;
 
 // Checks if the set of given args is convertible to the signature for a function.
-// Type A is convertible to B is A == ref B or B == ref A. TODO: Consider value categories,
-// rvalues should not be bindable to references
+// Type A is convertible to B is A == ref B or B == ref A.
 auto is_type_convertible_to(const type_name& lhs, const type_name& rhs) -> bool;
 
 auto are_types_convertible_to(const std::vector<type_name>& lhs,

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -155,6 +155,7 @@ auto to_string(const type_ptr& type) -> std::string;
 auto to_string(const type_span& type) -> std::string;
 auto to_string(const type_simple& type) -> std::string;
 auto to_string(const type_function_ptr& type) -> std::string;
+auto to_string(const type_reference& type) -> std::string;
 
 // Runtime pointer helpers to determine if the pointer is in stack, heap or read-only memory.
 static constexpr auto heap_bit = std::uint64_t{1} << 63;

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -362,6 +362,12 @@ auto parse_type(tokenstream& tokens) -> type_name
         else if (tokens.consume_maybe(token_type::ampersand)) {
             type = type_name{type_ptr{ .inner_type=type }};
         }
+        else if (tokens.consume_maybe(token_type::tilde)) {
+            if (std::holds_alternative<type_reference>(type)) {
+                tokens.consume().error("Invalid type, cannot have reference to reference");
+            }
+            type = type_name{type_reference{ .inner_type=type }};
+        }
         else {
             break;
         }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -172,6 +172,11 @@ auto parse_single_factor(tokenstream& tokens) -> node_expr_ptr
     auto node = std::make_shared<node_expr>();
 
     switch (tokens.curr().type) {
+        case token_type::kw_ref: {
+            auto& expr = node->emplace<node_reference_expr>();
+            expr.token = tokens.consume();
+            expr.expr = parse_expression(tokens);
+        } break;
         case token_type::left_paren: {
             tokens.consume();
             node = parse_expression(tokens);

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -172,11 +172,6 @@ auto parse_single_factor(tokenstream& tokens) -> node_expr_ptr
     auto node = std::make_shared<node_expr>();
 
     switch (tokens.curr().type) {
-        case token_type::kw_ref: {
-            auto& expr = node->emplace<node_reference_expr>();
-            expr.token = tokens.consume();
-            expr.expr = parse_expression(tokens);
-        } break;
         case token_type::left_paren: {
             tokens.consume();
             node = parse_expression(tokens);
@@ -240,6 +235,13 @@ auto parse_single_factor(tokenstream& tokens) -> node_expr_ptr
     // Handle postfix expressions
     while (true) {
         switch (tokens.curr().type) {
+            case token_type::tilde: {
+                auto new_node = std::make_shared<node_expr>();
+                auto& inner = new_node->emplace<node_reference_expr>();
+                inner.token = tokens.consume();
+                inner.expr = node;
+                node = new_node;
+            } break;
             case token_type::at: {
                 auto new_node = std::make_shared<node_expr>();
                 auto& inner = new_node->emplace<node_deref_expr>();

--- a/src/token.cpp
+++ b/src/token.cpp
@@ -63,7 +63,6 @@ auto to_string(token_type tt) -> std::string_view
         case token_type::kw_loop:             return "loop";
         case token_type::kw_new:              return "new";
         case token_type::kw_null:             return "null";
-        case token_type::kw_ref:              return "ref";
         case token_type::kw_return:           return "return";
         case token_type::kw_sizeof:           return "sizeof";
         case token_type::kw_struct:           return "struct";
@@ -87,6 +86,7 @@ auto to_string(token_type tt) -> std::string_view
         case token_type::star:                return "*";       
         case token_type::string:              return "string-literal"; 
         case token_type::uint64:              return "uint64";
+        case token_type::tilde:               return "~";
         default: return "::unknown::";
     }
 }

--- a/src/token.cpp
+++ b/src/token.cpp
@@ -63,6 +63,7 @@ auto to_string(token_type tt) -> std::string_view
         case token_type::kw_loop:             return "loop";
         case token_type::kw_new:              return "new";
         case token_type::kw_null:             return "null";
+        case token_type::kw_ref:              return "ref";
         case token_type::kw_return:           return "return";
         case token_type::kw_sizeof:           return "sizeof";
         case token_type::kw_struct:           return "struct";

--- a/src/token.hpp
+++ b/src/token.hpp
@@ -50,7 +50,6 @@ enum class token_type
     kw_loop,
     kw_new,
     kw_null,
-    kw_ref,
     kw_return,
     kw_sizeof,
     kw_struct,
@@ -74,6 +73,7 @@ enum class token_type
     star,
     string,
     uint64,
+    tilde,
 };
 
 struct token

--- a/src/token.hpp
+++ b/src/token.hpp
@@ -50,6 +50,7 @@ enum class token_type
     kw_loop,
     kw_new,
     kw_null,
+    kw_ref,
     kw_return,
     kw_sizeof,
     kw_struct,


### PR DESCRIPTION
* Added first implementation of references. Most likely riddled with bugs and will likely reimplement.
* Create a reference using postfix `~`, this is a temporary spelling, eventually references will be "visible" in the code, they will just be used to implement better function calls.
* Acts like references in C++, they cannot be reassigned, cannot be null, and act like the type they're referencing. Implementation mostly involves just going through the compiler and treating references specially.
* Values and bind to references in function arguments and vice versa.
* Added concept of convertibility between types.
* You cannot have functions overloaded on reference, eg; `fn foo(x: i64){}` and `fn foo(x: i64~) {}` is a compiler error as it is ambiguous.