### PR TITLE
Unsafe Block

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ An interpreted programming language written in C++. This started out as a stack-
     1. Create a span from an array using trailing `[]`.
     1. eg: If `l` is an array of 5 `i64`s, then `l[]` is an `int64[]`.
     1. Slicing syntax `l[0 : 2]` for creating subspans.
+    1. Arrays automatically convert to spans, useful for passing arrays to functions that accept spans as arguments.
 
 * Function Pointers:
     1. Function names resolve to function pointers which can be passed to functions.
@@ -35,6 +36,10 @@ An interpreted programming language written in C++. This started out as a stack-
 * Variables:
     * Declare with `:=` operator: `x := 5`.
     * Assign to existing variable with `=` operator: `x = 6`.
+
+* References:
+    * Similar to references in C++; cannot be rebound to different objects. Used to create aliases to existing objects and use simpler value syntax instead of pointer syntax. Soon these types will not be spellable directly and won't appear in the language; they will instead be used to implement nicer syntax across the language. A good example of this is the for-loop: the variable representing the current element is a reference, but you can treat it as if it's the original object itself.
+    * Will soon add `alias` as a keyword for creating alises of objects, as well as `read`, `mut` and `copy` as specifiers for functions arguments, which will use references where appropriate.
 
 * Comments using `#` symbol.
 
@@ -96,6 +101,14 @@ An interpreted programming language written in C++. This started out as a stack-
         }
     }
     ```
+* `unsafe` blocks:
+    ```cpp
+    unsafe
+    {
+        <body>
+    }
+    ```
+* `new` and `delete` for allocating memory. These are only useful within unsafe code and all usage should be wrapped in a safe container.
 * All the common arithmetic, comparison and logical operators. More will be implemented.
 * Builtin functions.
 
@@ -136,12 +149,6 @@ Utility Modules (in src/utility)
 -- value_ptr.hpp   : A value-semantic smart pointer
 -- views.hpp       : A collection of some helper views not in C++20
 ```
-
-# References TODO
-* Allow using sqaure brackets on references to arrays and spans.
-* Let arrays convert to spans for function arguments.
-* Refactor the compiler to call copy constructors in `push_expr_val` calls, which makes calling copy constructors more robust. Should be able to remove `push_object_copy` then.
-* Refactor for loops to use references instead of pointers.
 
 # Next Features
 * Complete modules

--- a/examples/std/vector.az
+++ b/examples/std/vector.az
@@ -55,14 +55,5 @@ fn new_vector() -> vector
     return vector(new i64 : 1u, 0u);
 }
 
-v := new_vector();
-
-v.push(4);
-v.push(7);
-v.push(8);
-
-idx := 0u;
-while idx != v.size() {
-    println(v.data[idx]);
-    idx = idx + 1u;
-}
+x := i64;
+p := x&;

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,3 +1,8 @@
 
 
 
+
+fn foo() {
+    unsafe x := new i64;
+    println(x@);
+}

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,5 +1,2 @@
-import std/string.az;
-
-
-s := new_string("hello world");
-println(s.get());
+unsafe;
+true;

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,2 +1,3 @@
-unsafe;
-true;
+
+
+

--- a/examples/test.az
+++ b/examples/test.az
@@ -3,6 +3,8 @@
 
 
 fn foo() {
-    unsafe x := new i64;
-    println(x@);
+    unsafe {
+        x := new i64;
+        delete x;
+    }
 }

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -135,6 +135,12 @@ auto print_node(const node_stmt& root, int indent) -> void
                 print_node(*seq_node, indent + 1);
             }
         },
