### PR TITLE
Make `self` a Reference

### DIFF
--- a/examples/feature_test.az
+++ b/examples/feature_test.az
@@ -108,15 +108,15 @@ struct vec2
     x: i64;
     y: i64;
 
-    fn copy(self: vec2&) -> vec2
+    fn copy(self: vec2~) -> vec2
     {
-        return vec2(self@.x, self@.y);
+        return vec2(self.x, self.y);
     }
 
-    fn assign(self: vec2&, other: vec2&)
+    fn assign(self: vec2~, other: vec2~)
     {
-        other@.x = self@.x;
-        other@.y = self@.y;
+        self.x = other.x;
+        self.y = other.y;
     }
 }
 
@@ -176,24 +176,24 @@ struct vec3
     y: f64;
     z: f64;
 
-    fn length(self: vec3&) -> f64
+    fn length(self: vec3~) -> f64
     {
-        x_squared := square(self@.x);
-        y_squared := square(self@.y);
-        z_squared := square(self@.z);
+        x_squared := square(self.x);
+        y_squared := square(self.y);
+        z_squared := square(self.z);
         return sqrt(x_squared + y_squared + z_squared);
     }
 
-    fn copy(self: vec3&) -> vec3
+    fn copy(self: vec3~) -> vec3
     {
-        return vec3(self@.x, self@.y, self@.z);
+        return vec3(self.x, self.y, self.z);
     }
 
-    fn assign(self: vec3&, other: vec3&)
+    fn assign(self: vec3~, other: vec3~)
     {
-        other@.x = self@.x;
-        other@.y = self@.y;
-        other@.z = self@.z;
+        self.x = other.x;
+        self.y = other.y;
+        self.z = other.z;
     }
 }
 
@@ -254,14 +254,23 @@ struct destructible
 {
     val: i64;
 
-    fn drop(self: destructible&)
+    fn drop(self: destructible~)
     {
         print("dropping ");
-        println(self@.val);
+        println(self.val);
     }
 }
 
 {
     a := destructible(1);
     b := destructible(2);
+}
+
+{
+    v1 := vec3(1.0, 1.0, 1.0);
+    v2 := vec3(2.0, 2.0, 2.0);
+    v3 := vec3(3.0, 3.0, 3.0);
+
+    v1 = v3;
+    println(v1.x);
 }

--- a/examples/list_destruction.az
+++ b/examples/list_destruction.az
@@ -2,10 +2,10 @@ struct object
 {
     inner: i64;
 
-    fn drop(self: &object) -> null
+    fn drop(self: object~) -> null
     {
         print("dropping object ");
-        println(self->inner);
+        println(self.inner);
     }
 }
 

--- a/examples/recursion.az
+++ b/examples/recursion.az
@@ -1,5 +1,5 @@
 # fibbonacci to demonstrate functions and recursion
