### PR TITLE
Conversion Code Refactor

### DIFF
--- a/examples/test.az
+++ b/examples/test.az
@@ -1,10 +1,45 @@
 
-let a := 5;
-var b := 6;
+fn min(a: f64, b: f64) -> f64
+{
+    if (a < b) { return a; } else { return b; }
+}
 
-let c := a~;
-#var d := a~;
-let e := b~;
-var f := b~;
+fn max(a: f64, b: f64) -> f64
+{
+    if (a > b) { return a; } else { return b; }
+}
 
-__dump_type(a, b, c, e, f);
+fn root(n: f64) -> f64
+{
+    var lo := min(1.0, n);
+    var hi := max(1.0, n);
+    var mid := 0.0;
+
+    while 100.0 * lo * lo < n {
+        lo = lo * 10.0;
+    }
+
+    while 0.01 * hi * hi > n {
+        hi = hi * 0.1;
+    }
+
+    var count := 0;
+    while count < 100 {
+        mid = (lo + hi) / 2.0;
+        if (mid * mid > n) {
+            hi = mid;
+        } else {
+            lo = mid;
+        }
+        count = count + 1;
+    }
+    return mid;
+}
+
+var count := 0;
+while count < 1000 {
+    sqrt(10.0);
+    count = count + 1;
+}
+println(sqrt(10.0));
+println(root(10.0));

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,45 +1,5 @@
+fn foo(x: const i64) {}
 
-fn min(a: f64, b: f64) -> f64
-{
-    if (a < b) { return a; } else { return b; }
-}
-
-fn max(a: f64, b: f64) -> f64
-{
-    if (a > b) { return a; } else { return b; }
-}
-
-fn root(n: f64) -> f64
-{
-    var lo := min(1.0, n);
-    var hi := max(1.0, n);
-    var mid := 0.0;
-
-    while 100.0 * lo * lo < n {
-        lo = lo * 10.0;
-    }
-
-    while 0.01 * hi * hi > n {
-        hi = hi * 0.1;
-    }
-
-    var count := 0;
-    while count < 100 {
-        mid = (lo + hi) / 2.0;
-        if (mid * mid > n) {
-            hi = mid;
-        } else {
-            lo = mid;
-        }
-        count = count + 1;
-    }
-    return mid;
-}
-
-var count := 0;
-while count < 1000 {
-    sqrt(10.0);
-    count = count + 1;
-}
-println(sqrt(10.0));
-println(root(10.0));
+var x := 50;
+foo(x);
+println(x);

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,5 +1,6 @@
-fn foo(x: const i64) {}
+fn foo(x: i64~) { x = 6; }
 
-var x := 50;
+var x := 5;
 foo(x);
+
 println(x);

--- a/examples/test.az
+++ b/examples/test.az
@@ -2,5 +2,4 @@ fn foo(x: i64~) { x = 6; }
 
 var x := 5;
 foo(x);
-
 println(x);

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,5 +1,2 @@
-fn foo(x: i64~) { x = 6; }
-
-var x := 5;
-foo(x);
-println(x);
+    var idx := 0;
+    print(idx);

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -856,6 +856,12 @@ auto is_type_convertible_to(const type_name& type, const type_name& expected) ->
         || (expected.add_const() == type && !type.is_ref());
 }
 
+auto get_converter(const type_name& src, const type_name& dst)
+    -> std::optional<std::function<void(compiler&, const node_expr&, const type_name&, const token&)>>
+{
+    return std::nullopt;
+}
+
 // Checks if the set of given args is convertible to the signature for a function.
 // Type A is convertible to B is A == ref B or B == ref A. TODO: Consider value categories,
 // rvalues should not be bindable to references

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -809,7 +809,7 @@ auto get_converter(const type_name& src, const type_name& dst)
         };
     }
 
