### PR TITLE
Remove References

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -81,6 +81,7 @@
         "mutex": "cpp",
         "numeric": "cpp",
         "filesystem": "cpp",
-        "source_location": "cpp"
+        "source_location": "cpp",
+        "random": "cpp"
     }
 }

--- a/README.md
+++ b/README.md
@@ -34,13 +34,9 @@ An interpreted programming language written in C++. This started out as a stack-
     1. Syntax for function pointer types: `fn(<arg_types>) -> <return_type>`.
 
 * Variables:
-    * Declare with `:=` operator and either `let`, `var` or 'ref': `let x := 5` or `var x := 5`.
-    * `let` declares a const value, `var` declares a mutable value, and 'ref' declares a new name for an existing object.
+    * Declare with `:=` operator and either `let` or `var`: `let x := 5` or `var x := 5`.
+    * `let` declares a const value and `var` declares a mutable value.
     * Assign to existing variable with `=` operator: `x = 6`.
-
-* References:
-    * Similar to references in C++; cannot be rebound to different objects. Used to create aliases to existing objects and use simpler value syntax instead of pointer syntax. Soon these types will not be spellable directly and won't appear in the language; they will instead be used to implement nicer syntax across the language. A good example of this is the for-loop: the variable representing the current element is a reference, but you can treat it as if it's the original object itself.
-    * Will soon add `alias` as a keyword for creating alises of objects, as well as `read`, `mut` and `copy` as specifiers for functions arguments, which will use references where appropriate.
 
 * Comments using `#` symbol.
 
@@ -96,7 +92,7 @@ An interpreted programming language written in C++. This started out as a stack-
         x: f64;
         y: f64;
 
-        fn length2(ref self: const vec2) -> f64
+        fn length2(self: (const vec2)&) -> f64
         {
             return (self.x * self.x) + (self.y * self.y);
         }

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,15 +1,9 @@
 
-struct foo
-{
-    val: i64;
+let x := 30;
+var y := 10;
 
-    fn bar(self: foo&)
-    {
-        println(self.val);
-    }
-}
+var p1 := x&; # pointer-to-const
+var p2 := y&; # pointer
 
-var f := foo(10);
-var p := f&;
-var p2 := p&;
-p2.bar();
+
+p1 = p2;

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -126,10 +126,6 @@ auto print_node(const node_expr& root, int indent) -> void
                 print("{}LowerBound:\n", spaces);
                 print_node(*node.upper_bound, indent + 1);
             }
-        },
-        [&](const node_reference_expr& node) {
-            print("{}Reference:\n", spaces);
-            print_node(*node.expr, indent + 1);
         }
     }, root);
 }
