### PR TITLE
Improve Type Printing

### DIFF
--- a/examples/test.az
+++ b/examples/test.az
@@ -1,26 +1,4 @@
 
 
-fn foo(x: (fn(i64) -> bool)[3u])
-{
-    println(x[0u](0));
-    println(x[1u](0));
-    println(x[2u](0));
-}
-
-fn positive(x: i64) -> bool
-{
-    return x > 0;
-}
-
-fn negative(x: i64) -> bool
-{
-    return x < 0;
-}
-
-fn zero(x: i64) -> bool
-{
-    return x == 0;
-}
-
-ops := [positive, negative, zero];
-foo(ops);
+fn foo1(_: i64~) {}
+fn foo2(x: (i64~)[3u]) {}

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -37,6 +37,14 @@ auto type_name::remove_ref() const -> type_name
     return remove_reference(*this);
 }
 
+auto to_string_paren(const type_name& type) -> std::string
+{
+    const auto str = to_string(type);
+    if (str.contains(' ')) {
+        return std::format("({})", str);
+    }
+    return str;
+}
 
 auto to_string(const type_name& type) -> std::string
 {
@@ -64,17 +72,17 @@ auto to_string(const type_struct& type) -> std::string
 
 auto to_string(const type_array& type) -> std::string
 {
-    return std::format("{}[{}]", to_string(*type.inner_type), type.count);
+    return std::format("{}[{}]", to_string_paren(*type.inner_type), type.count);
 }
 
 auto to_string(const type_ptr& type) -> std::string
 {
-    return std::format("{}&", to_string(*type.inner_type));
+    return std::format("{}&", to_string_paren(*type.inner_type));
 }
 
 auto to_string(const type_span& type) -> std::string
 {
-    return std::format("{}[]", to_string(*type.inner_type));
+    return std::format("{}[]", to_string_paren(*type.inner_type));
 }
 
 auto to_string(const type_function_ptr& type) -> std::string
@@ -82,14 +90,14 @@ auto to_string(const type_function_ptr& type) -> std::string
     return std::format(
         "{}({}) -> {}",
         to_string(token_type::kw_function),
-        format_comma_separated(type.param_types),
+        format_comma_separated(type.param_types, to_string_paren),
         *type.return_type
     );
 }
 
 auto to_string(const type_reference& type) -> std::string
 {
-    return std::format("{}~", to_string(*type.inner_type));
+    return std::format("ref {}", to_string_paren(*type.inner_type));
 }
 
 auto hash(const type_name& type) -> std::size_t

--- a/src/token.cpp
+++ b/src/token.cpp
@@ -54,7 +54,7 @@ auto to_string(token_type tt) -> std::string_view
         case token_type::kw_f64:              return "f64";
         case token_type::kw_false:            return "false";
         case token_type::kw_for:              return "for";
-        case token_type::kw_function:         return "function";
+        case token_type::kw_function:         return "fn";
         case token_type::kw_i32:              return "i32";
         case token_type::kw_i64:              return "i64";
         case token_type::kw_if:               return "if";


### PR DESCRIPTION
* When printing types, if a subtype has a space in it, add parens around it, so you can distinguish (for example) `fn(i64) -> bool[3u]` from `(fn(i64) -> bool)[3u]`.
* Changed the string representation of `kw_function` from "function" to "fn" to match the language.