-    // Values can convert to references (removing const taken care of above)
+    // Values can convert to references (except const -> non-const but that's above)
     //              val -> ref (const) val : ptr
     //        const val -> ref  const  val : ptr
     if (!src_is_ref && dst_is_ref) {

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -811,7 +811,7 @@ auto get_converter(const type_name& src, const type_name& dst)
     //    ref       val ->     const val : copy underlying
     //    ref const val ->     val       : copy underlying
     //    ref const val ->     const val : copy underlying
-    if (!src_is_ref) {
+    if (!dst_is_ref) {
         return [](compiler& com, const node_expr& expr, const token& tok) {
             push_object_copy(com, expr, tok);
         };

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -860,10 +860,10 @@ auto are_types_convertible_to(const std::vector<type_name>& args,
     if (args.size() != actuals.size()) return false;
     for (std::size_t i = 0; i != args.size(); ++i) {
         if (get_converter(args[i], actuals[i]).has_value()) {
-            return false;
+            return true;
         }
     }
-    return true;
+    return false;
 }
 
 auto get_builtin_id(const std::string& name, const std::vector<type_name>& args)

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -851,12 +851,6 @@ auto push_function_arg(
     (*converter)(com, expr, tok);
 }
 
-auto is_type_convertible_to(const type_name& type, const type_name& expected) -> bool
-{
-    const auto converter = get_converter(type, expected);
-    return converter.has_value();
-}
-
 // Checks if the set of given args is convertible to the signature for a function.
 // Type A is convertible to B is A == ref B or B == ref A. TODO: Consider value categories,
 // rvalues should not be bindable to references
@@ -865,7 +859,7 @@ auto are_types_convertible_to(const std::vector<type_name>& args,
 {
     if (args.size() != actuals.size()) return false;
     for (std::size_t i = 0; i != args.size(); ++i) {
-        if (!is_type_convertible_to(args[i], actuals[i])) {
+        if (get_converter(args[i], actuals[i]).has_value()) {
             return false;
         }
     }

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -178,17 +178,9 @@ auto construct_builtin_array() -> std::vector<builtin>
 
 static const auto builtins = construct_builtin_array();
 
-auto get_builtin_id(const std::string& name, const std::vector<type_name>& args)
-    -> std::optional<std::size_t>
+auto get_builtins() -> std::span<const builtin>
 {
-    auto index = std::size_t{0};
-    for (const auto& b : builtins) {
-        if (name == b.name && are_types_convertible_to(args, b.args)) {
-            return index;
-        }
-        ++index;
-    }
-    return std::nullopt;
+    return builtins;
 }
 
 auto get_builtin(std::size_t id) -> const builtin&

--- a/src/functions.hpp
+++ b/src/functions.hpp
@@ -20,9 +20,7 @@ struct builtin
     type_name              return_type;
 };
 
-auto get_builtin_id(const std::string& name, const std::vector<type_name>& args)
-    -> std::optional<std::size_t>;
-
+auto get_builtins() -> std::span<const builtin>;
 auto get_builtin(std::size_t id) -> const builtin&;
 
 }

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -333,47 +333,6 @@ auto is_type_trivially_copyable(const type_name& type) -> bool
     }, type);
 }
 
-auto is_type_convertible_to(const type_name& type, const type_name& expected) -> bool
-{
-    return
-        // Trivial, no conversion needed
-        type == expected
-
-        // References can convert to a non-ref via copy-construction, and
-        || (type.is_ref() && type.remove_ref() == expected)
-
-        // non-refs convert to references by taking the address
-        || (!type.is_ref() && type.add_ref() == expected)
-
-        // Arrays can convert to spans if the underlying types match
-        || (is_array_type(type) && is_span_type(expected) && inner_type(type) == inner_type(expected))
-        
-        // Non-const type can bind to a bind type
-        || (type.add_const() == expected)
-
-        // So long as we're not dealing with references, const objects can bind to non-const
-        // arguments because we can make a copy
-        || (!expected.is_ref() && !expected.is_const() && type.remove_const() == expected)
-
-        || (type.remove_cr() == expected)
-        || (expected.add_const() == type && !type.is_ref());
-}
-
-// Checks if the set of given args is convertible to the signature for a function.
-// Type A is convertible to B is A == ref B or B == ref A. TODO: Consider value categories,
-// rvalues should not be bindable to references
-auto are_types_convertible_to(const std::vector<type_name>& args,
-                              const std::vector<type_name>& actuals) -> bool
-{
-    if (args.size() != actuals.size()) return false;
-    for (std::size_t i = 0; i != args.size(); ++i) {
-        if (!is_type_convertible_to(args[i], actuals[i])) {
-            return false;
-        }
-    }
-    return true;
-}
-
 auto type_store::add(const type_name& name, const type_fields& fields) -> bool
 {
     if (d_classes.contains(name)) {

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -168,13 +168,6 @@ auto array_length(const type_name& t) -> std::size_t;
 
 auto is_type_trivially_copyable(const type_name& type) -> bool;
 
-// Checks if the set of given args is convertible to the signature for a function.
-// Type A is convertible to B is A == ref B or B == ref A.
-auto is_type_convertible_to(const type_name& lhs, const type_name& rhs) -> bool;
-
-auto are_types_convertible_to(const std::vector<type_name>& lhs,
-                              const std::vector<type_name>& rhs) -> bool;
-
 class type_store
 {
     using type_hash = decltype([](const type_name& t) { return anzu::hash(t); });


### PR DESCRIPTION
* `are_types_convertible_to` and `push_function_arg` both had very similar logic, one was for checking if a conversion is possible, the other is for compiling that conversion. These were both written in different ways and made it a complete mess to maintain.
* The original implementation of both of those functions probably had bugs in it where they disagreed.
* Created a new function, `get_converter(type_name src, type_name dst)` which returns an optional function; if the conversion is possible, the returned function is the logic to compile it. Both of the above functions are rewritten in this new one.
* Cleaned up all the call sites of `push_function_arg`, the only reason the error checking code was at the call site was because of a failed attempt to clean this code up earlier.