### PR TITLE
Keyword `ref`

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,17 +25,17 @@ An interpreted programming language written in C++. This started out as a stack-
 * Spans:
     1. Non-owning views over arrays, made up of a pointer + a size.
     1. Create a span from an array using trailing `[]`.
-    1. eg: If `l` is an array of 5 `i64`s, then `l[]` is an `int64[]`.
+    1. eg: If `l` is an array of 5 `i64`s, then `l[]` is an `i64[]`.
     1. Slicing syntax `l[0 : 2]` for creating subspans.
-    1. Arrays automatically convert to spans, useful for passing arrays to functions that accept spans as arguments.
+    1. Arrays can automatically convert to spans when passing to functions.
 
 * Function Pointers:
     1. Function names resolve to function pointers which can be passed to functions.
-    1. Syntax for function pointer types: `(<arg_types>) -> <return_type>`.
+    1. Syntax for function pointer types: `fn(<arg_types>) -> <return_type>`.
 
 * Variables:
-    * Declare with `:=` operator and either `let` or `var`: `let x := 5` or `var x := 5`.
-    * `let` declares a const value, `var` declares a mutable value.
+    * Declare with `:=` operator and either `let`, `var` or 'ref': `let x := 5` or `var x := 5`.
+    * `let` declares a const value, `var` declares a mutable value, and 'ref' declares a new name for an existing object.
     * Assign to existing variable with `=` operator: `x = 6`.
 
 * References:
@@ -96,9 +96,9 @@ An interpreted programming language written in C++. This started out as a stack-
         x: f64;
         y: f64;
 
