### PR TITLE
Const Member Functions

### DIFF
--- a/examples/test.az
+++ b/examples/test.az
@@ -1,0 +1,15 @@
+
+struct foo
+{
+    #fn bar(self: (const foo)~) {
+    #    println("const");
+    #}
+    fn bar(self: foo~) {
+        println("non-const");
+    }
+}
+let f := foo();
+f.bar();
+
+
+

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,15 +1,10 @@
 
-struct foo
-{
-    fn bar(self: (const foo)~) {
-        println("const by ref");
-    }
-    fn bar(self: foo~) {
-        println("non-const");
-    }
-}
-let f := foo();
-f.bar();
+let a := 5;
+var b := 6;
 
+let c := a~;
+#var d := a~;
+let e := b~;
+var f := b~;
 
-
+__dump_type(a, b, c, e, f);

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,9 +1,9 @@
 
 struct foo
 {
-    #fn bar(self: (const foo)~) {
-    #    println("const");
-    #}
+    fn bar(self: (const foo)~) {
+        println("const by ref");
+    }
     fn bar(self: foo~) {
         println("non-const");
     }

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -776,6 +776,7 @@ auto push_expr_val(compiler& com, const node_unary_op_expr& node) -> type_name
 }
 
 // This function is an absolute mess and need rewriting. Should also try and combine with
+// is_type_convertible_to
 [[nodiscard]] auto push_function_arg(
     compiler& com, const node_expr& expr, const type_name& expected, const token& tok
 ) -> bool
@@ -851,6 +852,17 @@ auto push_expr_val(compiler& com, const node_call_expr& node) -> type_name
                 push_value(com.program, op::push_null);
             }
             return type;
+        }
+
+        // Hack to allow for an easy way to dump types of expressions
+        if (inner.struct_name == nullptr & inner.name == "__dump_type") {
+            print("__dump_type(\n");
+            for (const auto& arg : node.args) {
+                print("    {},\n", type_of_expr(com, *arg));
+            }
+            print(")\n");
+            push_value(com.program, op::push_null);
+            return null_type();
         }
 
         // Second, it might be a function call

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -860,7 +860,7 @@ auto push_expr_val(compiler& com, const node_call_expr& node) -> type_name
             params.push_back(type_of_expr(com, *arg));
         }
         
-        const auto struct_type = resolve_type(com, node.token, inner.struct_name);
+        const auto struct_type = resolve_type(com, node.token, inner.struct_name).remove_cr();
         if (const auto func = get_function(com, struct_type, inner.name, params); func) {
             push_value(com.program, op::push_call_frame);
             for (std::size_t i = 0; i != node.args.size(); ++i) {

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -363,7 +363,7 @@ auto is_type_convertible_to(const type_name& type, const type_name& expected) ->
 // Type A is convertible to B is A == ref B or B == ref A. TODO: Consider value categories,
 // rvalues should not be bindable to references
 auto are_types_convertible_to(const std::vector<type_name>& args,
-                       const std::vector<type_name>& actuals) -> bool
+                              const std::vector<type_name>& actuals) -> bool
 {
     if (args.size() != actuals.size()) return false;
     for (std::size_t i = 0; i != args.size(); ++i) {


### PR DESCRIPTION
* Given how member functions are implemented (as just regular function calls), the only reason this wasn't working was due to a bug; the struct name is used as the namespace when searching for the funciton, but `const` wasn't being stripped off, so the function couldn't be found..
* Also added `__dump_type` compiler intrinsic function for dumping out types of variables.