### PR TITLE
Call Members Functions through Pointers

### DIFF
--- a/examples/feature_test.az
+++ b/examples/feature_test.az
@@ -122,12 +122,12 @@ struct vec2
     x: i64;
     y: i64;
 
-    fn copy(ref self: const vec2) -> vec2
+    fn copy(self: (const vec2)&) -> vec2
     {
         return vec2(self.x, self.y);
     }
 
-    fn assign(ref self: vec2, ref other: const vec2)
+    fn assign(self: vec2&, other: (const vec2)&)
     {
         self.x = other.x;
         self.y = other.y;
@@ -190,7 +190,7 @@ struct vec3
     y: f64;
     z: f64;
 
-    fn length(ref self: const vec3) -> f64
+    fn length(self: (const vec3)&) -> f64
     {
         let x_squared := square(self.x);
         let y_squared := square(self.y);
@@ -198,12 +198,12 @@ struct vec3
         return sqrt(x_squared + y_squared + z_squared);
     }
 
-    fn copy(ref self: const vec3) -> vec3
+    fn copy(self: (const vec3)&) -> vec3
     {
         return vec3(self.x, self.y, self.z);
     }
 
-    fn assign(ref self: vec3, ref other: const vec3)
+    fn assign(self: vec3&, other: (const vec3)&)
     {
         self.x = other.x;
         self.y = other.y;
@@ -268,7 +268,7 @@ struct destructible
 {
     val: i64;
 
-    fn drop(ref self: destructible)
+    fn drop(self: destructible&)
     {
         print("dropping ");
         println(self.val);

--- a/examples/list_destruction.az
+++ b/examples/list_destruction.az
@@ -2,7 +2,7 @@ struct object
 {
     inner: i64;
 
-    fn drop(ref self: object) -> null
+    fn drop(self: object&) -> null
     {
         print("dropping object ");
         println(self.inner);

--- a/examples/std/file.az
+++ b/examples/std/file.az
@@ -3,12 +3,12 @@ struct file
 {
     handle: u64;
 
-    fn drop(ref self: file)
+    fn drop(self: file&)
     {
         fclose(self.handle);
     }
 
-    fn write(ref self: file, str: (const char)[])
+    fn write(self: file&, str: (const char)[])
     {
         fputs(self.handle, str);
     }

--- a/examples/std/string.az
+++ b/examples/std/string.az
@@ -4,7 +4,7 @@ struct string
     data: char[];
     size: u64;
 
-    fn append_char(ref self: string, c: char)
+    fn append_char(self: string&, c: char)
     {
         if (self.size == self.data.size()) {
             unsafe {
@@ -28,53 +28,53 @@ struct string
         self.size = self.size + 1u;      
     }
 
-    fn at(ref self: string, idx: u64) -> char
+    fn at(self: string&, idx: u64) -> char
     {
         assert idx < self.size;
         return self.data[idx];
     }
 
-    fn append(ref self: string, other: char[])
+    fn append(self: string&, other: char[])
     {
         for c in other {
             self.append_char(c);
         }
     }
 
-    fn clear(ref self: string)
+    fn clear(self: string&)
     {
         self.size = 0u;
     }
 
-    fn get(ref self: string) -> char[]
+    fn get(self: (const string)&) -> char[]
     {
         return self.data[0u : self.size];
     }
 
-    fn set(ref self: string, value: char[])
+    fn set(self: string&, value: char[])
     {
         self.clear();
         self.append(value);
     }
 
-    fn transform(ref self: string, func: fn(char&) -> null)
+    fn transform(self: string&, func: fn(char&) -> null)
     {
         span := self.get();
         for c in span {
-            func(c&);
+            func(c);
         }
     }
 
     # SPECIAL MEMBER FUNCTIONS
 
-    fn drop(ref self: string)
+    fn drop(self: string&)
     {
         unsafe {
             delete self.data;
         }
     }
 
-    fn copy(ref self: string) -> string
+    fn copy(self: string&) -> string
     {
         unsafe {
             cpy := string(new char : self.data.size(), self.size);
@@ -83,7 +83,7 @@ struct string
         }
     }
 
-    fn assign(ref self: string, ref other: const string)
+    fn assign(self: string&, other: (const string)&)
     {
         # Resize self if needed
         if self.data.size() < other.data.size() {

--- a/examples/std/vector.az
+++ b/examples/std/vector.az
@@ -4,55 +4,56 @@ struct vector
     data: i64[];
     size: u64;
 
-    fn push(ref self: vector, val: i64)
+    fn push(self: vector&, val: i64)
     {
-        if (self.size == self.data.size()) {
-            var new_cap := 2u * self.data.size();
-            if new_cap == 0u {
-                new_cap = 1u;
-            }
-            var newdata := new i64 : new_cap;
+        unsafe {
+            if (self.size == self.data.size()) {
+                var new_cap := 2u * self.data.size();
+                if new_cap == 0u {
+                    new_cap = 1u;
+                }
+                var newdata := new i64 : new_cap;
 
-            var idx := 0u;
-            while idx != self.size {
-                newdata[idx] = self.data[idx];
-                idx = idx + 1u;
-            }
+                var idx := 0u;
+                while idx != self.size {
+                    newdata[idx] = self.data[idx];
+                    idx = idx + 1u;
+                }
 
-            delete self.data;
-            self.data = newdata;
+                delete self.data;
+                self.data = newdata;
+            }
+            self.data[self.size] = val;
+            self.size = self.size + 1u;
         }
-        self.data[self.size] = val;
-        self.size = self.size + 1u;
     }
 
-    fn pop(ref self: vector) -> i64
+    fn pop(self: vector&) -> i64
     {
         self.size = self.size - 1u;
         return self.data[self.size];
     }
 
-    fn size(ref self: vector) -> u64
+    fn size(self: (const vector)&) -> u64
     {
         return self.size;
     }
 
-    fn capacity(ref self: vector) -> u64
+    fn capacity(self: (const vector)&) -> u64
     {
         return self.data.size();
     }
 
-    fn drop(ref self: vector)
+    fn drop(self: vector&)
     {
-        delete self.data;
+        unsafe { delete self.data; }
     }
 }
 
 fn new_vector() -> vector
 {
     # We don't have nullptr yet, so we must allocate some space here for now
-    return vector(new i64 : 1u, 0u);
+    unsafe {
+        return vector(new i64 : 1u, 0u);
+    }
 }
-
-x := i64;
-p := x&;

--- a/examples/test.az
+++ b/examples/test.az
@@ -2,5 +2,4 @@
 var x := [1, 2, 3, 4, 5];
 var y := x[];
 
-println(x.size());
 println(y.size());

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,11 +1,6 @@
 
-struct foo {
-    val: i64;
+var x := [1, 2, 3, 4, 5];
+var y := x[];
 
-    fn pr(self: foo&, x: i64) {
-        println(self.val + x);
-    }
-}
-
-var f := foo(1);
-f.pr(6);
+println(x.size());
+println(y.size());

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,17 +1,6 @@
+import std/vector.az;
 
-struct foo
-{
-    val: i64;
-
-    fn bar(self: foo&) 
-    {
-        println("HERE");
-        println(self.val);
-    }
-}
-
-var v := foo(1);
-var p := v&;
-var p2 := p&;
-
-p2@@.bar();
+var v := new_vector();
+v.push(5);
+v.push(10);
+println(v.size());

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,5 +1,17 @@
 
-var x := [1, 2, 3, 4, 5];
-var y := x[];
+struct foo
+{
+    val: i64;
 
-println(y.size());
+    fn bar(self: foo&) 
+    {
+        println("HERE");
+        println(self.val);
+    }
+}
+
+var v := foo(1);
+var p := v&;
+var p2 := p&;
+
+p2@@.bar();

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,6 +1,15 @@
-import std/vector.az;
 
-var v := new_vector();
-v.push(5);
-v.push(10);
-println(v.size());
+struct foo
+{
+    val: i64;
+
+    fn bar(self: foo&)
+    {
+        println(self.val);
+    }
+}
+
+var f := foo(10);
+var p := f&;
+var p2 := p&;
+p2.bar();

--- a/examples/test.az
+++ b/examples/test.az
@@ -2,10 +2,10 @@
 struct foo {
     val: i64;
 
-    fn pr(self: foo&) {
-        println(self.val);
+    fn pr(self: foo&, x: i64) {
+        println(self.val + x);
     }
 }
 
 var f := foo(1);
-f.pr();
+f.pr(6);

--- a/examples/test.az
+++ b/examples/test.az
@@ -2,16 +2,10 @@
 struct foo {
     val: i64;
 
-    fn pr(ref self: foo) {
+    fn pr(self: foo&) {
         println(self.val);
     }
 }
 
 var f := foo(1);
-var p := f&;
-var p2 := p&;
-
-f.val = 5;
-p2.val = 10;
-
-p2@@.pr();
+f.pr();

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -66,6 +66,16 @@ auto print_node(const node_expr& root, int indent) -> void
                 print_node(*arg, indent + 1);
             }
         },
+        [&](const node_member_call_expr& node) {
+            print("{}MemberCall:\n", spaces);
+            print("{}- Expr:\n", spaces);
+            print_node(*node.expr, indent + 1);
+            print("{}- FunctionName: {}\n", spaces, node.function_name);
+            print("{}- OtherArgs:\n", spaces);
+            for (const auto& arg : node.other_args) {
+                print_node(*arg, indent + 1);
+            }
+        },
         [&](const node_array_expr& node) {
             print("{}Array:\n", spaces);
             print("{}- Elements:\n", spaces);

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -137,6 +137,15 @@ struct node_call_expr
     anzu::token token;
 };
 
+struct node_member_call_expr
+{
+    node_expr_ptr              expr;
+    std::string                function_name;
+    std::vector<node_expr_ptr> other_args;
+
+    anzu::token token;
+};
+
 struct node_array_expr
 {
     std::vector<node_expr_ptr> elements;
@@ -218,6 +227,7 @@ struct node_expr : std::variant<
     node_unary_op_expr,
     node_binary_op_expr,
     node_call_expr,
+    node_member_call_expr,
     node_array_expr,
     node_repeat_array_expr,
     node_addrof_expr,

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -970,15 +970,10 @@ auto push_expr_val(compiler& com, const node_member_call_expr& node) -> type_nam
     node.token.assert(func.has_value(), "could not find member function {}::{}", stripped_type, node.function_name);
 
     push_value(com.program, op::push_call_frame);
-    if (type.is_ptr()) {
-        push_expr_val(com, *node.expr); // self
-        auto t = type;
-        while (t.is_ptr() && t.remove_ptr().is_ptr()) { // allow for calling member functions through pointers
-            push_value(com.program, op::load, size_of_ptr());
-            t = t.remove_ptr();
-        }
-    } else {
-        push_expr_ptr(com, *node.expr); // self
+    auto t = push_expr_ptr(com, *node.expr); // self
+    while (t.is_ptr()) { // allow for calling member functions through pointers
+        push_value(com.program, op::load, size_of_ptr());
+        t = t.remove_ptr();
     }
     for (std::size_t i = 0; i != node.other_args.size(); ++i) {
         push_function_arg(com, *node.other_args.at(i), func->sig.params[i + 1], node.token);

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -940,7 +940,7 @@ auto push_expr_val(compiler& com, const node_member_call_expr& node) -> type_nam
     // Handle .size() calls on spans
     if (is_span_type(type) && node.function_name == "size") {
         node.token.assert(node.other_args.empty(), "{}.size() takes no extra arguments", type);
-        push_expr_val(com, *node.expr); // push pointer to span
+        push_expr_ptr(com, *node.expr); // push pointer to span
         push_value(com.program, op::push_u64, size_of_ptr());
         push_value(com.program, op::u64_add); // offset to the size value
         push_value(com.program, op::load, com.types.size_of(u64_type())); // load the size

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -948,7 +948,7 @@ auto push_expr_val(compiler& com, const node_member_call_expr& node) -> type_nam
     }
 
     const auto stripped_type = [&] {
-        auto t = type_of_expr(com, *node.expr);
+        auto t = type;
         while (is_ptr_type(t)) { t = inner_type(t); }
         return t;
     }();
@@ -963,10 +963,10 @@ auto push_expr_val(compiler& com, const node_member_call_expr& node) -> type_nam
     node.token.assert(func.has_value(), "could not find member function {}::{}", stripped_type, node.function_name);
 
     push_value(com.program, op::push_call_frame);
-    if (is_ptr_type(type)) {
+    if (type.is_ptr()) {
         push_expr_val(com, *node.expr); // self
         auto t = type;
-        while (t.is_ptr() && t.remove_ptr().is_ptr()) {
+        while (t.is_ptr() && t.remove_ptr().is_ptr()) { // allow for calling member functions through pointers
             push_value(com.program, op::load, size_of_ptr());
             t = t.remove_ptr();
         }

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -280,7 +280,7 @@ auto call_destructor(compiler& com, const type_name& type, compile_obj_ptr_cb pu
 {
     std::visit(overloaded{
         [&](const type_struct&) {
-            const auto params = type_names{ type.add_ref() };
+            const auto params = type_names{ type.add_ptr() };
             if (const auto func = get_function(com, type, "drop", params); func) {
                 // Push the args to the stack
                 push_value(com.program, op::push_call_frame);

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -944,7 +944,7 @@ auto push_expr_val(compiler& com, const node_member_call_expr& node) -> type_nam
         push_value(com.program, op::push_call_frame);
         push_expr_ptr(com, *node.expr); // self
         for (std::size_t i = 0; i != node.other_args.size(); ++i) {
-            push_function_arg(com, *node.other_args.at(i), func->sig.params[i], node.token);
+            push_function_arg(com, *node.other_args.at(i), func->sig.params[i + 1], node.token);
         }
         push_function_call(com, *func);
         return func->sig.return_type;

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -963,7 +963,16 @@ auto push_expr_val(compiler& com, const node_member_call_expr& node) -> type_nam
     node.token.assert(func.has_value(), "could not find member function {}::{}", stripped_type, node.function_name);
 
     push_value(com.program, op::push_call_frame);
-    push_expr_ptr(com, *node.expr); // self
+    if (is_ptr_type(type)) {
+        push_expr_val(com, *node.expr); // self
+        auto t = type;
+        while (t.is_ptr() && t.remove_ptr().is_ptr()) {
+            push_value(com.program, op::load, size_of_ptr());
+            t = t.remove_ptr();
+        }
+    } else {
+        push_expr_ptr(com, *node.expr); // self
+    }
     for (std::size_t i = 0; i != node.other_args.size(); ++i) {
         push_function_arg(com, *node.other_args.at(i), func->sig.params[i + 1], node.token);
     }

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -928,42 +928,47 @@ auto push_expr_val(compiler& com, const node_call_expr& node) -> type_name
 
 auto push_expr_val(compiler& com, const node_member_call_expr& node) -> type_name
 {
-    const auto type = [&] {
+    const auto type = type_of_expr(com, *node.expr);
+
+    // Handle .size() calls on arrays
+    if (is_array_type(type) && node.function_name == "size") {
+        node.token.assert(node.other_args.empty(), "{}.size() takes no extra arguments", type);
+        push_value(com.program, op::push_u64, array_length(type));
+        return u64_type();
+    }
+
+    // Handle .size() calls on spans
+    if (is_span_type(type) && node.function_name == "size") {
+        node.token.assert(node.other_args.empty(), "{}.size() takes no extra arguments", type);
+        push_expr_val(com, *node.expr); // push pointer to span
+        push_value(com.program, op::push_u64, size_of_ptr());
+        push_value(com.program, op::u64_add); // offset to the size value
+        push_value(com.program, op::load, com.types.size_of(u64_type())); // load the size
+        return u64_type();
+    }
+
+    const auto stripped_type = [&] {
         auto t = type_of_expr(com, *node.expr);
         while (is_ptr_type(t)) { t = inner_type(t); }
         return t;
     }();
 
     auto params = std::vector<type_name>{};
-    params.push_back(concrete_ptr_type(type));
+    params.push_back(concrete_ptr_type(stripped_type));
     for (const auto& arg : node.other_args) {
         params.push_back(type_of_expr(com, *arg));
     }
 
-    if (const auto func = get_function(com, type, node.function_name, params); func.has_value()) {
-        push_value(com.program, op::push_call_frame);
-        push_expr_ptr(com, *node.expr); // self
-        for (std::size_t i = 0; i != node.other_args.size(); ++i) {
-            push_function_arg(com, *node.other_args.at(i), func->sig.params[i + 1], node.token);
-        }
-        push_function_call(com, *func);
-        return func->sig.return_type;
+    const auto func = get_function(com, stripped_type, node.function_name, params);
+    node.token.assert(func.has_value(), "could not find member function {}::{}", stripped_type, node.function_name);
+
+    push_value(com.program, op::push_call_frame);
+    push_expr_ptr(com, *node.expr); // self
+    for (std::size_t i = 0; i != node.other_args.size(); ++i) {
+        push_function_arg(com, *node.other_args.at(i), func->sig.params[i + 1], node.token);
     }
-    // It might be a .size member function on a span, TODO: make it easier to add
-    // builtin member functions first arg is a pointer to a span, so need to deref with
-    // inner_type before checking if its a span. BUG: This will match ANY call a size
-    // function, and if the type of the argument is not an array, ptr or span, inner_type is
-    // not defined and we fail compilation.
-    //if (inner.name == "size" && node.args.size() == 1 &&
-    //    is_span_type(inner_type(type_of_expr(com, *node.args[0]))))
-    //{
-    //    push_expr_val(com, *node.args[0]); // push pointer to span
-    //    push_value(com.program, op::push_u64, size_of_ptr());
-    //    push_value(com.program, op::u64_add); // offset to the size value
-    //    push_value(com.program, op::load, com.types.size_of(u64_type())); // load the size
-    //    return u64_type();
-    //}
-    return null_type();
+    push_function_call(com, *func);
+    return func->sig.return_type;
 }
 
 auto push_expr_val(compiler& com, const node_array_expr& node) -> type_name

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -896,21 +896,6 @@ auto push_expr_val(compiler& com, const node_call_expr& node) -> type_name
             return func->sig.return_type;
         }
 
-        // Third, it might be a .size member function on a span, TODO: make it easier to add
-        // builtin member functions first arg is a pointer to a span, so need to deref with
-        // inner_type before checking if its a span. BUG: This will match ANY call a size
-        // function, and if the type of the argument is not an array, ptr or span, inner_type is
-        // not defined and we fail compilation.
-        if (inner.name == "size" && node.args.size() == 1 &&
-            is_span_type(inner_type(type_of_expr(com, *node.args[0]))))
-        {
-            push_expr_val(com, *node.args[0]); // push pointer to span
-            push_value(com.program, op::push_u64, size_of_ptr());
-            push_value(com.program, op::u64_add); // offset to the size value
-            push_value(com.program, op::load, com.types.size_of(u64_type())); // load the size
-            return u64_type();
-        }
-
         // Lastly, it might be a builtin function
         if (const auto b = get_builtin_id(inner.name, params); b.has_value()) {
             const auto& builtin = get_builtin(*b);
@@ -939,6 +924,25 @@ auto push_expr_val(compiler& com, const node_call_expr& node) -> type_name
     push_expr_val(com, *node.expr);
     push_value(com.program, op::call, args_size);
     return *sig.return_type;
+}
+
+auto push_expr_val(compiler& com, const node_member_call_expr& node) -> type_name
+{
+    // Third, it might be a .size member function on a span, TODO: make it easier to add
+    // builtin member functions first arg is a pointer to a span, so need to deref with
+    // inner_type before checking if its a span. BUG: This will match ANY call a size
+    // function, and if the type of the argument is not an array, ptr or span, inner_type is
+    // not defined and we fail compilation.
+    //if (inner.name == "size" && node.args.size() == 1 &&
+    //    is_span_type(inner_type(type_of_expr(com, *node.args[0]))))
+    //{
+    //    push_expr_val(com, *node.args[0]); // push pointer to span
+    //    push_value(com.program, op::push_u64, size_of_ptr());
+    //    push_value(com.program, op::u64_add); // offset to the size value
+    //    push_value(com.program, op::load, com.types.size_of(u64_type())); // load the size
+    //    return u64_type();
+    //}
+    return null_type();
 }
 
 auto push_expr_val(compiler& com, const node_array_expr& node) -> type_name

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -264,12 +264,12 @@ auto ends_in_return(const node_stmt& node) -> bool
 
 auto assign_fn_params(const type_name& type) -> type_names
 {
-    return { type.add_ref(), type.add_ref() };
+    return { type.add_ptr(), type.add_const().add_ptr() };
 }
 
 auto copy_fn_params(const type_name& type) -> type_names
 {
-    return { type.add_ref() };
+    return { type.add_const().add_ptr() };
 }
 
 // Assumes that the given "push_object_ptr" is a function that compiles code to produce
@@ -768,6 +768,13 @@ auto get_converter(const type_name& src, const type_name& dst)
         return [](compiler& com, const node_expr& expr, const token& tok) {
             const auto type = push_expr_ptr(com, expr);
             push_value(com.program, op::push_u64, array_length(type));
+        };
+    }
+
+    // pointers can convert to pointers-to-const
+    if (src.is_ptr() && dst.is_ptr() && src.remove_ptr() == dst.remove_ptr().remove_const()) {
+        return [](compiler& com, const node_expr& expr, const token& tok) {
+            push_object_copy(com, expr, tok);
         };
     }
 

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -31,6 +31,23 @@ auto type_name::remove_ref() const -> type_name
     return *std::get<type_reference>(*this).inner_type;
 }
 
+auto type_name::is_ptr() const -> bool
+{
+    return std::holds_alternative<type_ptr>(*this);
+}
+
+auto type_name::add_ptr() const -> type_name
+{
+    if (is_ptr()) return *this;
+    return { type_ptr{ .inner_type{*this} } };
+}
+
+auto type_name::remove_ptr() const -> type_name
+{
+    if (!is_ptr()) return *this;
+    return *std::get<type_ptr>(*this).inner_type;
+}
+
 auto type_name::is_const() const -> bool
 {
     return std::holds_alternative<type_const>(*this);

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -96,6 +96,10 @@ struct type_name : public std::variant<
     auto add_ref() const -> type_name;
     auto remove_ref() const -> type_name;
 
+    auto is_ptr() const -> bool;
+    auto add_ptr() const -> type_name;
+    auto remove_ptr() const -> type_name;
+
     auto is_const() const -> bool;
     auto add_const() const -> type_name;
     auto remove_const() const -> type_name;


### PR DESCRIPTION
* `p.func()` is now valid when `p` is a pointer; it will dereference down to the original.
* Member functions now take pointers as their first args again. `assign` also takes `other` by pointer too.
* Added `node_member_call_expr` to the AST to implement member function calls in a more explicit way; parsing `x.foo(...)` as `typeof(x)::foo(x&, ...)` made it really hard to implement the dereferencing of the first arg in a non-hacky way.
* The new AST node also made it simpler to implement `.size()` on spans and this also fixes the bug of free functions called `size` getting picked in some cases.
* Also added `.size()` onto arrays as it was trivial to add.