-        fn length2(self: vec2&) -> f64
+        fn length2(ref self: const vec2) -> f64
         {
-            return (self@.x * self@.x) + (self@.y * self@.y);
+            return (self.x * self.x) + (self.y * self.y);
         }
     }
     ```

--- a/examples/feature_test.az
+++ b/examples/feature_test.az
@@ -122,12 +122,12 @@ struct vec2
     x: i64;
     y: i64;
 
-    fn copy(self: vec2~) -> vec2
+    fn copy(self: (const vec2)~) -> vec2
     {
         return vec2(self.x, self.y);
     }
 
-    fn assign(self: vec2~, other: vec2~)
+    fn assign(self: vec2~, other: (const vec2)~)
     {
         self.x = other.x;
         self.y = other.y;
@@ -190,7 +190,7 @@ struct vec3
     y: f64;
     z: f64;
 
-    fn length(self: vec3~) -> f64
+    fn length(self: (const vec3)~) -> f64
     {
         let x_squared := square(self.x);
         let y_squared := square(self.y);
@@ -198,12 +198,12 @@ struct vec3
         return sqrt(x_squared + y_squared + z_squared);
     }
 
-    fn copy(self: vec3~) -> vec3
+    fn copy(self: (const vec3)~) -> vec3
     {
         return vec3(self.x, self.y, self.z);
     }
 
-    fn assign(self: vec3~, other: vec3~)
+    fn assign(self: vec3~, other: (const vec3)~)
     {
         self.x = other.x;
         self.y = other.y;

--- a/examples/feature_test.az
+++ b/examples/feature_test.az
@@ -122,12 +122,12 @@ struct vec2
     x: i64;
     y: i64;
 
-    fn copy(self: (const vec2)~) -> vec2
+    fn copy(ref self: const vec2) -> vec2
     {
         return vec2(self.x, self.y);
     }
 
-    fn assign(self: vec2~, other: (const vec2)~)
+    fn assign(ref self: vec2, ref other: const vec2)
     {
         self.x = other.x;
         self.y = other.y;
@@ -190,7 +190,7 @@ struct vec3
     y: f64;
     z: f64;
 
-    fn length(self: (const vec3)~) -> f64
+    fn length(ref self: const vec3) -> f64
     {
         let x_squared := square(self.x);
         let y_squared := square(self.y);
@@ -198,12 +198,12 @@ struct vec3
         return sqrt(x_squared + y_squared + z_squared);
     }
 
-    fn copy(self: (const vec3)~) -> vec3
+    fn copy(ref self: const vec3) -> vec3
     {
         return vec3(self.x, self.y, self.z);
     }
 
-    fn assign(self: vec3~, other: (const vec3)~)
+    fn assign(ref self: vec3, ref other: const vec3)
     {
         self.x = other.x;
         self.y = other.y;
@@ -268,7 +268,7 @@ struct destructible
 {
     val: i64;
 
-    fn drop(self: destructible~)
+    fn drop(ref self: destructible)
     {
         print("dropping ");
         println(self.val);

--- a/examples/list_destruction.az
+++ b/examples/list_destruction.az
@@ -2,7 +2,7 @@ struct object
 {
     inner: i64;
 
-    fn drop(self: object~) -> null
+    fn drop(ref self: object) -> null
     {
         print("dropping object ");
         println(self.inner);

--- a/examples/std/file.az
+++ b/examples/std/file.az
@@ -3,12 +3,12 @@ struct file
 {
     handle: u64;
 
-    fn drop(self: file&)
+    fn drop(ref self: file)
     {
         fclose(self@.handle);
     }
 
-    fn write(self: file&, str: char[])
+    fn write(ref self: file, str: char[])
     {
         fputs(self@.handle, str);
     }

--- a/examples/std/file.az
+++ b/examples/std/file.az
@@ -5,16 +5,16 @@ struct file
 
     fn drop(ref self: file)
     {
-        fclose(self@.handle);
+        fclose(self.handle);
     }
 
-    fn write(ref self: file, str: char[])
+    fn write(ref self: file, str: (const char)[])
     {
-        fputs(self@.handle, str);
+        fputs(self.handle, str);
     }
 }
 
-fn open_file(filename: char[], mode: char[]) -> file
+fn open_file(filename: (const char)[], mode: (const char)[]) -> file
 {
     return file(fopen(filename, mode));
 }

--- a/examples/std/string.az
+++ b/examples/std/string.az
@@ -4,7 +4,7 @@ struct string
     data: char[];
     size: u64;
 
-    fn append_char(self: string~, c: char)
+    fn append_char(ref self: string, c: char)
     {
         if (self.size == self.data.size()) {
             unsafe {
@@ -28,36 +28,36 @@ struct string
         self.size = self.size + 1u;      
     }
 
-    fn at(self: string~, idx: u64) -> char
+    fn at(ref self: string, idx: u64) -> char
     {
         assert idx < self.size;
         return self.data[idx];
     }
 
-    fn append(self: string~, other: char[])
+    fn append(ref self: string, other: char[])
     {
         for c in other {
             self.append_char(c);
         }
     }
 
-    fn clear(self: string~)
+    fn clear(ref self: string)
     {
         self.size = 0u;
     }
 
-    fn get(self: string~) -> char[]
+    fn get(ref self: string) -> char[]
     {
         return self.data[0u : self.size];
     }
 
-    fn set(self: string~, value: char[])
+    fn set(ref self: string, value: char[])
     {
         self.clear();
         self.append(value);
     }
 
-    fn transform(self: string~, func: fn(char&) -> null)
+    fn transform(ref self: string, func: fn(char&) -> null)
     {
         span := self.get();
         for c in span {
@@ -67,14 +67,14 @@ struct string
 
     # SPECIAL MEMBER FUNCTIONS
 
-    fn drop(self: string~)
+    fn drop(ref self: string)
     {
         unsafe {
             delete self.data;
         }
     }
 
-    fn copy(self: string~) -> string
+    fn copy(ref self: string) -> string
     {
         unsafe {
             cpy := string(new char : self.data.size(), self.size);
@@ -83,7 +83,7 @@ struct string
         }
     }
 
-    fn assign(self: string~, other: string~)
+    fn assign(ref self: string, ref other: const string)
     {
         # Resize self if needed
         if self.data.size() < other.data.size() {

--- a/examples/std/vector.az
+++ b/examples/std/vector.az
@@ -4,7 +4,7 @@ struct vector
     data: i64[];
     size: u64;
 
-    fn push(self: vector~, val: i64)
+    fn push(ref self: vector, val: i64)
     {
         if (self.size == self.data.size()) {
             var new_cap := 2u * self.data.size();
@@ -26,23 +26,23 @@ struct vector
         self.size = self.size + 1u;
     }
 
-    fn pop(self: vector~) -> i64
+    fn pop(ref self: vector) -> i64
     {
         self.size = self.size - 1u;
         return self.data[self.size];
     }
 
-    fn size(self: vector~) -> u64
+    fn size(ref self: vector) -> u64
     {
         return self.size;
     }
 
-    fn capacity(self: vector~) -> u64
+    fn capacity(ref self: vector) -> u64
     {
         return self.data.size();
     }
 
-    fn drop(self: vector~)
+    fn drop(ref self: vector)
     {
         delete self.data;
     }

--- a/examples/test.az
+++ b/examples/test.az
@@ -2,8 +2,8 @@
 struct foo {
     val: i64;
 
-    fn print(self: (const foo)~) {
-        print(self.val);
+    fn print(ref self: const foo) {
+        println(self.val);
     }
 }
 

--- a/examples/test.az
+++ b/examples/test.az
@@ -4,6 +4,7 @@ struct foo {
 
     fn print(ref self: const foo) {
         println(self.val);
+        __dump_type(self);
     }
 }
 

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,6 +1,11 @@
 
-let x := 5;
-ref y := x;
-var z := 10;
+struct foo {
+    val: i64;
 
-fn foo(x: i64, y : const i64, ref z: i64)
+    fn print(self: (const foo)~) {
+        print(self.val);
+    }
+}
+
+var f := foo(1);
+f.print();

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,12 +1,6 @@
-struct foo
-{
-    fn drop(self: foo~) { println("drop"); }
-}
 
-struct wrapper
-{
-    f: foo;
-}
+let x := 5;
+ref y := x;
+var z := 10;
 
-let arr1 := [foo(), foo()];
-let arr2 := [wrapper(foo()), wrapper(foo())];
+fn foo(x: i64, y : const i64, ref z: i64)

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -191,7 +191,12 @@ auto print_node(const node_stmt& root, int indent) -> void
         [&](const node_declaration_stmt& node) {
             print("{}Declaration:\n", spaces);
             print("{}- Name: {}\n", spaces, node.name);
-            print("{}- IsConst: {}\n", spaces, node.is_const);
+            switch (node.qual) {
+                using enum node_declaration_stmt::qualifier;
+                case var: { print("{}- Var\n", spaces); } break;
+                case let: { print("{}- Let\n", spaces); } break;
+                case ref: { print("{}- Ref\n", spaces); } break;
+            }
             print("{}- Value:\n", spaces);
             print_node(*node.expr, indent + 1);
         },

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -210,7 +210,11 @@ auto print_node(const node_stmt& root, int indent) -> void
         [&](const node_function_def_stmt& node) {
             print("{}Function: {} (", spaces, node.name);
             print_comma_separated(node.sig.params, [](const auto& arg) {
-                return std::format("{}: {}", arg.name, *arg.type);
+                if (arg.is_ref) {
+                    return std::format("ref {}: {}", arg.name, *arg.type);
+                } else {
+                    return std::format("{}: {}", arg.name, *arg.type);
+                }
             });
             print(") -> {}\n", *node.sig.return_type);
             print_node(*node.body, indent + 1);
@@ -218,7 +222,11 @@ auto print_node(const node_stmt& root, int indent) -> void
         [&](const node_member_function_def_stmt& node) {
             print("{}MemberFunction: {}::{} (", spaces, node.struct_name, node.function_name);
             print_comma_separated(node.sig.params, [](const auto& arg) {
-                return std::format("{}: {}", arg.name, *arg.type);
+                if (arg.is_ref) {
+                    return std::format("ref {}: {}", arg.name, *arg.type);
+                } else {
+                    return std::format("{}: {}", arg.name, *arg.type);
+                }
             });
             print(") -> {}\n", *node.sig.return_type);
             print_node(*node.body, indent + 1);

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -301,8 +301,10 @@ struct node_continue_stmt
 
 struct node_declaration_stmt
 {
+    enum class qualifier { var, let, ref };
+
     std::string   name;
-    bool          is_const;
+    qualifier     qual;
     node_expr_ptr expr;
 
     anzu::token token;

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -42,6 +42,7 @@ struct node_parameter
 {
     std::string   name;
     node_type_ptr type;
+    bool          is_ref;
 };
 
 struct node_signature

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -1395,7 +1395,8 @@ auto compile_function_body(
         declare_var(com, tok, "# old_base_ptr", u64_type()); // Store the old base ptr
         declare_var(com, tok, "# old_prog_ptr", u64_type()); // Store the old program ptr
         for (const auto& arg : node_sig.params) {
-            const auto type = resolve_type(com, tok, arg.type);
+            auto type = resolve_type(com, tok, arg.type);
+            if (arg.is_ref) type = type.add_ref();
             sig.params.push_back({type});
             declare_var(com, tok, arg.name, type);
         }

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -263,12 +263,12 @@ auto ends_in_return(const node_stmt& node) -> bool
 
 auto assign_fn_params(const type_name& type) -> type_names
 {
-    return { concrete_reference_type(type), concrete_reference_type(type) };
+    return { type.add_ref(), type.add_ref() };
 }
 
 auto copy_fn_params(const type_name& type) -> type_names
 {
-    return { concrete_reference_type(type) };
+    return { type.add_ref() };
 }
 
 // Assumes that the given "push_object_ptr" is a function that compiles code to produce
@@ -279,7 +279,7 @@ auto call_destructor(compiler& com, const type_name& type, compile_obj_ptr_cb pu
 {
     std::visit(overloaded{
         [&](const type_struct&) {
-            const auto params = type_names{ concrete_reference_type(type) };
+            const auto params = type_names{ type.add_ref() };
             if (const auto func = get_function(com, type, "drop", params); func) {
                 // Push the args to the stack
                 push_value(com.program, op::push_call_frame);
@@ -1237,7 +1237,7 @@ void push_stmt(compiler& com, const node_for_stmt& node)
         push_value(com.program, op::push_u64, com.types.size_of(inner));
         push_value(com.program, op::u64_mul);
         push_value(com.program, op::u64_add);
-        declare_var(com, node.token, node.name, concrete_reference_type(inner));
+        declare_var(com, node.token, node.name, inner.add_ref());
 
         // idx = idx + 1;
         load_variable(com, node.token, "#:idx");
@@ -1464,8 +1464,8 @@ void push_stmt(compiler& com, const node_function_def_stmt& node)
 void push_stmt(compiler& com, const node_member_function_def_stmt& node)
 {
     const auto struct_type = make_type(node.struct_name);
-    const auto expected = concrete_reference_type(struct_type);
-    const auto const_expected = concrete_reference_type(struct_type.add_const());
+    const auto expected = struct_type.add_ref();
+    const auto const_expected = struct_type.add_const().add_ref();
     const auto sig = compile_function_body(com, node.token, struct_type, node.function_name, node.sig, node.body);
 
     // Verification code

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -865,7 +865,8 @@ auto push_expr_val(compiler& com, const node_call_expr& node) -> type_name
         if (inner.struct_name == nullptr & inner.name == "__dump_type") {
             print("__dump_type(\n");
             for (const auto& arg : node.args) {
-                print("    {},\n", type_of_expr(com, *arg));
+                const auto dump = type_of_expr(com, *arg);
+                print("    {}{},\n", dump.is_ref() ? "[ref] " : "", dump.remove_ref());
             }
             print(")\n");
             push_value(com.program, op::push_null);
@@ -1404,9 +1405,6 @@ auto compile_function_body(
         sig.return_type = resolve_type(com, tok, node_sig.return_type);
         com.scopes.get_function_info().return_type = sig.return_type;
         for (const auto& function : com.functions[struct_type][name]) {
-            // TODO Remove use of this, use push_function_arg instead using the same trick as with
-            // type_of_expr where we compile the actual expression then remove the op codes from
-            // the program
             if (are_types_convertible_to(sig.params, function.sig.params)) {
                 tok.error("multiple definitions of {}({})", name, format_comma_separated(sig.params));
             }

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -1054,6 +1054,14 @@ auto push_expr_val(compiler& com, const node_new_expr& node) -> type_name
     return concrete_ptr_type(type);
 }
 
+auto push_expr_val(compiler& com, const node_reference_expr& node) -> type_name
+{
+    // If we're taking a reference of an existing reference object, we just return the inner
+    // object; in order words we create a new reference to the same underlying object, rather
+    // than creating a reference to a reference.
+    return push_ptr_underlying(com, *node.expr).add_ref();
+}
+
 // If not implemented explicitly, assume that the given node_expr is an lvalue, in which case
 // we can load it by pushing the address to the stack and loading.
 auto push_expr_val(compiler& com, const auto& node) -> type_name

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -1303,21 +1303,16 @@ void push_stmt(compiler& com, const node_continue_stmt& node)
 
 auto push_stmt(compiler& com, const node_declaration_stmt& node) -> void
 {
-    switch (node.qual) {
-        using enum node_declaration_stmt::qualifier;
-        case var: {
-            const auto type = push_object_copy(com, *node.expr, node.token);
-            declare_var(com, node.token, node.name, type);
-        } break;
-        case let: {
-            const auto type = push_object_copy(com, *node.expr, node.token);
-            declare_var(com, node.token, node.name, type.add_const());
-        } break;
-        case ref: {
-            const auto type = push_ptr_underlying(com, *node.expr);
-            declare_var(com, node.token, node.name, type);
-        } break;
-    }
+    const auto type = [&] {
+        switch (node.qual) {
+            using enum node_declaration_stmt::qualifier;
+            case var: return push_object_copy(com, *node.expr, node.token);
+            case let: return push_object_copy(com, *node.expr, node.token).add_const();
+            case ref: return push_ptr_underlying(com, *node.expr);
+        }
+    }();
+    
+    declare_var(com, node.token, node.name, type);
 }
 
 auto is_assignable(const type_name& lhs, const type_name& rhs) -> bool

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -76,6 +76,7 @@ auto identifier_type(std::string_view token) -> token_type
     if (token == "loop")     return token_type::kw_loop;
     if (token == "new")      return token_type::kw_new;
     if (token == "null")     return token_type::kw_null;
+    if (token == "ref")      return token_type::kw_ref;
     if (token == "return")   return token_type::kw_return;
     if (token == "sizeof")   return token_type::kw_sizeof;
     if (token == "struct")   return token_type::kw_struct;

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -261,16 +261,6 @@ auto is_function_ptr_type(const type_name& t) -> bool
     return std::holds_alternative<type_function_ptr>(t);
 }
 
-auto concrete_reference_type(const type_name& t) -> type_name
-{
-    return {type_reference{ .inner_type = { t } }};
-}
-
-auto is_reference_type(const type_name& t) -> bool
-{
-    return std::holds_alternative<type_reference>(t);
-}
-
 auto inner_type(const type_name& t) -> type_name
 {
     if (is_array_type(t)) {
@@ -300,16 +290,6 @@ auto array_length(const type_name& t) -> std::size_t
 }
 
 auto size_of_ptr() -> std::size_t
-{
-    return PTR_SIZE;
-}
-
-auto size_of_span() -> std::size_t
-{
-    return 2 * PTR_SIZE; // actually a pointer + a size, but they are both 8 bytes
-}
-
-auto size_of_reference() -> std::size_t
 {
     return PTR_SIZE;
 }
@@ -391,16 +371,16 @@ auto type_store::size_of(const type_name& type) const -> std::size_t
             return size_of(*t.inner_type) * t.count;
         },
         [](const type_ptr&) {
-            return size_of_ptr();
+            return PTR_SIZE;
         },
         [](const type_span&) {
-            return size_of_span();
+            return 2 * PTR_SIZE; // actually a pointer + a size, but they are both 8 bytes
         },
         [](const type_function_ptr&) {
-            return size_of_ptr();
+            return PTR_SIZE;
         },
         [](const type_reference&) {
-            return size_of_reference();
+            return PTR_SIZE;
         },
         [&](const type_const& t) {
             return size_of(*t.inner_type);

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -152,12 +152,7 @@ auto is_span_type(const type_name& t) -> bool;
 
 auto is_function_ptr_type(const type_name& t) -> bool;
 
-auto concrete_reference_type(const type_name& t) -> type_name;
-auto is_reference_type(const type_name& t) -> bool;
-
 auto size_of_ptr() -> std::size_t;
-auto size_of_span() -> std::size_t;
-auto size_of_reference() -> std::size_t;
 
 // Extracts the single inner type of the given t. Undefined if the given t is not a compound
 // type with a single subtype.

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -604,10 +604,11 @@ auto parse_declaration_stmt(tokenstream& tokens) -> node_stmt_ptr
 
     switch (stmt.token.type) {
         using enum node_declaration_stmt::qualifier;
-        case token_type::kw_let: stmt.qual = let;
-        case token_type::kw_var: stmt.qual = var;
-        case token_type::kw_ref: stmt.qual = ref;
-        default: stmt.token.error("declaration must start with 'let', 'var' or 'ref'");
+        case token_type::kw_let: { stmt.qual = let; } break;
+        case token_type::kw_var: { stmt.qual = var; } break;
+        case token_type::kw_ref: { stmt.qual = ref; } break;
+        default: stmt.token.error("declaration must start with 'let', 'var' or 'ref', not {}",
+                                  stmt.token.text);
     }
 
     stmt.name = parse_name(tokens);
@@ -703,7 +704,8 @@ auto parse_statement(tokenstream& tokens) -> node_stmt_ptr
         case token_type::left_brace:  return parse_braced_statement_list(tokens);
         case token_type::kw_unsafe:   return parse_unsafe_stmt(tokens);
         case token_type::kw_let:
-        case token_type::kw_var:      return parse_declaration_stmt(tokens);
+        case token_type::kw_var:
+        case token_type::kw_ref:      return parse_declaration_stmt(tokens);
     }
 
     auto node = std::make_shared<node_stmt>();

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -385,12 +385,6 @@ auto parse_type_inner(tokenstream& tokens) -> type_name
         else if (tokens.consume_maybe(token_type::ampersand)) {
             type = type_name{type_ptr{ .inner_type=type }};
         }
-        else if (tokens.consume_maybe(token_type::tilde)) {
-            if (std::holds_alternative<type_reference>(type)) {
-                tokens.consume().error("Invalid type, cannot have reference to reference");
-            }
-            type = type_name{type_reference{ .inner_type=type }};
-        }
         else {
             break;
         }
@@ -465,6 +459,7 @@ auto parse_function_def_stmt(tokenstream& tokens) -> node_stmt_ptr
     tokens.consume_only(token_type::left_paren);
     tokens.consume_comma_separated_list(token_type::right_paren, [&]{
         auto param = node_parameter{};
+        param.is_ref = tokens.consume_maybe(token_type::kw_ref);
         param.name = parse_name(tokens);
         tokens.consume_only(token_type::colon);
         param.type = parse_type_node(tokens);
@@ -492,6 +487,7 @@ auto parse_member_function_def_stmt(const std::string& struct_name, tokenstream&
     tokens.consume_only(token_type::left_paren);
     tokens.consume_comma_separated_list(token_type::right_paren, [&]{
         auto param = node_parameter{};
+        param.is_ref = tokens.consume_maybe(token_type::kw_ref);
         param.name = parse_name(tokens);
         tokens.consume_only(token_type::colon);
         param.type = parse_type_node(tokens);

--- a/src/token.cpp
+++ b/src/token.cpp
@@ -64,6 +64,7 @@ auto to_string(token_type tt) -> std::string_view
         case token_type::kw_loop:             return "loop";
         case token_type::kw_new:              return "new";
         case token_type::kw_null:             return "null";
+        case token_type::kw_ref:              return "ref";
         case token_type::kw_return:           return "return";
         case token_type::kw_sizeof:           return "sizeof";
         case token_type::kw_struct:           return "struct";

--- a/src/token.hpp
+++ b/src/token.hpp
@@ -52,6 +52,7 @@ enum class token_type
     kw_loop,
     kw_new,
     kw_null,
+    kw_ref,
     kw_return,
     kw_sizeof,
     kw_struct,


### PR DESCRIPTION
* Added `ref` as a keyword.
* Declare aliases to existing objects with `ref`: `ref x := y`. Similar to `let` and `var`.
* It's not possible to create a const ref alias to a mutable object, but I don't think it's a big deal. If you want to make a const ref to a mutable object, create a function and pass it there.
* Specifying a function param as a ref is done to the left of the param name, rather than part of the type, similar to the above syntax for creating local references. eg in `fn foo(ref x: const i64)`, `x` is of type `const i64` but is also a reference so no copy happens. `(ref x: i64)` is a mutable reference to an i64.
* `copy` and `assign` now use const references where appropriate: `copy(ref self: const T) -> T` and `assign(ref self: T, ref other: const T)`.
* Optimise `push_ptr_adjust` slightly; don't output any op codes if the offset is 0.
* `get_converter` now returns a function pointer, no need for the extra allocation for `std::function`.