+        [&](const node_unsafe_stmt& node) {
+            print("{}Unsafe:\n", spaces);
+            for (const auto& seq_node : node.sequence) {
+                print_node(*seq_node, indent + 1);
+            }
+        },
         [&](const node_loop_stmt& node) {
             print("{}Loop:\n", spaces);
             print("{}- Body:\n", spaces);
@@ -227,10 +233,6 @@ auto print_node(const node_stmt& root, int indent) -> void
         [&](const node_assert_stmt& node) {
             print("{}Assert:\n", spaces);
             print_node(*node.expr, indent + 1);
-        },
-        [&](const node_unsafe_stmt& node) {
-            print("{}Unsafe:\n", spaces);
-            print_node(*node.body, indent + 1);
         }
     }, root);
 }

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -227,6 +227,10 @@ auto print_node(const node_stmt& root, int indent) -> void
         [&](const node_assert_stmt& node) {
             print("{}Assert:\n", spaces);
             print_node(*node.expr, indent + 1);
+        },
+        [&](const node_unsafe_stmt& node) {
+            print("{}Unsafe:\n", spaces);
+            print_node(*node.body, indent + 1);
         }
     }, root);
 }

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -240,6 +240,13 @@ struct node_sequence_stmt
     anzu::token token;
 };
 
+struct node_unsafe_stmt
+{
+    std::vector<node_stmt_ptr> sequence;
+
+    anzu::token token;
+};
+
 struct node_loop_stmt
 {
     node_stmt_ptr body;
@@ -355,16 +362,10 @@ struct node_assert_stmt
     anzu::token token;
 };
 
-struct node_unsafe_stmt
-{
-    node_stmt_ptr body;
-
-    anzu::token token;
-};
-
 
 struct node_stmt : std::variant<
     node_sequence_stmt,
+    node_unsafe_stmt,
     node_loop_stmt,
     node_while_stmt,
     node_for_stmt,
@@ -379,8 +380,7 @@ struct node_stmt : std::variant<
     node_expression_stmt,
     node_return_stmt,
     node_delete_stmt,
-    node_assert_stmt,
-    node_unsafe_stmt>
+    node_assert_stmt>
 {
 };
 

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -355,6 +355,14 @@ struct node_assert_stmt
     anzu::token token;
 };
 
+struct node_unsafe_stmt
+{
+    node_stmt_ptr body;
+
+    anzu::token token;
+};
+
+
 struct node_stmt : std::variant<
     node_sequence_stmt,
     node_loop_stmt,
@@ -371,7 +379,8 @@ struct node_stmt : std::variant<
     node_expression_stmt,
     node_return_stmt,
     node_delete_stmt,
