### PR TITLE
Printing Char Spans

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -109,6 +109,7 @@
         "spanstream": "cpp",
         "syncstream": "cpp",
         "typeindex": "cpp",
-        "valarray": "cpp"
+        "valarray": "cpp",
+        "semaphore": "cpp"
     }
 }

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,2 +1,1 @@
-
 print("Hello {}\n", "world");

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,8 +1,2 @@
-# while-statements
 
-    var idx := 0;
-    while idx < 10 {
-        print("a{}b, ", idx);
-        idx = idx + 1;
-    }
-    print("--");
+print("Hello {}\n", "world");

--- a/src/bytecode.cpp
+++ b/src/bytecode.cpp
@@ -286,21 +286,13 @@ auto apply_op(const bytecode_program& prog, bytecode_context& ctx) -> void
             const auto size = pop_value<std::uint64_t>(ctx.stack);
             const auto index = pop_value<std::uint64_t>(ctx.stack);
 
-            if (is_heap_ptr(index)) {
-                const auto ptr = unset_heap_bit(index);
-                const auto data = std::string_view{reinterpret_cast<const char*>(&ctx.heap[ptr]), size};
-                std::print("{}", data);
-            }
-            else if (is_rom_ptr(index)) {
-                const auto ptr = unset_rom_bit(index);
-                const auto data = std::string_view{reinterpret_cast<const char*>(&ctx.rom[ptr]), size};
-                std::print("{}", data);
-            }
-            else {
-                const auto ptr = index;
-                const auto data = std::string_view{reinterpret_cast<const char*>(&ctx.stack[ptr]), size};
-                std::print("{}", data);
-            }
+            const auto ptr = [&] {
+                if (is_heap_ptr(index)) return reinterpret_cast<const char*>(&ctx.heap[unset_heap_bit(index)]);
+                if (is_rom_ptr(index))  return reinterpret_cast<const char*>(&ctx.rom[unset_rom_bit(index)]);
+                return reinterpret_cast<const char*>(&ctx.stack[index]);
+            }();
+
+            std::print("{}", std::string_view{ptr, size});
         } break;
 
         default: { runtime_error("unknown op code! ({})", static_cast<int>(op_code)); } break;

--- a/src/bytecode.hpp
+++ b/src/bytecode.hpp
@@ -102,7 +102,7 @@ enum class op : std::uint8_t
     print_i64,
     print_u64,
     print_f64,
-    print_string_literal,
+    print_char_span,
 };
 
 using bytecode = std::vector<std::byte>;

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -1537,7 +1537,7 @@ auto push_print_fundamental(compiler& com, const node_expr& node, const token& t
     else if (type == i64_type()) { push_value(com.program, op::print_i64); }
     else if (type == u64_type()) { push_value(com.program, op::print_u64); }
     else if (type == f64_type()) { push_value(com.program, op::print_f64); }
-    else if (type == char_type().add_const().add_span()) {
+    else if (type == char_type().add_const().add_span() || type == char_type().add_span()) {
         push_value(com.program, op::print_char_span);
     }
     else { tok.error("Cannot print value of type {}", type); }


### PR DESCRIPTION
* Rename `op::print_string_literal` to `op::print_char_span`, which now works for any kind of span, including the stack and heap.
* Allow for passing a `char[]` or `(const char)[]` to print is now valid.
