### PR TITLE
Improve Unsafe Blocks and Type Parsing

### DIFF
--- a/examples/std/string.az
+++ b/examples/std/string.az
@@ -118,6 +118,3 @@ fn new_string(data: char[]) -> string
     str.append(data);
     return str;
 }
-
-s := new_string("hello world");
-println(s.get());

--- a/examples/std/string.az
+++ b/examples/std/string.az
@@ -7,20 +7,22 @@ struct string
     fn append_char(self: string~, c: char)
     {
         if (self.size == self.data.size()) {
-            new_cap := 2u * self.data.size();
-            if new_cap == 0u {
-                new_cap = 1u;
-            }
-            newdata := new char : new_cap;
+            unsafe {
+                new_cap := 2u * self.data.size();
+                if new_cap == 0u {
+                    new_cap = 1u;
+                }
+                newdata := new char : new_cap;
 
-            idx := 0u;
-            while idx != self.size {
-                newdata[idx] = self.data[idx];
-                idx = idx + 1u;
-            }
+                idx := 0u;
+                while idx != self.size {
+                    newdata[idx] = self.data[idx];
+                    idx = idx + 1u;
+                }
 
-            delete self.data;
-            self.data = newdata;
+                delete self.data;
+                self.data = newdata;
+            }
         }
         self.data[self.size] = c;
         self.size = self.size + 1u;      
@@ -55,7 +57,7 @@ struct string
         self.append(value);
     }
 
