### PR TITLE
Rename Lists to Arrays

### DIFF
--- a/examples/feature_test.az
+++ b/examples/feature_test.az
@@ -5,7 +5,7 @@
     a := 1;               # ints
     b := true;            # bools
     c := "hello world\n"; # string literal
-    d := [1, 2, 3];       # list
+    d := [1, 2, 3];       # array
 
     # variables from variables
     e := a;
@@ -148,11 +148,11 @@ fn println(v: vec2) -> null
     println(p_value);
 }
 
-# Lists
+# Arrays
 {
     xl := [1, 2, 3, 4];
     xl[2u] = 0;
-    println("Size of list is 4:");
+    println("Size of array is 4:");
     println(sizeof(xl));
 
     xl2 := [vec2(1, 2), vec2(3, 4)];
@@ -204,7 +204,7 @@ struct vec3
     println(v.length());
 }
 
-# Repeat-element syntax for lists
+# Repeat-element syntax for arrays
 {
     a := [1; 5u];
     b := [1, 1, 1, 1, 1];

--- a/examples/list_destruction.az
+++ b/examples/list_destruction.az
@@ -10,6 +10,6 @@ struct object
 }
 
 
-x := 10; # makes the address of the following list non-zero, to make sure offsets work
+x := 10; # makes the address of the following array non-zero, to make sure offsets work
 l := [object(1), object(2), object(3)];
 println("end");

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -67,15 +67,15 @@ auto print_node(const node_expr& root, int indent) -> void
                 print_node(*arg, indent + 1);
             }
         },
-        [&](const node_list_expr& node) {
-            print("{}List:\n", spaces);
+        [&](const node_array_expr& node) {
+            print("{}Array:\n", spaces);
             print("{}- Elements:\n", spaces);
             for (const auto& element : node.elements) {
                 print_node(*element, indent + 1);
             }
         },
-        [&](const node_repeat_list_expr& node) {
-            print("{}List:\n", spaces);
+        [&](const node_repeat_array_expr& node) {
+            print("{}Array:\n", spaces);
             print("{}- Element:\n", spaces);
             print_node(*node.value, indent + 1);
             print("{}- Count: {}\n", spaces, node.size);

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -136,14 +136,14 @@ struct node_call_expr
     anzu::token token;
 };
 
-struct node_list_expr
+struct node_array_expr
 {
     std::vector<node_expr_ptr> elements;
 
     anzu::token token;
 };
 
-struct node_repeat_list_expr
+struct node_repeat_array_expr
 {
     node_expr_ptr value;
     std::size_t   size;
@@ -217,8 +217,8 @@ struct node_expr : std::variant<
     node_unary_op_expr,
     node_binary_op_expr,
     node_call_expr,
-    node_list_expr,
-    node_repeat_list_expr,
+    node_array_expr,
+    node_repeat_array_expr,
     node_addrof_expr,
     node_sizeof_expr,
     node_new_expr,

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -869,7 +869,6 @@ auto push_function_arg(compiler& com, const node_expr& expr, const type_name& ex
     tok.assert(is_type_convertible_to(actual, expected), "Could not convert arg of type {} to {}", actual, expected);
 
     if (is_span_type(expected) && is_array_type(actual)) {
-        print("adding code to bind a array to a span\n");
         push_expr_ptr(com, expr);
         push_value(com.program, op::push_u64, array_length(actual));
         return concrete_span_type(inner_type(actual));

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -31,11 +31,11 @@ struct type_simple
     auto operator==(const type_simple&) const -> bool = default;
 };
 
-struct type_list
+struct type_array
 {
     value_ptr<type_name> inner_type;
     std::size_t          count;
-    auto operator==(const type_list&) const -> bool = default;
+    auto operator==(const type_array&) const -> bool = default;
 };
 
 struct type_ptr
@@ -65,7 +65,7 @@ struct type_reference
 
 struct type_name : public std::variant<
     type_simple,
-    type_list,
+    type_array,
     type_ptr,
     type_span,
     type_function_ptr,
@@ -90,7 +90,7 @@ struct type_info
 };
 
 auto hash(const type_name& type) -> std::size_t;
-auto hash(const type_list& type) -> std::size_t;
+auto hash(const type_array& type) -> std::size_t;
 auto hash(const type_ptr& type) -> std::size_t;
 auto hash(const type_span& type) -> std::size_t;
 auto hash(const type_simple& type) -> std::size_t;
@@ -107,8 +107,8 @@ auto null_type() -> type_name;
 
 auto make_type(const std::string& name) -> type_name;
 
-auto concrete_list_type(const type_name& t, std::size_t size) -> type_name;
-auto is_list_type(const type_name& t) -> bool;
+auto concrete_array_type(const type_name& t, std::size_t size) -> type_name;
+auto is_array_type(const type_name& t) -> bool;
 
 auto concrete_ptr_type(const type_name& t) -> type_name;
 auto is_ptr_type(const type_name& t) -> bool;
@@ -160,7 +160,7 @@ public:
 };
 
 auto to_string(const type_name& type) -> std::string;
-auto to_string(const type_list& type) -> std::string;
+auto to_string(const type_array& type) -> std::string;
 auto to_string(const type_ptr& type) -> std::string;
 auto to_string(const type_span& type) -> std::string;
 auto to_string(const type_simple& type) -> std::string;

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -181,13 +181,13 @@ auto parse_single_factor(tokenstream& tokens) -> node_expr_ptr
             const auto tok = tokens.consume();
             auto first = parse_expression(tokens);
             if (tokens.consume_maybe(token_type::semicolon)) {
-                auto& expr = node->emplace<node_repeat_list_expr>();
+                auto& expr = node->emplace<node_repeat_array_expr>();
                 expr.token = tok;
                 expr.value = first;
                 expr.size = tokens.consume_u64();
                 tokens.consume_only(token_type::right_bracket);
             } else {
-                auto& expr = node->emplace<node_list_expr>();
+                auto& expr = node->emplace<node_array_expr>();
                 expr.token = tok;
                 expr.elements.push_back(first);
                 if (tokens.consume_maybe(token_type::comma)) {
@@ -355,7 +355,7 @@ auto parse_type(tokenstream& tokens) -> type_name
                 type = type_name{type_span{ .inner_type=type }};
             }
             else {
-                type = type_name{type_list{ .inner_type=type, .count=tokens.consume_u64() }};
+                type = type_name{type_array{ .inner_type=type, .count=tokens.consume_u64() }};
                 tokens.consume_only(token_type::right_bracket);
             }
         }


### PR DESCRIPTION
* They've been referred to as both for ages now. I started with them called arrays back when everything was dynamically typed. When I switched to static typing I started referring to them as arrays because they had to be fixed size.
* Now all functions related to arrays are spelled correctly, no more having code using a mix of `is_list_type()` and `array_length()`.
* Simplified the `push_function_call` function now that the second and third args are just sub elements of the same object in all cases.