-import nested/string.az;
+
 fn fibb(n: i64) -> i64
 {
     if n == 0 {

--- a/examples/std/string.az
+++ b/examples/std/string.az
@@ -35,7 +35,7 @@ struct string
     fn append(self: string~, other: char[])
     {
         for c in other {
-            self.append_char(c@);
+            self.append_char(c);
         }
     }
 
@@ -80,19 +80,19 @@ struct string
     fn assign(self: string~, other: string~)
     {
         # Resize self if needed
-        if self.data.size() < other@.data.size() {
+        if self.data.size() < other.data.size() {
             delete self.data;
-            self.data = new char : other@.data.size();
+            self.data = new char : other.data.size();
         }
 
         # Copy over the data
         idx := 0u;
-        while idx != other@.size {
-            self.data[idx] = other@.data[idx];
+        while idx != other.size {
+            self.data[idx] = other.data[idx];
             idx = idx + 1u;
         }
 
-        self.size = other@.size;
+        self.size = other.size;
     }
 }
 

--- a/examples/std/string.az
+++ b/examples/std/string.az
@@ -4,95 +4,95 @@ struct string
     data: char[];
     size: u64;
 
-    fn append_char(self: string&, c: char)
+    fn append_char(self: string~, c: char)
     {
-        if (self@.size == self@.data.size()) {
-            new_cap := 2u * self@.data.size();
+        if (self.size == self.data.size()) {
+            new_cap := 2u * self.data.size();
             if new_cap == 0u {
                 new_cap = 1u;
             }
             newdata := new char : new_cap;
 
             idx := 0u;
-            while idx != self@.size {
-                newdata[idx] = self@.data[idx];
+            while idx != self.size {
+                newdata[idx] = self.data[idx];
                 idx = idx + 1u;
             }
 
-            delete self@.data;
-            self@.data = newdata;
+            delete self.data;
+            self.data = newdata;
         }
-        self@.data[self@.size] = c;
-        self@.size = self@.size + 1u;      
+        self.data[self.size] = c;
+        self.size = self.size + 1u;      
     }
 
-    fn at(self: string&, idx: u64) -> char
+    fn at(self: string~, idx: u64) -> char
     {
-        assert idx < self@.size;
-        return self@.data[idx];
+        assert idx < self.size;
+        return self.data[idx];
     }
 
-    fn append(self: string&, other: char[])
+    fn append(self: string~, other: char[])
     {
         for c in other {
-            self@.append_char(c@);
+            self.append_char(c@);
         }
     }
 
-    fn clear(self: string&)
+    fn clear(self: string~)
     {
-        self@.size = 0u;
+        self.size = 0u;
     }
 
-    fn get(self: string&) -> char[]
+    fn get(self: string~) -> char[]
     {
-        return self@.data[0u : self@.size];
+        return self.data[0u : self.size];
     }
 
-    fn set(self: string&, value: char[])
+    fn set(self: string~, value: char[])
     {
-        self@.clear();
-        self@.append(value);
+        self.clear();
+        self.append(value);
     }
 
-    fn transform(self: string&, func: (char&) -> null)
+    fn transform(self: string~, func: (char&) -> null)
     {
-        span := self@.get();
+        span := self.get();
         for c in span {
-            func(c);
+            func(c&);
         }
     }
 
     # SPECIAL MEMBER FUNCTIONS
 
-    fn drop(self: string&)
+    fn drop(self: string~)
     {
-        delete self@.data;
+        delete self.data;
     }
 
-    fn copy(self: string&) -> string
+    fn copy(self: string~) -> string
     {
-        cpy := string(new char : self@.data.size(), self@.size);
-        cpy.append(self@.get());
+        cpy := string(new char : self.data.size(), self.size);
+        cpy.append(self.get());
         return cpy;
     }
 
-    fn assign(self: string&, other: string&)
+    fn assign(self: string~, other: string~)
     {
         # Resize self if needed
-        if self@.data.size() < other@.data.size() {
-            delete self@.data;
-            self@.data = new char : other@.data.size();
+        if self.data.size() < other@.data.size() {
+            delete self.data;
+            self.data = new char : other@.data.size();
         }
 
         # Copy over the data
         idx := 0u;
         while idx != other@.size {
-            self@.data[idx] = other@.data[idx];
+            self.data[idx] = other@.data[idx];
             idx = idx + 1u;
         }
 
-        self@.size = other@.size;
+        self.size = other@.size;
     }
 }
 

--- a/examples/std/vector.az
+++ b/examples/std/vector.az
@@ -4,48 +4,48 @@ struct vector
     data: i64[];
     size: u64;
 
-    fn push(self: vector&, val: i64)
+    fn push(self: vector~, val: i64)
     {
-        if (self@.size == self@.data.size()) {
-            new_cap := 2u * self@.data.size();
+        if (self.size == self.data.size()) {
+            new_cap := 2u * self.data.size();
             if new_cap == 0u {
                 new_cap = 1u;
             }
             newdata := new i64 : new_cap;
 
             idx := 0u;
-            while idx != self@.size {
-                newdata[idx] = self@.data[idx];
+            while idx != self.size {
+                newdata[idx] = self.data[idx];
                 idx = idx + 1u;
             }
 
-            delete self@.data;
-            self@.data = newdata;
+            delete self.data;
+            self.data = newdata;
         }
-        self@.data[self@.size] = val;
-        self@.size = self@.size + 1u;
+        self.data[self.size] = val;
+        self.size = self.size + 1u;
     }
 
-    fn pop(self: vector&) -> i64
+    fn pop(self: vector~) -> i64
     {
-        self@.size = self@.size - 1u;
-        ret := self@.data[self@.size];
+        self.size = self.size - 1u;
+        ret := self.data[self.size];
         return ret;
     }
 
-    fn size(self: vector&) -> u64
+    fn size(self: vector~) -> u64
     {
-        return self@.size;
+        return self.size;
     }
 
-    fn capacity(self: vector&) -> u64
+    fn capacity(self: vector~) -> u64
     {
-        return self@.data.size();
+        return self.data.size();
     }
 
-    fn drop(self: vector&)
+    fn drop(self: vector~)
     {
-        delete self@.data;
+        delete self.data;
     }
 }
 

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,8 +1,10 @@
 
-x := 5;
-y := x~;
+struct foo
+{
+    val: i64;
 
-p := y&;
-p@ = 10;
+    fn bar(self: foo~) { println(self.val); }
+}
 
-println(x);
+f := foo(1);
+f.bar();

--- a/examples/test.az
+++ b/examples/test.az
@@ -2,7 +2,8 @@
 
 
 
-str := "abc";
-for c in str {
-    println(c);
+arr := ['1', '2', '3'];
+
+for x in arr {
+    println(x);
 }

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,16 +1,23 @@
+import std/string.az;
 
-struct foo
-{
-    val: i64;
-    fn assign(self: foo~, other: foo~)
-    {
-        println("assign");
-        self.val = other.val;
-    }
-}
+s := new_string();
+s.append_char('a');
+s.append_char('b');
+s.append("cdef");
+println(s.get());
 
-a := foo(1);
-b := foo(3);
-
-a = b;
-println(a.val);
+#struct foo
+#{
+#    val: i64;
+#    fn assign(self: foo~, other: foo~)
+#    {
+#        println("assign");
+#        self.val = other.val;
+#    }
+#}
+#
+#a := foo(1);
+#b := foo(3);
+#
+#a = b;
+#println(a.val);

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,10 +1,4 @@
+import std/string.az;
 
-struct foo
-{
-    val: i64;
-
-    fn bar(self: foo~) { println(self.val); }
-}
-
-f := foo(1);
-f.bar();
+s := new_string("hello world");
+println(s.get());

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,23 +1,8 @@
-import std/string.az;
 
-s := new_string();
-s.append_char('a');
-s.append_char('b');
-s.append("cdef");
-println(s.get());
 
-#struct foo
-#{
-#    val: i64;
-#    fn assign(self: foo~, other: foo~)
-#    {
-#        println("assign");
-#        self.val = other.val;
-#    }
-#}
-#
-#a := foo(1);
-#b := foo(3);
-#
-#a = b;
-#println(a.val);
+
+
+str := "abc";
+for c in str {
+    println(c);
+}

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,4 +1,16 @@
-import std/string.az;
 
-s := new_string("hello world");
-println(s.get());
+struct foo
+{
+    val: i64;
+    fn assign(self: foo~, other: foo~)
+    {
+        println("assign");
+        self.val = other.val;
+    }
+}
+
+a := foo(1);
+b := foo(3);
+
+a = b;
+println(a.val);

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,9 +1,5 @@
+import std/string.az;
 
 
-
-
-arr := ['1', '2', '3'];
-
-for x in arr {
-    println(x);
-}
+s := new_string("hello world");
+println(s.get());

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -1452,7 +1452,7 @@ void push_stmt(compiler& com, const node_function_def_stmt& node)
 void push_stmt(compiler& com, const node_member_function_def_stmt& node)
 {
     const auto struct_type = make_type(node.struct_name);
-    const auto expected = concrete_ptr_type(struct_type);
+    const auto expected = concrete_reference_type(struct_type);
     const auto sig = compile_function_body(com, node.token, struct_type, node.function_name, node.sig, node.body);
 
     // Verification code

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -178,6 +178,7 @@ auto push_ptr_underlying(compiler& com, const node_expr& expr) -> type_name
     return type.remove_ref();
 }
 
+// TODO: Add an assert; this is only safe to use on fundamental types
 auto push_val_underlying(compiler& com, const node_expr& expr) -> type_name
 {
     const auto type = push_expr_val(com, expr);

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -1366,7 +1366,7 @@ void push_stmt(compiler& com, const node_assignment_stmt& node)
             push_ptr_adjust(com, i * inner_size);
 
             push_function_call(com, *assign);
-            push_value(com.program, op::pop, 1);
+            push_value(com.program, op::pop, std::size_t{1});
         }
 
         return;
@@ -1381,7 +1381,7 @@ void push_stmt(compiler& com, const node_assignment_stmt& node)
     push_ptr_underlying(com, *node.position);
     push_ptr_underlying(com, *node.expr);
     push_function_call(com, *assign);
-    push_value(com.program, op::pop, 1);
+    push_value(com.program, op::pop, std::size_t{1});
 }
 
 auto compile_function_body(

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -401,17 +401,17 @@ auto function_ends_with_return(const node_stmt& node) -> bool
 
 auto assign_fn_params(const type_name& type) -> type_names
 {
-    return { concrete_ptr_type(type), concrete_ptr_type(type) };
+    return { concrete_reference_type(type), concrete_reference_type(type) };
 }
 
 auto copy_fn_params(const type_name& type) -> type_names
 {
-    return { concrete_ptr_type(type) };
+    return { concrete_reference_type(type) };
 }
 
 auto drop_fn_params(const type_name& type) -> type_names
 {
-    return { concrete_ptr_type(type) };
+    return { concrete_reference_type(type) };
 }
 
 // Assumes that the given "push_object_ptr" is a function that compiles code to produce
@@ -980,7 +980,7 @@ auto push_expr_val(compiler& com, const node_repeat_array_expr& node) -> type_na
 
 auto push_expr_val(compiler& com, const node_addrof_expr& node) -> type_name
 {
-    const auto type = push_expr_ptr(com, *node.expr);
+    const auto type = push_ptr_underlying(com, *node.expr);
     return concrete_ptr_type(type);
 }
 
@@ -1360,9 +1360,9 @@ void push_stmt(compiler& com, const node_assignment_stmt& node)
         for (std::size_t i = 0; i != array_length(rhs); ++i) {
             push_value(com.program, op::push_call_frame);
 
-            push_expr_ptr(com, *node.position); // i-th element of dst
+            push_ptr_underlying(com, *node.position); // i-th element of dst
             push_ptr_adjust(com, i * inner_size);
-            push_expr_ptr(com, *node.expr); // i-th element of src
+            push_ptr_underlying(com, *node.expr); // i-th element of src
             push_ptr_adjust(com, i * inner_size);
 
             push_function_call(com, *assign);

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -866,15 +866,8 @@ auto push_function_arg(compiler& com, const node_expr& expr, const type_name& ex
     if (is_span_type(expected) && is_array_type(actual)) {
         push_expr_ptr(com, expr);
         push_value(com.program, op::push_u64, array_length(actual));
-        return;
-    }
-    
-    if (expected.is_ref()) {
-        if (actual.is_ref()) {
-            push_expr_val(com, expr);
-        } else {
-            push_ptr_underlying(com, expr);
-        }
+    } else if (expected.is_ref()) {
+        push_ptr_underlying(com, expr);
     } else {
         push_object_copy(com, expr, tok);
     }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -143,10 +143,10 @@ auto parse_member_access(tokenstream& tokens, node_expr_ptr& node)
     auto new_node = std::make_shared<node_expr>();
     const auto tok = tokens.consume();
     if (tokens.peek_next(token_type::left_paren)) {
-        auto addrof = std::make_shared<node_expr>();
-        auto& addrof_inner = addrof->emplace<node_addrof_expr>();
-        addrof_inner.expr = node;
-        addrof_inner.token = tok;
+        auto self = std::make_shared<node_expr>();
+        auto& self_inner = self->emplace<node_reference_expr>();
+        self_inner.expr = node;
+        self_inner.token = tok;
         auto& expr = new_node->emplace<node_call_expr>();
         expr.expr = std::make_shared<node_expr>(node_name_expr{
             .struct_name = std::make_shared<node_type>(node_expr_type{node}),
@@ -154,7 +154,7 @@ auto parse_member_access(tokenstream& tokens, node_expr_ptr& node)
         });
         expr.token = tok;
         tokens.consume_only(token_type::left_paren);
-        expr.args.push_back(addrof);
+        expr.args.push_back(self);
         tokens.consume_comma_separated_list(token_type::right_paren, [&] {
             expr.args.push_back(parse_expression(tokens));
         });


### PR DESCRIPTION
* The `self` and `other` arguments of member functions are now expected to be references, not pointers, eliminating most uses of `@.` in the examples.
* Bugfix: in `push_val_underlying`, the load was wrong; it would only load 8 bytes (size of a reference), instead of the actual size. 
* Modified `is_assignable` to support assigning from a reference to a concrete value. Previously only support from concrete to reference. The implementation of loading function args uses `push_object_copy` here so copy constructors will be correctly invoked.