### PR TITLE
Auto Dereference Pointers for Field Access

### DIFF
--- a/examples/feature_test.az
+++ b/examples/feature_test.az
@@ -288,3 +288,15 @@ struct destructible
     v1 = v3;
     println(v1.x);
 }
+
+struct container
+{
+    val: i64;
+}
+
+# Pointer auto dereference
+{
+    let x := container(5);
+    let p := x&;
+    println(p.val);
+}

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,6 +1,10 @@
 
 struct foo {
     val: i64;
+
+    fn pr(ref self: foo) {
+        println(self.val);
+    }
 }
 
 var f := foo(1);
@@ -10,4 +14,4 @@ var p2 := p&;
 f.val = 5;
 p2.val = 10;
 
-println(p2.val);
+p2@@.pr();

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,12 +1,13 @@
 
 struct foo {
     val: i64;
-
-    fn print(ref self: const foo) {
-        println(self.val);
-        __dump_type(self);
-    }
 }
 
 var f := foo(1);
-f.print();
+var p := f&;
+var p2 := p&;
+
+f.val = 5;
+p2.val = 10;
+
+println(p2.val);

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -529,7 +529,12 @@ auto push_expr_val(compiler& com, const node_name_expr& node) -> type_name
 
 auto push_expr_ptr(compiler& com, const node_field_expr& node) -> type_name
 {
-    const auto [type, is_const, is_ref] = push_ptr_underlying(com, *node.expr).strip_qualifiers();
+    auto [type, is_const, is_ref] = push_ptr_underlying(com, *node.expr).strip_qualifiers();
+
+    while (is_ptr_type(type)) {
+        push_value(com.program, op::load, size_of_ptr());
+        type = inner_type(type);
+    }
 
     auto ret = push_adjust_ptr_to_field(com, node.token, type, node.field_name);
     if (is_const) ret = ret.add_const(); // Propagate const to members
@@ -1228,7 +1233,7 @@ void push_stmt(compiler& com, const node_for_stmt& node)
         push_value(com.program, op::push_u64, com.types.size_of(inner));
         push_value(com.program, op::u64_mul);
         push_value(com.program, op::u64_add);
-        declare_var(com, node.token, node.name, inner.add_ref());
+        declare_var(com, node.token, node.name, concrete_ptr_type(inner));
 
         // idx = idx + 1;
         load_variable(com, node.token, "#:idx");
@@ -1309,6 +1314,7 @@ auto push_stmt(compiler& com, const node_declaration_stmt& node) -> void
             case var: return push_object_copy(com, *node.expr, node.token);
             case let: return push_object_copy(com, *node.expr, node.token).add_const();
             case ref: return push_ptr_underlying(com, *node.expr);
+            default: node.token.error("Logic error: declaration isn't using var, let or ref");
         }
     }();
     

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -531,6 +531,7 @@ auto push_expr_ptr(compiler& com, const node_field_expr& node) -> type_name
 {
     auto [type, is_const, is_ref] = push_ptr_underlying(com, *node.expr).strip_qualifiers();
 
+    // Allow for field access on a pointer
     while (is_ptr_type(type)) {
         push_value(com.program, op::load, size_of_ptr());
         type = inner_type(type);


### PR DESCRIPTION
* When given a pointer `p`, `p.x` is equivalent to `p@.f`. This is recursive and can dereference multiple times eg for a `i64&&`, `p.x` is equivalent to `p@@.x`.
* Switched for-loop back to returning pointers.
* This is an experiment; after implementing references, they do work well, but I dislike the huge amount of complexity added to the compiler. I want to see if I can use a similar strategy that Go uses; making pointers nicer to work with. I've also started to dislike the `@` syntax, and would prefer to use that for reflection like cppfront. I may end up going back to making derferencing a prefix operator, or using Zig style syntax `p.*` for dereferencing to disambiguate between that and multiplication.