@@ -220,11 +216,7 @@ auto print_node(const node_stmt& root, int indent) -> void
         [&](const node_function_def_stmt& node) {
             print("{}Function: {} (", spaces, node.name);
             print_comma_separated(node.sig.params, [](const auto& arg) {
-                if (arg.is_ref) {
-                    return std::format("ref {}: {}", arg.name, *arg.type);
-                } else {
-                    return std::format("{}: {}", arg.name, *arg.type);
-                }
+                return std::format("{}: {}", arg.name, *arg.type);
             });
             print(") -> {}\n", *node.sig.return_type);
             print_node(*node.body, indent + 1);
@@ -232,11 +224,7 @@ auto print_node(const node_stmt& root, int indent) -> void
         [&](const node_member_function_def_stmt& node) {
             print("{}MemberFunction: {}::{} (", spaces, node.struct_name, node.function_name);
             print_comma_separated(node.sig.params, [](const auto& arg) {
-                if (arg.is_ref) {
-                    return std::format("ref {}: {}", arg.name, *arg.type);
-                } else {
-                    return std::format("{}: {}", arg.name, *arg.type);
-                }
+                return std::format("{}: {}", arg.name, *arg.type);
             });
             print(") -> {}\n", *node.sig.return_type);
             print_node(*node.body, indent + 1);

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -42,7 +42,6 @@ struct node_parameter
 {
     std::string   name;
     node_type_ptr type;
-    bool          is_ref;
 };
 
 struct node_signature
@@ -198,13 +197,6 @@ struct node_new_expr
     anzu::token token;
 };
 
-struct node_reference_expr
-{
-    node_expr_ptr expr;
-
-    anzu::token token;
-};
-
 struct node_span_expr
 {
     node_expr_ptr expr;
@@ -233,7 +225,6 @@ struct node_expr : std::variant<
     node_addrof_expr,
     node_sizeof_expr,
     node_new_expr,
-    node_reference_expr,
 
     // Lvalue expressions
     node_name_expr,

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -408,7 +408,7 @@ auto push_object_copy(compiler& com, const node_expr& expr, const token& tok) ->
     }
 
     else if (type.is_array()) {
-        const auto etype = inner_type(type).remove_const();
+        const auto etype = type.remove_array().remove_const();
         const auto esize = com.types.size_of(etype);
 
         const auto params = copy_fn_params(etype);
@@ -1327,7 +1327,7 @@ void push_stmt(compiler& com, const node_assignment_stmt& node)
     }
     
     if (rhs.is_array()) {
-        const auto etype = inner_type(rhs);
+        const auto etype = rhs.remove_array();
         const auto inner_size = com.types.size_of(etype);
         const auto params = assign_fn_params(etype);
 
@@ -1484,10 +1484,10 @@ void push_stmt(compiler& com, const node_delete_stmt& node)
     const auto type = type_of_expr(com, *node.expr);
     if (type.is_span()) {
         push_expr_val(com, *node.expr);
-        push_value(com.program, op::dealloc_span, com.types.size_of(inner_type(type)));
+        push_value(com.program, op::dealloc_span, com.types.size_of(type.remove_span()));
     } else if (type.is_ptr()) {
         push_expr_val(com, *node.expr);
-        push_value(com.program, op::dealloc_ptr, com.types.size_of(inner_type(type)));
+        push_value(com.program, op::dealloc_ptr, com.types.size_of(type.remove_ptr()));
     } else {
         node.token.error("can only call delete spans and pointers, not {}", type);
     }

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -145,7 +145,7 @@ auto builtin_fputs(bytecode_context& ctx) -> void
 
 auto construct_builtin_array() -> std::vector<builtin>
 {
-    const auto char_span = concrete_span_type(char_type().add_const()).add_const();
+    const auto char_span = char_type().add_const().add_span().add_const();
 
     auto b = std::vector<builtin>{};
 

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -76,7 +76,6 @@ auto identifier_type(std::string_view token) -> token_type
     if (token == "loop")     return token_type::kw_loop;
     if (token == "new")      return token_type::kw_new;
     if (token == "null")     return token_type::kw_null;
-    if (token == "ref")      return token_type::kw_ref;
     if (token == "return")   return token_type::kw_return;
     if (token == "sizeof")   return token_type::kw_sizeof;
     if (token == "struct")   return token_type::kw_struct;

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -203,50 +203,52 @@ auto make_type(const std::string& name) -> type_name
     return { type_struct{ .name=name } };
 }
 
-auto concrete_array_type(const type_name& t, std::size_t size) -> type_name
+auto type_name::is_array() const -> bool
 {
-    return {type_array{ .inner_type = { t }, .count = size }};
+    return std::holds_alternative<type_array>(*this);
 }
 
-auto is_array_type(const type_name& t) -> bool
+auto type_name::add_array(std::size_t size) const -> type_name
 {
-    return std::holds_alternative<type_array>(t);
+    return {type_array{ .inner_type = { *this }, .count = size }};
 }
 
-auto concrete_ptr_type(const type_name& t) -> type_name
+auto type_name::remove_array() const -> type_name
 {
-    return {type_ptr{ .inner_type = { t } }};
+    if (!is_array()) return *this;
+    return *std::get<type_array>(*this).inner_type;
 }
 
-auto is_ptr_type(const type_name& t) -> bool
+auto type_name::is_span() const -> bool
 {
-    return std::holds_alternative<type_ptr>(t);
+    return std::holds_alternative<type_span>(*this);
 }
 
-auto concrete_span_type(const type_name& t) -> type_name
+auto type_name::add_span() const -> type_name
 {
-    return {type_span{ .inner_type = { t } }};
+    return {type_span{ .inner_type = { *this } }};
 }
 
-auto is_span_type(const type_name& t) -> bool
+auto type_name::remove_span() const -> type_name
 {
-    return std::holds_alternative<type_span>(t);
+    if (!is_span()) return *this;
+    return *std::get<type_span>(*this).inner_type;
 }
 
-auto is_function_ptr_type(const type_name& t) -> bool
+auto type_name::is_function_ptr() const -> bool
 {
-    return std::holds_alternative<type_function_ptr>(t);
+    return std::holds_alternative<type_function_ptr>(*this);
 }
 
 auto inner_type(const type_name& t) -> type_name
 {
-    if (is_array_type(t)) {
+    if (t.is_array()) {
         return *std::get<type_array>(t).inner_type;
     }
-    if (is_ptr_type(t)) {
+    if (t.is_ptr()) {
         return *std::get<type_ptr>(t).inner_type;
     }
-    if (is_span_type(t)) {
+    if (t.is_span()) {
         return *std::get<type_span>(t).inner_type; 
     }
     if (t.is_const()) {
@@ -259,7 +261,7 @@ auto inner_type(const type_name& t) -> type_name
 auto array_length(const type_name& t) -> std::size_t
 {
     const auto mut_type = t.remove_const();
-    panic_if(!is_array_type(mut_type), "Tried to get length of a non-array type");
+    panic_if(!mut_type.is_array(), "Tried to get length of a non-array type");
     return std::get<type_array>(mut_type).count;
 }
 

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -245,17 +245,11 @@ auto inner_type(const type_name& t) -> type_name
     if (t.is_array()) {
         return *std::get<type_array>(t).inner_type;
     }
-    if (t.is_ptr()) {
-        return *std::get<type_ptr>(t).inner_type;
-    }
     if (t.is_span()) {
         return *std::get<type_span>(t).inner_type; 
     }
-    if (t.is_const()) {
-        return t.remove_const();
-    }
     panic("tried to get the inner type of an invalid type category, "
-          "can only get the inner type for arrays, pointers, spans and references");
+          "can only get the inner type for arrays and spans");
 }
 
 auto array_length(const type_name& t) -> std::size_t

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -215,7 +215,7 @@ auto type_name::add_array(std::size_t size) const -> type_name
 
 auto type_name::remove_array() const -> type_name
 {
-    if (!is_array()) return *this;
+    panic_if(!is_array(), "Tried to strip array from non-array type {}", *this);
     return *std::get<type_array>(*this).inner_type;
 }
 
@@ -231,7 +231,7 @@ auto type_name::add_span() const -> type_name
 
 auto type_name::remove_span() const -> type_name
 {
-    if (!is_span()) return *this;
+    panic_if(!is_span(), "Tried to strip span from non-span type {}", *this);
     return *std::get<type_span>(*this).inner_type;
 }
 

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -85,15 +85,25 @@ struct type_name : public std::variant<
 {
     using variant::variant;
 
-    auto is_ptr() const -> bool;
-    auto add_ptr() const -> type_name;
-    auto remove_ptr() const -> type_name;
+    [[nodicard]] auto is_ptr() const -> bool;
+    [[nodicard]] auto add_ptr() const -> type_name;
+    [[nodicard]] auto remove_ptr() const -> type_name;
+ 
+    [[nodicard]] auto is_const() const -> bool;
+    [[nodicard]] auto add_const() const -> type_name;
+    [[nodicard]] auto remove_const() const -> type_name;
 
-    auto is_const() const -> bool;
-    auto add_const() const -> type_name;
-    auto remove_const() const -> type_name;
+    [[nodicard]] auto is_array() const -> bool;
+    [[nodicard]] auto add_array(std::size_t size) const -> type_name;
+    [[nodicard]] auto remove_array() const -> type_name;
 
-    auto strip_const() const -> std::pair<type_name, bool>;
+    [[nodicard]] auto is_span() const -> bool;
+    [[nodicard]] auto add_span() const -> type_name;
+    [[nodicard]] auto remove_span() const -> type_name;
+
+    [[nodicard]] auto is_function_ptr() const -> bool;
+
+    [[nodicard]] auto strip_const() const -> std::pair<type_name, bool>;
 };
 
 using type_names = std::vector<type_name>;
@@ -129,17 +139,6 @@ auto u64_type() -> type_name;
 auto f64_type() -> type_name;
 
 auto make_type(const std::string& name) -> type_name;
-
-auto concrete_array_type(const type_name& t, std::size_t size) -> type_name;
-auto is_array_type(const type_name& t) -> bool;
-
-auto concrete_ptr_type(const type_name& t) -> type_name;
-auto is_ptr_type(const type_name& t) -> bool;
-
-auto concrete_span_type(const type_name& t) -> type_name;
-auto is_span_type(const type_name& t) -> bool;
-
-auto is_function_ptr_type(const type_name& t) -> bool;
 
 auto size_of_ptr() -> std::size_t;
 

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -67,12 +67,6 @@ struct type_function_ptr
     auto operator==(const type_function_ptr&) const -> bool = default;
 };
 
-struct type_reference
-{
-    value_ptr<type_name> inner_type;
-    auto operator==(const type_reference&) const -> bool = default;
-};
-
 struct type_const
 {
     value_ptr<type_name> inner_type;
@@ -87,14 +81,9 @@ struct type_name : public std::variant<
     type_ptr,
     type_span,
     type_function_ptr,
-    type_reference,
     type_const>
 {
     using variant::variant;
-
-    auto is_ref() const -> bool;
-    auto add_ref() const -> type_name;
-    auto remove_ref() const -> type_name;
 
     auto is_ptr() const -> bool;
     auto add_ptr() const -> type_name;
@@ -105,9 +94,6 @@ struct type_name : public std::variant<
     auto remove_const() const -> type_name;
 
     auto strip_const() const -> std::pair<type_name, bool>;
-    auto strip_qualifiers() const -> std::tuple<type_name, bool, bool>;
-
-    auto remove_cr() const -> type_name;
 };
 
 using type_names = std::vector<type_name>;
@@ -132,7 +118,6 @@ auto hash(const type_array& type) -> std::size_t;
 auto hash(const type_ptr& type) -> std::size_t;
 auto hash(const type_span& type) -> std::size_t;
 auto hash(const type_function_ptr& type) -> std::size_t;
-auto hash(const type_reference& type) -> std::size_t;
 auto hash(const type_const& type) -> std::size_t;
 
 auto null_type() -> type_name;
@@ -187,7 +172,6 @@ auto to_string(const type_ptr& type) -> std::string;
 auto to_string(const type_span& type) -> std::string;
 auto to_string(const type_struct& type) -> std::string;
 auto to_string(const type_function_ptr& type) -> std::string;
-auto to_string(const type_reference& type) -> std::string;
 auto to_string(const type_const& type) -> std::string;
 
 // Runtime pointer helpers to determine if the pointer is in stack, heap or read-only memory.

--- a/src/token.cpp
+++ b/src/token.cpp
@@ -64,7 +64,6 @@ auto to_string(token_type tt) -> std::string_view
         case token_type::kw_loop:             return "loop";
         case token_type::kw_new:              return "new";
         case token_type::kw_null:             return "null";
-        case token_type::kw_ref:              return "ref";
         case token_type::kw_return:           return "return";
         case token_type::kw_sizeof:           return "sizeof";
         case token_type::kw_struct:           return "struct";

--- a/src/token.hpp
+++ b/src/token.hpp
@@ -52,7 +52,6 @@ enum class token_type
     kw_loop,
     kw_new,
     kw_null,
-    kw_ref,
     kw_return,
     kw_sizeof,
     kw_struct,


### PR DESCRIPTION
* References made the code confusing and the compiler code hard to reason about.
* The main reason for implementing references in the first place was to make parameter passing nicer and being able to use simple dot syntax rather than `@.`.
* Since pointers cannot be null either, one of the other main differences between refs and pointers in C++ doesn't apply to Anzu.
* With the previous changes to allow for dot access on pointers, this mostly goes away. `@.` is still available but not really needed.
* Moved all the `concrete_X_type` and `is_X_type` functions to be member functions on `type_name`, similar to the const and pointer functions.
* `inner_type()` now only works for arrays and spans. For pointers and const, use `remove_ptr` and `remove_const` instead.
* Removed the `ref` keyword.