-    fn transform(self: string~, func: (char&) -> null)
+    fn transform(self: string~, func: fn(char&) -> null)
     {
         span := self.get();
         for c in span {
@@ -67,22 +69,28 @@ struct string
 
     fn drop(self: string~)
     {
-        delete self.data;
+        unsafe {
+            delete self.data;
+        }
     }
 
     fn copy(self: string~) -> string
     {
-        cpy := string(new char : self.data.size(), self.size);
-        cpy.append(self.get());
-        return cpy;
+        unsafe {
+            cpy := string(new char : self.data.size(), self.size);
+            cpy.append(self.get());
+            return cpy;
+        }
     }
 
     fn assign(self: string~, other: string~)
     {
         # Resize self if needed
         if self.data.size() < other.data.size() {
-            delete self.data;
-            self.data = new char : other.data.size();
+            unsafe {
+                delete self.data;
+                self.data = new char : other.data.size();
+            }
         }
 
         # Copy over the data
@@ -99,7 +107,9 @@ struct string
 fn new_string() -> string
 {
     # We don't have nullptr yet, so we must allocate some space here for now
-    return string(new char : 1u, 0u);
+    unsafe {
+        return string(new char : 1u, 0u);
+    }
 }
 
 fn new_string(data: char[]) -> string
@@ -108,3 +118,6 @@ fn new_string(data: char[]) -> string
     str.append(data);
     return str;
 }
+
+s := new_string("hello world");
+println(s.get());

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,21 +1,26 @@
 
 
-fn foo(x: fn(i64) -> bool[3u])
+fn foo(x: (fn(i64) -> bool)[3u])
 {
-    y := x(-5);
-    println(y[0u]);
-    println(y[1u]);
-    println(y[2u]);
-
-    y = x(5);
-    println(y[0u]);
-    println(y[1u]);
-    println(y[2u]);
+    println(x[0u](0));
+    println(x[1u](0));
+    println(x[2u](0));
 }
 
-fn cb(x1: i64) -> bool[3u]
+fn positive(x: i64) -> bool
 {
-    return [x1 > 0, x1 < 0, x1 == 0];
+    return x > 0;
 }
 
-foo(cb);
+fn negative(x: i64) -> bool
+{
+    return x < 0;
+}
+
+fn zero(x: i64) -> bool
+{
+    return x == 0;
+}
+
+ops := [positive, negative, zero];
+foo(ops);

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,6 +1,2 @@
-variable := 0;
-fn typeof_example(y: typeof(variable)) -> i64
-{
-    return y + y;
-}
-println(typeof_example(3)); # no error here!
+
+x := -5;

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,2 +1,21 @@
 
-x := -5;
+
+fn foo(x: fn(i64) -> bool[3u])
+{
+    y := x(-5);
+    println(y[0u]);
+    println(y[1u]);
+    println(y[2u]);
+
+    y = x(5);
+    println(y[0u]);
+    println(y[1u]);
+    println(y[2u]);
+}
+
+fn cb(x1: i64) -> bool[3u]
+{
+    return [x1 > 0, x1 < 0, x1 == 0];
+}
+
+foo(cb);

--- a/src/bytecode.cpp
+++ b/src/bytecode.cpp
@@ -34,7 +34,6 @@ auto unary_op(bytecode_context& ctx) -> void
 {
     static constexpr auto op = Op<Type>{};
     const auto obj = pop_value<Type>(ctx.stack);
-    print("obj = {}\n", obj);
     push_value(ctx.stack, op(obj));
 }
 

--- a/src/bytecode.cpp
+++ b/src/bytecode.cpp
@@ -34,6 +34,7 @@ auto unary_op(bytecode_context& ctx) -> void
 {
     static constexpr auto op = Op<Type>{};
     const auto obj = pop_value<Type>(ctx.stack);
+    print("obj = {}\n", obj);
     push_value(ctx.stack, op(obj));
 }
 

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -673,75 +673,75 @@ auto push_expr_val(compiler& com, const node_binary_op_expr& node) -> type_name
     const auto& type = lhs;
     if (type == char_type()) {
         switch (node.token.type) {
-            case tt::equal_equal: push_value(com.program, op::char_eq); return bool_type();
-            case tt::bang_equal:  push_value(com.program, op::char_ne); return bool_type();
+            case tt::equal_equal: { push_value(com.program, op::char_eq); return bool_type(); }
+            case tt::bang_equal:  { push_value(com.program, op::char_ne); return bool_type(); }
         }
     }
     else if (type == i32_type()) {
         switch (node.token.type) {
-            case tt::plus:          push_value(com.program, op::i32_add); return type;
-            case tt::minus:         push_value(com.program, op::i32_sub); return type;
-            case tt::star:          push_value(com.program, op::i32_mul); return type;
-            case tt::slash:         push_value(com.program, op::i32_div); return type;
-            case tt::percent:       push_value(com.program, op::i32_mod); return type;
-            case tt::equal_equal:   push_value(com.program, op::i32_eq); return bool_type();
-            case tt::bang_equal:    push_value(com.program, op::i32_ne); return bool_type();
-            case tt::less:          push_value(com.program, op::i32_lt); return bool_type();
-            case tt::less_equal:    push_value(com.program, op::i32_le); return bool_type();
-            case tt::greater:       push_value(com.program, op::i32_gt); return bool_type();
-            case tt::greater_equal: push_value(com.program, op::i32_ge); return bool_type();
+            case tt::plus:          { push_value(com.program, op::i32_add); return type;       }
+            case tt::minus:         { push_value(com.program, op::i32_sub); return type;       }
+            case tt::star:          { push_value(com.program, op::i32_mul); return type;       }
+            case tt::slash:         { push_value(com.program, op::i32_div); return type;       }
+            case tt::percent:       { push_value(com.program, op::i32_mod); return type;       }
+            case tt::equal_equal:   { push_value(com.program, op::i32_eq); return bool_type(); }
+            case tt::bang_equal:    { push_value(com.program, op::i32_ne); return bool_type(); }
+            case tt::less:          { push_value(com.program, op::i32_lt); return bool_type(); }
+            case tt::less_equal:    { push_value(com.program, op::i32_le); return bool_type(); }
+            case tt::greater:       { push_value(com.program, op::i32_gt); return bool_type(); }
+            case tt::greater_equal: { push_value(com.program, op::i32_ge); return bool_type(); }
         }
     }
     else if (type == i64_type()) {
         switch (node.token.type) {
-            case tt::plus:          push_value(com.program, op::i64_add); return type;
-            case tt::minus:         push_value(com.program, op::i64_sub); return type;
-            case tt::star:          push_value(com.program, op::i64_mul); return type;
-            case tt::slash:         push_value(com.program, op::i64_div); return type;
-            case tt::percent:       push_value(com.program, op::i64_mod); return type;
-            case tt::equal_equal:   push_value(com.program, op::i64_eq); return bool_type();
-            case tt::bang_equal:    push_value(com.program, op::i64_ne); return bool_type();
-            case tt::less:          push_value(com.program, op::i64_lt); return bool_type();
-            case tt::less_equal:    push_value(com.program, op::i64_le); return bool_type();
-            case tt::greater:       push_value(com.program, op::i64_gt); return bool_type();
-            case tt::greater_equal: push_value(com.program, op::i64_ge); return bool_type();
+            case tt::plus:          { push_value(com.program, op::i64_add); return type;       }
+            case tt::minus:         { push_value(com.program, op::i64_sub); return type;       }
+            case tt::star:          { push_value(com.program, op::i64_mul); return type;       }
+            case tt::slash:         { push_value(com.program, op::i64_div); return type;       }
+            case tt::percent:       { push_value(com.program, op::i64_mod); return type;       }
+            case tt::equal_equal:   { push_value(com.program, op::i64_eq); return bool_type(); }
+            case tt::bang_equal:    { push_value(com.program, op::i64_ne); return bool_type(); }
+            case tt::less:          { push_value(com.program, op::i64_lt); return bool_type(); }
+            case tt::less_equal:    { push_value(com.program, op::i64_le); return bool_type(); }
+            case tt::greater:       { push_value(com.program, op::i64_gt); return bool_type(); }
+            case tt::greater_equal: { push_value(com.program, op::i64_ge); return bool_type(); }
         }
     }
     else if (type == u64_type()) {
         switch (node.token.type) {
-            case tt::plus:          push_value(com.program, op::u64_add); return type;
-            case tt::minus:         push_value(com.program, op::u64_sub); return type;
-            case tt::star:          push_value(com.program, op::u64_mul); return type;
-            case tt::slash:         push_value(com.program, op::u64_div); return type;
-            case tt::percent:       push_value(com.program, op::u64_mod); return type;
-            case tt::equal_equal:   push_value(com.program, op::u64_eq); return bool_type();
-            case tt::bang_equal:    push_value(com.program, op::u64_ne); return bool_type();
-            case tt::less:          push_value(com.program, op::u64_lt); return bool_type();
-            case tt::less_equal:    push_value(com.program, op::u64_le); return bool_type();
-            case tt::greater:       push_value(com.program, op::u64_gt); return bool_type();
-            case tt::greater_equal: push_value(com.program, op::u64_ge); return bool_type();
+            case tt::plus:          { push_value(com.program, op::u64_add); return type;       }
+            case tt::minus:         { push_value(com.program, op::u64_sub); return type;       }
+            case tt::star:          { push_value(com.program, op::u64_mul); return type;       }
+            case tt::slash:         { push_value(com.program, op::u64_div); return type;       }
+            case tt::percent:       { push_value(com.program, op::u64_mod); return type;       }
+            case tt::equal_equal:   { push_value(com.program, op::u64_eq); return bool_type(); }
+            case tt::bang_equal:    { push_value(com.program, op::u64_ne); return bool_type(); }
+            case tt::less:          { push_value(com.program, op::u64_lt); return bool_type(); }
+            case tt::less_equal:    { push_value(com.program, op::u64_le); return bool_type(); }
+            case tt::greater:       { push_value(com.program, op::u64_gt); return bool_type(); }
+            case tt::greater_equal: { push_value(com.program, op::u64_ge); return bool_type(); }
         }
     }
     else if (type == f64_type()) {
         switch (node.token.type) {
-            case tt::plus:          push_value(com.program, op::f64_add); return type;
-            case tt::minus:         push_value(com.program, op::f64_sub); return type;
-            case tt::star:          push_value(com.program, op::f64_mul); return type;
-            case tt::slash:         push_value(com.program, op::f64_div); return type;
-            case tt::equal_equal:   push_value(com.program, op::f64_eq); return bool_type();
-            case tt::bang_equal:    push_value(com.program, op::f64_ne); return bool_type();
-            case tt::less:          push_value(com.program, op::f64_lt); return bool_type();
-            case tt::less_equal:    push_value(com.program, op::f64_le); return bool_type();
-            case tt::greater:       push_value(com.program, op::f64_gt); return bool_type();
-            case tt::greater_equal: push_value(com.program, op::f64_ge); return bool_type();
+            case tt::plus:          { push_value(com.program, op::f64_add); return type;       }
+            case tt::minus:         { push_value(com.program, op::f64_sub); return type;       }
+            case tt::star:          { push_value(com.program, op::f64_mul); return type;       }
+            case tt::slash:         { push_value(com.program, op::f64_div); return type;       }
+            case tt::equal_equal:   { push_value(com.program, op::f64_eq); return bool_type(); }
+            case tt::bang_equal:    { push_value(com.program, op::f64_ne); return bool_type(); }
+            case tt::less:          { push_value(com.program, op::f64_lt); return bool_type(); }
+            case tt::less_equal:    { push_value(com.program, op::f64_le); return bool_type(); }
+            case tt::greater:       { push_value(com.program, op::f64_gt); return bool_type(); }
+            case tt::greater_equal: { push_value(com.program, op::f64_ge); return bool_type(); }
         }
     }
     else if (type == bool_type()) {
         switch (node.token.type) {
-            case tt::ampersand_ampersand: push_value(com.program, op::bool_and); return type;
-            case tt::bar_bar:             push_value(com.program, op::bool_or);  return type;
-            case tt::equal_equal:         push_value(com.program, op::bool_eq);  return type;
-            case tt::bang_equal:          push_value(com.program, op::bool_ne);  return type;
+            case tt::ampersand_ampersand: { push_value(com.program, op::bool_and); return type; }
+            case tt::bar_bar:             { push_value(com.program, op::bool_or);  return type; }
+            case tt::equal_equal:         { push_value(com.program, op::bool_eq);  return type; }
+            case tt::bang_equal:          { push_value(com.program, op::bool_ne);  return type; }
         }
     }
 
@@ -755,12 +755,12 @@ auto push_expr_val(compiler& com, const node_unary_op_expr& node) -> type_name
 
     switch (node.token.type) {
         case tt::minus: {
-            if (type == i32_type()) push_value(com.program, op::i32_neg); return type;
-            if (type == i64_type()) push_value(com.program, op::i64_neg); return type;
-            if (type == f64_type()) push_value(com.program, op::f64_neg); return type;
+            if (type == i32_type()) { push_value(com.program, op::i32_neg); return type; }
+            if (type == i64_type()) { push_value(com.program, op::i64_neg); return type; }
+            if (type == f64_type()) { push_value(com.program, op::f64_neg); return type; }
         } break;
         case tt::bang: {
-            if (type == bool_type()) push_value(com.program, op::bool_not); return type;
+            if (type == bool_type()) { push_value(com.program, op::bool_not); return type; }
         } break;
     }
     node.token.error("could not find op '{}{}'", node.token.type, type);

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -240,14 +240,25 @@ auto get_constructor_params(const compiler& com, const type_name& type) -> std::
     return params;
 }
 
+// TODO: Generalise further
 auto function_ends_with_return(const node_stmt& node) -> bool
 {
     if (std::holds_alternative<node_sequence_stmt>(node)) {
         const auto& seq = std::get<node_sequence_stmt>(node).sequence;
-        if (seq.empty() || !std::holds_alternative<node_return_stmt>(*seq.back())) {
+        if (seq.empty()) {
             return false;
         }
-        return true;
+        if (std::holds_alternative<node_return_stmt>(*seq.back())) {
+            return true;
+        }
+        if (std::holds_alternative<node_unsafe_stmt>(*seq.back())) {
+            const auto& back = std::get<node_unsafe_stmt>(*seq.back());
+            if (back.sequence.empty() || !std::holds_alternative<node_return_stmt>(*back.sequence.back())) {
+                return false;
+            }
+            return true;
+        }
+        return false;
     }
     return std::holds_alternative<node_return_stmt>(node);
 }

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -69,7 +69,7 @@ auto to_string(const type_array& type) -> std::string
 
 auto to_string(const type_ptr& type) -> std::string
 {
-    return std::format("&{}", to_string(*type.inner_type));
+    return std::format("{}&", to_string(*type.inner_type));
 }
 
 auto to_string(const type_span& type) -> std::string
@@ -79,7 +79,12 @@ auto to_string(const type_span& type) -> std::string
 
 auto to_string(const type_function_ptr& type) -> std::string
 {
-    return std::format("({}) -> {}", format_comma_separated(type.param_types), *type.return_type);
+    return std::format(
+        "{}({}) -> {}",
+        to_string(token_type::kw_function),
+        format_comma_separated(type.param_types),
+        *type.return_type
+    );
 }
 
 auto to_string(const type_reference& type) -> std::string

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -351,6 +351,13 @@ auto parse_simple_type(tokenstream& tokens) -> type_name
 
 auto parse_type(tokenstream& tokens) -> type_name
 {
+    // Parens take highest precendence
+    if (tokens.consume_maybe(token_type::left_paren)) {
+        auto type = parse_type(tokens);
+        tokens.consume_only(token_type::right_paren);
+        return type;
+    }
+
     // Function pointers
     if (tokens.consume_maybe(token_type::kw_function)) {
         tokens.consume_only(token_type::left_paren);

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -351,13 +351,6 @@ auto parse_simple_type(tokenstream& tokens) -> type_name
 
 auto parse_type(tokenstream& tokens) -> type_name
 {
-    // Parens take highest precendence
-    if (tokens.consume_maybe(token_type::left_paren)) {
-        auto type = parse_type(tokens);
-        tokens.consume_only(token_type::right_paren);
-        return type;
-    }
-
     // Function pointers
     if (tokens.consume_maybe(token_type::kw_function)) {
         tokens.consume_only(token_type::left_paren);
@@ -370,7 +363,14 @@ auto parse_type(tokenstream& tokens) -> type_name
         return ret;
     }
 
-    auto type = parse_simple_type(tokens);
+    auto type = null_type();
+    if (tokens.consume_maybe(token_type::left_paren)) {
+        type = parse_type(tokens);
+        tokens.consume_only(token_type::right_paren);
+    } else {
+        type = parse_simple_type(tokens);
+    }
+
     while (true) {
         if (tokens.consume_maybe(token_type::left_bracket)) {
             if (tokens.consume_maybe(token_type::right_bracket)) {

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -352,7 +352,8 @@ auto parse_simple_type(tokenstream& tokens) -> type_name
 auto parse_type(tokenstream& tokens) -> type_name
 {
     // Function pointers
-    if (tokens.consume_maybe(token_type::left_paren)) {
+    if (tokens.consume_maybe(token_type::kw_function)) {
+        tokens.consume_only(token_type::left_paren);
         auto ret = type_function_ptr{};
         tokens.consume_comma_separated_list(token_type::right_paren, [&]{
             ret.param_types.push_back(parse_type(tokens));


### PR DESCRIPTION
* Updated the standard string to use `unsafe` around `new` and `delete`, completely broken before.
* Made the check for a return statement more flexible. Previously, a non-null returning function required the last statement in the function be a `return` statement. Now, the last statement can also be an `unsafe` block, provided the last statement in the block is a `return`. This can generalise to `if` statements too.
* Unary and binary operations were completely broken, with only `+` working. Should always add braces! Now it all works correctly. Only spotted it because I tried printing `x := -5` and was seeing 5.
* Function pointer types are now spelled with a `fn` at the front, eg `fn(i64) -> bool`. This makes it unambiguous to parse, and also...
* Parens are now allowed within types, making is possible to distinguish between `(fn(i64) -> bool)[3u]` and `fn(i64) -> (bool[3u])`. This does mean printing types is now non-trivial, and both will print as `fn(i64) -> bool[3u]` like before. Will need to fix. How?