### PR TITLE
References in For Loops

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,6 @@ An interpreted programming language written in C++. This started out as a stack-
         <body>
     }
     ```
-    NOTE: `name` is a pointer to the element in the array
 
 * `fn` function statements:
 

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,16 +1,6 @@
 
-struct noisy_drop
-{
-    fn drop(self: noisy_drop&)
-    {
-        println("Dropped");
-    }
+arr := [1, 2, 3];
 
-    fn copy(self: noisy_drop&) -> noisy_drop
-    {
-        return noisy_drop();
-    }
+for x in arr {
+    println(x);
 }
-
-y := noisy_drop();
-x := [y, y, y];

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -1248,14 +1248,14 @@ void push_stmt(compiler& com, const node_for_stmt& node)
         } else {
             push_expr_ptr(com, *node.iter);
             if (is_span_type(iter_type)) {
-                push_value(com.program, op::load, com.types.size_of(concrete_ptr_type(inner)));
+                push_value(com.program, op::load, size_of_ptr());
             }
         }
         load_variable(com, node.token, "#:idx");
-        push_value(com.program, op::push_u64, com.types.size_of(inner_type(iter_type)));
+        push_value(com.program, op::push_u64, com.types.size_of(inner));
         push_value(com.program, op::u64_mul);
         push_value(com.program, op::u64_add);
-        declare_var(com, node.token, node.name, concrete_ptr_type(inner_type(iter_type)));
+        declare_var(com, node.token, node.name, concrete_reference_type(inner));
 
         // idx = idx + 1;
         load_variable(com, node.token, "#:idx");


### PR DESCRIPTION
* Currently, the loop parameter of a for loop is a pointer, otherwise we would have only gotten copies.
* Now that we have references, for loops can use them instead. Done by simply changing the type of the declared variable.