-    node_assert_stmt>
+    node_assert_stmt,
+    node_unsafe_stmt>
 {
 };
 

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -1070,10 +1070,8 @@ auto push_expr_val(compiler& com, const node_span_expr& node) -> type_name
 
 auto push_expr_val(compiler& com, const node_new_expr& node) -> type_name
 {
-    // TODO: Combine all scope info into one stack, really we should be able to write
-    // com.current_scope().is_unsafe() since safeness is a property of the 
     if (!in_unsafe(com)) {
-        node.token.error("Cannot have a new statement outside of an unsafe block");
+        node.token.error("Cannot have a 'new' statement outside of an unsafe block");
     }
 
     if (node.size) {
@@ -1515,6 +1513,10 @@ void push_stmt(compiler& com, const node_expression_stmt& node)
 
 void push_stmt(compiler& com, const node_delete_stmt& node)
 {
+    if (!in_unsafe(com)) {
+        node.token.error("Cannot have a 'delete' statement outside of an unsafe block");
+    }
+
     const auto type = type_of_expr(com, *node.expr);
     if (is_span_type(type)) {
         push_expr_val(com, *node.expr);

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -1511,6 +1511,11 @@ void push_stmt(compiler& com, const node_assert_stmt& node)
     }
 }
 
+void push_stmt(compiler& com, const node_unsafe_stmt& node)
+{
+
+}
+
 auto push_expr_val(compiler& com, const node_expr& expr) -> type_name
 {
     return std::visit([&](const auto& node) { return push_expr_val(com, node); }, expr);

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -81,6 +81,7 @@ auto identifier_type(std::string_view token) -> token_type
     if (token == "true")     return token_type::kw_true;
     if (token == "typeof")   return token_type::kw_typeof;
     if (token == "u64")      return token_type::kw_u64;
+    if (token == "unsafe")   return token_type::kw_unsafe;
     if (token == "while")    return token_type::kw_while;
     return token_type::identifier;
 }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -597,8 +597,13 @@ auto parse_unsafe_stmt(tokenstream& tokens) -> node_stmt_ptr
 {
     auto node = std::make_shared<node_stmt>();
     auto& stmt = node->emplace<node_unsafe_stmt>();
+
     stmt.token = tokens.consume_only(token_type::kw_unsafe);
-    stmt.body = parse_statement(tokens);
+    tokens.consume_only(token_type::left_brace);
+    while (!tokens.consume_maybe(token_type::right_brace)) {
+        stmt.sequence.push_back(parse_statement(tokens));
+    }
+
     return node;
 }
 
@@ -632,10 +637,10 @@ auto parse_statement(tokenstream& tokens) -> node_stmt_ptr
         case token_type::kw_if:       return parse_if_stmt(tokens);
         case token_type::kw_delete:   return parse_delete_stmt(tokens);
         case token_type::kw_assert:   return parse_assert_stmt(tokens);
-        case token_type::kw_unsafe:   return parse_unsafe_stmt(tokens);
         case token_type::kw_break:    return parse_break_stmt(tokens);
         case token_type::kw_continue: return parse_continue_stmt(tokens);
         case token_type::left_brace:  return parse_braced_statement_list(tokens);
+        case token_type::kw_unsafe:   return parse_unsafe_stmt(tokens);
     }
 
     if (tokens.peek(token_type::identifier) && tokens.peek_next(token_type::colon_equal)) {

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -593,6 +593,15 @@ auto parse_assert_stmt(tokenstream& tokens) -> node_stmt_ptr
     return node;
 }
 
+auto parse_unsafe_stmt(tokenstream& tokens) -> node_stmt_ptr
+{
+    auto node = std::make_shared<node_stmt>();
+    auto& stmt = node->emplace<node_unsafe_stmt>();
+    stmt.token = tokens.consume_only(token_type::kw_unsafe);
+    stmt.body = parse_statement(tokens);
+    return node;
+}
+
 auto parse_break_stmt(tokenstream& tokens) -> node_stmt_ptr
 {
     auto ret = std::make_shared<node_stmt>(node_break_stmt{ tokens.consume() });
@@ -623,6 +632,7 @@ auto parse_statement(tokenstream& tokens) -> node_stmt_ptr
         case token_type::kw_if:       return parse_if_stmt(tokens);
         case token_type::kw_delete:   return parse_delete_stmt(tokens);
         case token_type::kw_assert:   return parse_assert_stmt(tokens);
+        case token_type::kw_unsafe:   return parse_unsafe_stmt(tokens);
         case token_type::kw_break:    return parse_break_stmt(tokens);
         case token_type::kw_continue: return parse_continue_stmt(tokens);
         case token_type::left_brace:  return parse_braced_statement_list(tokens);

--- a/src/token.cpp
+++ b/src/token.cpp
@@ -69,6 +69,7 @@ auto to_string(token_type tt) -> std::string_view
         case token_type::kw_true:             return "true";
         case token_type::kw_typeof:           return "typeof";
         case token_type::kw_u64:              return "u64";
+        case token_type::kw_unsafe:           return "unsafe";
         case token_type::kw_while:            return "while";
         case token_type::left_brace:          return "{";        
         case token_type::left_bracket:        return "[";        

--- a/src/token.hpp
+++ b/src/token.hpp
@@ -56,6 +56,7 @@ enum class token_type
     kw_true,
     kw_typeof,
     kw_u64,
+    kw_unsafe,
     kw_while,
     left_brace,
     left_bracket,


### PR DESCRIPTION
* Added `unsafe { ... }` syntax. Certain language features will only be usable in unsafe blocks.
* `new` and `delete` are only usable in unsafe code.
* Motivation for this is to add a version of `reinterpret_cast` and placement-new, which will allow a better vector implementation written purely in anzu. Vector will need to store a span of bytes rather than actual objects in order to avoid needing to call constructors for the "empty" elements. Currently the vector of ints zeroes all elements, which isn't generic enough (of course, a generic vector requires templates, but that's another problem to solve).
* The scope logic is all a bit messy, it would be good to refactor it all into a single data structure.