### PR TITLE
Type Category for Fundamentals + Bugfixes

### DIFF
--- a/examples/test.az
+++ b/examples/test.az
@@ -13,5 +13,4 @@ struct noisy_drop
 }
 
 y := noisy_drop();
-r := y~;
 x := [y, y, y];

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,11 +1,17 @@
-x := 5;
-r := x~;
 
-arr := [x, r, r];
-
-fn print_ints(s: i64[])
+struct noisy_drop
 {
-    println(s.size());
+    fn drop(self: noisy_drop&)
+    {
+        println("Dropped");
+    }
+
+    fn copy(self: noisy_drop&) -> noisy_drop
+    {
+        return noisy_drop();
+    }
 }
 
-print_ints(arr);
+y := noisy_drop();
+r := y~;
+x := [y, y, y];

--- a/src/bytecode.cpp
+++ b/src/bytecode.cpp
@@ -461,6 +461,10 @@ auto run_program(const bytecode_program& prog) -> void
         apply_op(prog, ctx);
     }
 
+    if (ctx.stack.size() > 0) {
+        anzu::print("\n -> Stack Size: {}, bug in the compiler!\n", ctx.stack.size());
+    }
+
     if (ctx.allocator.bytes_allocated() > 0) {
         anzu::print("\n -> Heap Size: {}, fix your memory leak!\n", ctx.allocator.bytes_allocated());
     }

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -403,6 +403,9 @@ using compile_obj_ptr_cb = std::function<void(const token&)>;
 auto call_destructor(compiler& com, const type_name& type, compile_obj_ptr_cb push_object_ptr) -> void
 {
     std::visit(overloaded{
+        [](type_fundamental) {
+            // nothing to do
+        },
         [&](const type_struct&) {
             const auto params = drop_fn_params(type);
             if (const auto func = get_function(com, type, "drop", params); func) {

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -403,7 +403,7 @@ using compile_obj_ptr_cb = std::function<void(const token&)>;
 auto call_destructor(compiler& com, const type_name& type, compile_obj_ptr_cb push_object_ptr) -> void
 {
     std::visit(overloaded{
-        [&](const type_simple&) {
+        [&](const type_struct&) {
             const auto params = drop_fn_params(type);
             if (const auto func = get_function(com, type, "drop", params); func) {
                 // Push the args to the stack

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -26,6 +26,20 @@ auto to_string(const type_name& type) -> std::string
     return std::visit([](const auto& t) { return ::anzu::to_string(t); }, type);
 }
 
+auto to_string(type_fundamental t) -> std::string
+{
+    switch (t.type) {
+        case fundamental::null_type: return "null";
+        case fundamental::bool_type: return "bool";
+        case fundamental::char_type: return "char";
+        case fundamental::i32_type:  return "i32";
+        case fundamental::i64_type:  return "i64";
+        case fundamental::u64_type:  return "u64";
+        case fundamental::f64_type:  return "f64";
+        default: return "UNKNOWN";
+    }
+}
+
 auto to_string(const type_struct& type) -> std::string
 {
     return type.name;

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -26,7 +26,7 @@ auto to_string(const type_name& type) -> std::string
     return std::visit([](const auto& t) { return ::anzu::to_string(t); }, type);
 }
 
-auto to_string(const type_simple& type) -> std::string
+auto to_string(const type_struct& type) -> std::string
 {
     return type.name;
 }
@@ -61,7 +61,7 @@ auto hash(const type_name& type) -> std::size_t
     return std::visit([](const auto& t) { return hash(t); }, type);
 }
 
-auto hash(const type_simple& type) -> std::size_t
+auto hash(const type_struct& type) -> std::size_t
 {
     return std::hash<std::string>{}(type.name);
 }
@@ -100,42 +100,42 @@ auto hash(const type_reference& type) -> std::size_t
 
 auto i32_type() -> type_name
 {
-    return {type_simple{ .name = std::string{i32_sv} }};
+    return {type_struct{ .name = std::string{i32_sv} }};
 }
 
 auto i64_type() -> type_name
 {
-    return {type_simple{ .name = std::string{i64_sv} }};
+    return {type_struct{ .name = std::string{i64_sv} }};
 }
 
 auto u64_type() -> type_name
 {
-    return {type_simple{ .name = std::string{u64_sv} }};
+    return {type_struct{ .name = std::string{u64_sv} }};
 }
 
 auto char_type() -> type_name
 {
-    return {type_simple{ .name = std::string{char_sv} }};
+    return {type_struct{ .name = std::string{char_sv} }};
 }
 
 auto f64_type() -> type_name
 {
-    return {type_simple{ .name = std::string{f64_sv} }};
+    return {type_struct{ .name = std::string{f64_sv} }};
 }
 
 auto bool_type() -> type_name
 {
-    return {type_simple{ .name = std::string{bool_sv} }};
+    return {type_struct{ .name = std::string{bool_sv} }};
 }
 
 auto null_type() -> type_name
 {
-    return {type_simple{ .name = std::string{null_sv} }};
+    return {type_struct{ .name = std::string{null_sv} }};
 }
 
 auto make_type(const std::string& name) -> type_name
 {
-    return { type_simple{ .name=name } };
+    return { type_struct{ .name=name } };
 }
 
 auto concrete_array_type(const type_name& t, std::size_t size) -> type_name
@@ -302,7 +302,7 @@ auto type_store::contains(const type_name& type) const -> bool
 auto type_store::size_of(const type_name& type) const -> std::size_t
 {
     return std::visit(overloaded{
-        [&](const type_simple& t) -> std::size_t {
+        [&](const type_struct& t) -> std::size_t {
             if (type == null_type() || type == char_type() || type == bool_type()) {
                 return 1;
             }

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -247,11 +247,6 @@ auto size_of_reference() -> std::size_t
     return PTR_SIZE;
 }
 
-auto is_type_fundamental(const type_name& type) -> bool
-{
-    return std::holds_alternative<type_fundamental>(type);
-}
-
 auto is_type_trivially_copyable(const type_name& type) -> bool
 {
     // TODO: Allow for trivially copyable struct types
@@ -262,7 +257,12 @@ auto is_type_trivially_copyable(const type_name& type) -> bool
         [](const type_span&)         { return true; },
         [](const type_ptr&)          { return true; },
         [](const type_function_ptr&) { return true; },
-        [](const type_reference&)    { return false; }
+        [](const type_reference&)    {
+            print("Logic Error: Tried to check if a ref is trivially copyable, but it should "
+                  "have already been stripped away\n");
+            std::exit(1);
+            return false;
+        }
     }, type);
 }
 

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -333,7 +333,7 @@ auto type_store::size_of(const type_name& type) const -> std::size_t
             for (const auto& field : fields_of(type)) {
                 size += size_of(field.type);
             }
-            return size;
+            return std::max(std::size_t{1}, size); // empty structs take up one byte
         },
         [&](const type_array& t) {
             return size_of(*t.inner_type) * t.count;

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -25,10 +25,10 @@ static_assert(std::is_same_v<std::uint64_t, std::size_t>);
 
 struct type_name;
 
-struct type_simple
+struct type_struct
 {
     std::string name;
-    auto operator==(const type_simple&) const -> bool = default;
+    auto operator==(const type_struct&) const -> bool = default;
 };
 
 struct type_array
@@ -64,7 +64,7 @@ struct type_reference
 };
 
 struct type_name : public std::variant<
-    type_simple,
+    type_struct,
     type_array,
     type_ptr,
     type_span,
@@ -93,7 +93,7 @@ auto hash(const type_name& type) -> std::size_t;
 auto hash(const type_array& type) -> std::size_t;
 auto hash(const type_ptr& type) -> std::size_t;
 auto hash(const type_span& type) -> std::size_t;
-auto hash(const type_simple& type) -> std::size_t;
+auto hash(const type_struct& type) -> std::size_t;
 auto hash(const type_function_ptr& type) -> std::size_t;
 auto hash(const type_reference& type) -> std::size_t;
 
@@ -163,7 +163,7 @@ auto to_string(const type_name& type) -> std::string;
 auto to_string(const type_array& type) -> std::string;
 auto to_string(const type_ptr& type) -> std::string;
 auto to_string(const type_span& type) -> std::string;
-auto to_string(const type_simple& type) -> std::string;
+auto to_string(const type_struct& type) -> std::string;
 auto to_string(const type_function_ptr& type) -> std::string;
 auto to_string(const type_reference& type) -> std::string;
 

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -11,19 +11,28 @@
 
 namespace anzu {
 
-static constexpr auto i32_sv = std::string_view{"i32"};
-static constexpr auto i64_sv = std::string_view{"i64"};
-static constexpr auto u64_sv = std::string_view{"u64"};
-static constexpr auto f64_sv = std::string_view{"f64"};
-static constexpr auto char_sv = std::string_view{"char"};
-static constexpr auto bool_sv = std::string_view{"bool"};
-static constexpr auto null_sv = std::string_view{"null"};
-
 // Want these to be equivalent since we want uints available in the runtime but we also want
 // to use it as indexes into C++ vectors which use size_t.
 static_assert(std::is_same_v<std::uint64_t, std::size_t>);
 
 struct type_name;
+
+enum class fundamental : std::uint8_t
+{
+    null_type,
+    bool_type,
+    char_type,
+    i32_type,
+    i64_type,
+    u64_type,
+    f64_type,
+};
+
+struct type_fundamental
+{
+    fundamental type;
+    auto operator==(const type_fundamental&) const -> bool = default;
+};
 
 struct type_struct
 {
@@ -64,6 +73,7 @@ struct type_reference
 };
 
 struct type_name : public std::variant<
+    type_fundamental,
     type_struct,
     type_array,
     type_ptr,
@@ -90,20 +100,21 @@ struct type_info
 };
 
 auto hash(const type_name& type) -> std::size_t;
+auto hash(type_fundamental type) -> std::size_t;
+auto hash(const type_struct& type) -> std::size_t;
 auto hash(const type_array& type) -> std::size_t;
 auto hash(const type_ptr& type) -> std::size_t;
 auto hash(const type_span& type) -> std::size_t;
-auto hash(const type_struct& type) -> std::size_t;
 auto hash(const type_function_ptr& type) -> std::size_t;
 auto hash(const type_reference& type) -> std::size_t;
 
+auto null_type() -> type_name;
+auto bool_type() -> type_name;
+auto char_type() -> type_name;
 auto i32_type() -> type_name;
 auto i64_type() -> type_name;
 auto u64_type() -> type_name;
 auto f64_type() -> type_name;
-auto char_type() -> type_name;
-auto bool_type() -> type_name;
-auto null_type() -> type_name;
 
 auto make_type(const std::string& name) -> type_name;
 

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -143,8 +143,6 @@ auto inner_type(const type_name& t) -> type_name;
 // Extracts the array size of the given type. Undefined if the given t is not an array
 auto array_length(const type_name& t) -> std::size_t;
 
-auto is_type_fundamental(const type_name& type) -> bool;
-
 auto is_type_trivially_copyable(const type_name& type) -> bool;
 
 // Checks if the set of given args is convertible to the signature for a function.

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -171,6 +171,7 @@ public:
 };
 
 auto to_string(const type_name& type) -> std::string;
+auto to_string(type_fundamental t) -> std::string;
 auto to_string(const type_array& type) -> std::string;
 auto to_string(const type_ptr& type) -> std::string;
 auto to_string(const type_span& type) -> std::string;

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -348,7 +348,7 @@ auto parse_type(tokenstream& tokens) -> type_name
         return ret;
     }
 
-    auto type = type_name{type_simple{.name=std::string{tokens.consume().text}}};
+    auto type = type_name{type_struct{.name=std::string{tokens.consume().text}}};
     while (true) {
         if (tokens.consume_maybe(token_type::left_bracket)) {
             if (tokens.consume_maybe(token_type::right_bracket)) {

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -335,6 +335,20 @@ auto parse_name(tokenstream& tokens)
     return token.text;
 }
 
+// If it's a fundamental type, return that, otherwise return a struct_type
+auto parse_simple_type(tokenstream& tokens) -> type_name
+{
+    const auto tok = tokens.consume();
+    if (tok.text == "null") return { type_fundamental{ .type=fundamental::null_type }};
+    if (tok.text == "bool") return { type_fundamental{ .type=fundamental::bool_type }};
+    if (tok.text == "char") return { type_fundamental{ .type=fundamental::char_type }};
+    if (tok.text == "i32")  return { type_fundamental{ .type=fundamental::i32_type  }};
+    if (tok.text == "i64")  return { type_fundamental{ .type=fundamental::i64_type  }};
+    if (tok.text == "u64")  return { type_fundamental{ .type=fundamental::u64_type  }};
+    if (tok.text == "f64")  return { type_fundamental{ .type=fundamental::f64_type  }};
+    return {type_struct{ .name=std::string{tok.text} }};
+}
+
 auto parse_type(tokenstream& tokens) -> type_name
 {
     // Function pointers
@@ -348,7 +362,7 @@ auto parse_type(tokenstream& tokens) -> type_name
         return ret;
     }
 
-    auto type = type_name{type_struct{.name=std::string{tokens.consume().text}}};
+    auto type = parse_simple_type(tokens);
     while (true) {
         if (tokens.consume_maybe(token_type::left_bracket)) {
             if (tokens.consume_maybe(token_type::right_bracket)) {


### PR DESCRIPTION
* Replace `type_simple` with `type_fundamental` and `type_struct`
* Simplify a bunch of other functions to use `std::visit` instead of needing to use functions like `is_type_fundamental`, which has been deleted.
* Bugfix: Empty structs had a size of zero which caused some problems. These now have a size of 1.
* Bugfix: Correctly pop the return values from `assign` and `drop` calls. This was leaving excess data on the stack at the end of the program, which was almost certainly causing other bugs as objects would be misaligned.
* Improvement: `type_store::contains` is now stronger in that it will check the inner types for arrays, spans, pointers and references. In practice this doesn't change anything but it makes the function less surprising.
* Improvement: Trying to call `is_type_trivially_copyable` on a reference results in an error. This is because the reference should be stripped off the type at the call site, since references don't behave like a typically type category.