### PR TITLE
Arrays Convert to Spans

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,7 @@
             "program": "${workspaceFolder}/build/src/Debug/anzu.exe",
             "args": [
                 "${workspaceFolder}/examples/test.az",
-                "com"
+                "run"
             ],
             "stopAtEntry": false,
             "cwd": "${fileDirname}",

--- a/examples/test.az
+++ b/examples/test.az
@@ -2,7 +2,10 @@ x := 5;
 r := x~;
 
 arr := [x, r, r];
-ref := arr~;
-ref[0u] = 10;
 
-println(arr[0u]);
+fn print_ints(s: i64[])
+{
+    println(s.size());
+}
+
+print_ints(arr);

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -253,8 +253,9 @@ auto is_type_trivially_copyable(const type_name& type) -> bool
 auto is_type_convertible_to(const type_name& type, const type_name& expected) -> bool
 {
     return type == expected
-        || is_reference_type(type) && inner_type(type) == expected
-        || is_reference_type(expected) && inner_type(expected) == type;
+        || (is_reference_type(type) && inner_type(type) == expected)
+        || (is_reference_type(expected) && inner_type(expected) == type)
+        || (is_list_type(type) && is_span_type(expected) && inner_type(type) == inner_type(expected));
 }
 
 // Checks if the set of given args is convertible to the signature for a function.


### PR DESCRIPTION
* Using the new concept of convertible types that allow for objects to bind to reference function parameters, we can also allow for other types to bind to different types too.
* It is now possible to pass arrays to functions that accept a span. Eg; given `fn foo(arr: i64[]) {}` and `arr := [1, 2, 3]`, you would previously have to write `foo(arr[])`, now you can simply wrote `foo(arr)` (both ways are still allowed).
* Fix a bug with calculating the size of function arguments. Previously used the given arguments rather than the actual parameters, which was fine before adding references, but now they can disagree.