### PR TITLE
Runtime Cleanups

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,7 @@
             "program": "${workspaceFolder}/build/src/Debug/anzu.exe",
             "args": [
                 "${workspaceFolder}/examples/test.az",
-                "run"
+                "com"
             ],
             "stopAtEntry": false,
             "cwd": "${fileDirname}",

--- a/examples/feature_test.az
+++ b/examples/feature_test.az
@@ -285,10 +285,19 @@ struct container
     print("{}\n", p.val);
 }
 
-# dynamic memory check
+# Dynamic memory check
 unsafe {
     var x := new i64;
     x@ = 5;
     print("{}\n", x@);
     delete x;
 }
+
+# Function pointer check
+fn print_success() -> null
+{
+    print("Success!\n");
+}
+
+#var function_ptr := print_success;
+#function_ptr();

--- a/examples/test.az
+++ b/examples/test.az
@@ -6,4 +6,3 @@ struct foo
 var f := foo(5);
 var x := 0;
 var y := 1;
-ref a := z;

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,10 +1,8 @@
 # Function pointer check
-fn print_success(y: i64) -> null
+fn print_success() -> null
 {
     print("Success!\n");
 }
 
-let x := 5;
-let y := 10;
 var function_ptr := print_success;
-function_ptr(x);
+function_ptr();

--- a/examples/test.az
+++ b/examples/test.az
@@ -6,5 +6,4 @@ struct foo
 var f := foo(5);
 var x := 0;
 var y := 1;
-
-x + f.x = 10;
+ref a := z;

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,8 +1,10 @@
-struct foo
+# Function pointer check
+fn print_success(y: i64) -> null
 {
-    x: i64;
+    print("Success!\n");
 }
 
-var f := foo(5);
-var x := 0;
-var y := 1;
+let x := 5;
+let y := 10;
+var function_ptr := print_success;
+function_ptr(x);

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -197,12 +197,7 @@ auto print_node(const node_stmt& root, int indent) -> void
         [&](const node_declaration_stmt& node) {
             print("{}Declaration:\n", spaces);
             print("{}- Name: {}\n", spaces, node.name);
-            switch (node.qual) {
-                using enum node_declaration_stmt::qualifier;
-                case var: { print("{}- Var\n", spaces); } break;
-                case let: { print("{}- Let\n", spaces); } break;
-                case ref: { print("{}- Ref\n", spaces); } break;
-            }
+            print("{}- AddConst: {}\n", spaces, node.add_const);
             print("{}- Value:\n", spaces);
             print_node(*node.expr, indent + 1);
         },

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -303,11 +303,9 @@ struct node_continue_stmt
 
 struct node_declaration_stmt
 {
-    enum class qualifier { var, let, ref };
-
     std::string   name;
-    qualifier     qual;
     node_expr_ptr expr;
+    bool          add_const;
 
     anzu::token token;
 };

--- a/src/bytecode.cpp
+++ b/src/bytecode.cpp
@@ -36,7 +36,7 @@ auto binary_op(bytecode_context& ctx) -> void
 }
 
 template <typename Type>
-auto print_op(bytecode_context& ctx) -> void
+auto print_value(bytecode_context& ctx) -> void
 {
     const auto obj = ctx.stack.pop<Type>();
     std::print("{}", obj);
@@ -109,16 +109,12 @@ auto apply_op(bytecode_context& ctx) -> void
         case op::load: {
             const auto size = read_advance<std::uint64_t>(ctx);
             const auto ptr = ctx.stack.pop<std::byte*>();
-
-            for (std::size_t i = 0; i != size; ++i) {
-                ctx.stack.push(*(ptr + i));
-            }
+            ctx.stack.push(ptr, size);
         } break;
         case op::save: {
             const auto size = read_advance<std::uint64_t>(ctx);
             const auto ptr = ctx.stack.pop<std::byte*>();
-            std::memcpy(ptr, &ctx.stack.at(ctx.stack.size() - size), size);
-            ctx.stack.pop_n(size);
+            ctx.stack.pop_and_save(ptr, size);
         } break;
         case op::pop: {
             const auto size = read_advance<std::uint64_t>(ctx);
@@ -163,7 +159,6 @@ auto apply_op(bytecode_context& ctx) -> void
             const auto size = read_advance<std::uint64_t>(ctx);
             std::memcpy(&ctx.stack.at(frame.base_ptr), &ctx.stack.at(ctx.stack.size() - size), size);
             ctx.stack.resize(frame.base_ptr + size);
-
             ctx.frames.pop_back();
         } break;
         case op::call: {
@@ -260,10 +255,10 @@ auto apply_op(bytecode_context& ctx) -> void
             const auto c = ctx.stack.pop<char>();
             std::print("{}", c);
         } break;
-        case op::print_i32: { print_op<std::int32_t>(ctx); } break;
-        case op::print_i64: { print_op<std::int64_t>(ctx); } break;
-        case op::print_u64: { print_op<std::uint64_t>(ctx); } break;
-        case op::print_f64: { print_op<double>(ctx); } break;
+        case op::print_i32: { print_value<std::int32_t>(ctx); } break;
+        case op::print_i64: { print_value<std::int64_t>(ctx); } break;
+        case op::print_u64: { print_value<std::uint64_t>(ctx); } break;
+        case op::print_f64: { print_value<double>(ctx); } break;
         case op::print_char_span: {
             const auto size = ctx.stack.pop<std::uint64_t>();
             const auto ptr = ctx.stack.pop<const char*>();

--- a/src/bytecode.cpp
+++ b/src/bytecode.cpp
@@ -52,7 +52,6 @@ auto read_at(const bytecode_context& ctx, std::size_t& ptr) -> T
     return ret;
 }
 
-
 template <typename T>
 requires std::integral<T> || std::floating_point<T> || std::is_same_v<T, std::byte*> || std::is_same_v<T, op>
 auto read_advance(bytecode_context& ctx) -> T

--- a/src/bytecode.cpp
+++ b/src/bytecode.cpp
@@ -43,12 +43,13 @@ auto print_op(bytecode_context& ctx) -> void
 }
 
 template <typename T>
-requires std::integral<T> || std::floating_point<T> || std::is_same_v<T, std::byte*>
-auto read_advance(const bytecode_context& ctx, std::size_t& ptr) -> T
+requires std::integral<T> || std::floating_point<T> || std::is_same_v<T, std::byte*> || std::is_same_v<T, op>
+auto read_advance(bytecode_context& ctx) -> T
 {
+    const auto ptr = ctx.frames.back().prog_ptr;
     auto ret = T{0};
     std::memcpy(&ret, &ctx.code[ptr], sizeof(T));
-    ptr += sizeof(T);
+    ctx.frames.back().prog_ptr += sizeof(T);
     return ret;
 }
 
@@ -80,8 +81,8 @@ auto apply_op(bytecode_context& ctx) -> void
             push_from_program<std::uint64_t>(ctx);
         } break;
         case op::push_string_literal: {
-            const auto index = read_advance<std::uint64_t>(ctx, frame.prog_ptr);
-            const auto size = read_advance<std::uint64_t>(ctx, frame.prog_ptr);
+            const auto index = read_advance<std::uint64_t>(ctx);
+            const auto size = read_advance<std::uint64_t>(ctx);
             ctx.stack.push(&ctx.rom[index]);
             ctx.stack.push(size);
         } break;
@@ -89,17 +90,17 @@ auto apply_op(bytecode_context& ctx) -> void
             ctx.stack.push(std::byte{0});
         } break;
         case op::push_ptr_global: {
-            const auto offset = read_advance<std::uint64_t>(ctx, frame.prog_ptr);
+            const auto offset = read_advance<std::uint64_t>(ctx);
             std::byte* ptr = &ctx.stack.at(offset);
             ctx.stack.push(ptr);
         } break;
         case op::push_ptr_local: {
-            const auto offset = read_advance<std::uint64_t>(ctx, frame.prog_ptr);
+            const auto offset = read_advance<std::uint64_t>(ctx);
             std::byte* ptr = &ctx.stack.at(frame.base_ptr + offset);
             ctx.stack.push(ptr);
         } break;
         case op::load: {
-            const auto size = read_advance<std::uint64_t>(ctx, frame.prog_ptr);
+            const auto size = read_advance<std::uint64_t>(ctx);
             const auto ptr = ctx.stack.pop<std::byte*>();
 
             for (std::size_t i = 0; i != size; ++i) {
@@ -107,59 +108,59 @@ auto apply_op(bytecode_context& ctx) -> void
             }
         } break;
         case op::save: {
-            const auto size = read_advance<std::uint64_t>(ctx, frame.prog_ptr);
+            const auto size = read_advance<std::uint64_t>(ctx);
             const auto ptr = ctx.stack.pop<std::byte*>();
             std::memcpy(ptr, &ctx.stack.at(ctx.stack.size() - size), size);
             ctx.stack.pop_n(size);
         } break;
         case op::pop: {
-            const auto size = read_advance<std::uint64_t>(ctx, frame.prog_ptr);
+            const auto size = read_advance<std::uint64_t>(ctx);
             ctx.stack.pop_n(size);
         } break;
         case op::alloc_span: {
-            const auto type_size = read_advance<std::uint64_t>(ctx, frame.prog_ptr);
+            const auto type_size = read_advance<std::uint64_t>(ctx);
             const auto count = ctx.stack.pop<std::uint64_t>();
             const auto ptr = (std::byte*)std::malloc(count * type_size);
             ctx.heap_size += count * type_size;
             ctx.stack.push(ptr);
         } break;
         case op::dealloc_span: {
-            const auto type_size = read_advance<std::uint64_t>(ctx, frame.prog_ptr);
+            const auto type_size = read_advance<std::uint64_t>(ctx);
             const auto count = ctx.stack.pop<std::uint64_t>();
             const auto ptr = ctx.stack.pop<std::byte*>();
             ctx.heap_size -= count * type_size;
             std::free(ptr);
         } break;
         case op::alloc_ptr: {
-            const auto type_size = read_advance<std::uint64_t>(ctx, frame.prog_ptr);
+            const auto type_size = read_advance<std::uint64_t>(ctx);
             const auto ptr = (std::byte*)std::malloc(type_size);
             ctx.heap_size += type_size;
             ctx.stack.push(ptr);
         } break;
         case op::dealloc_ptr: {
-            const auto type_size = read_advance<std::uint64_t>(ctx, frame.prog_ptr);
+            const auto type_size = read_advance<std::uint64_t>(ctx);
             const auto ptr = ctx.stack.pop<std::byte*>();
             ctx.heap_size -= type_size;
             std::free(ptr);
         } break;
         case op::jump: {
-            frame.prog_ptr = read_advance<std::uint64_t>(ctx, frame.prog_ptr);
+            frame.prog_ptr = read_advance<std::uint64_t>(ctx);
         } break;
         case op::jump_if_false: {
-            const auto jump = read_advance<std::uint64_t>(ctx, frame.prog_ptr);
+            const auto jump = read_advance<std::uint64_t>(ctx);
             if (!ctx.stack.pop<bool>()) {
                 frame.prog_ptr = jump;
             }
         } break;
         case op::ret: {
-            const auto size = read_advance<std::uint64_t>(ctx, frame.prog_ptr);
+            const auto size = read_advance<std::uint64_t>(ctx);
             std::memcpy(&ctx.stack.at(frame.base_ptr), &ctx.stack.at(ctx.stack.size() - size), size);
             ctx.stack.resize(frame.base_ptr + size);
 
             ctx.frames.pop_back();
         } break;
         case op::call: {
-            const auto args_size = read_advance<std::uint64_t>(ctx, frame.prog_ptr);
+            const auto args_size = read_advance<std::uint64_t>(ctx);
             const auto prog_ptr = ctx.stack.pop<std::uint64_t>();
             ctx.frames.push_back(call_frame{
                 .prog_ptr = prog_ptr,
@@ -168,12 +169,12 @@ auto apply_op(bytecode_context& ctx) -> void
 
         } break;
         case op::builtin_call: {
-            const auto id = read_advance<std::uint64_t>(ctx, frame.prog_ptr);
+            const auto id = read_advance<std::uint64_t>(ctx);
             get_builtin(id).ptr(ctx);
         } break;
         case op::assert: {
-            const auto index = read_advance<std::uint64_t>(ctx, frame.prog_ptr);
-            const auto size = read_advance<std::uint64_t>(ctx, frame.prog_ptr);
+            const auto index = read_advance<std::uint64_t>(ctx);
+            const auto size = read_advance<std::uint64_t>(ctx);
             if (!ctx.stack.pop<bool>()) {
                 const auto data = &ctx.rom[index];
                 runtime_error("{}", std::string_view{data, size});
@@ -266,108 +267,108 @@ auto apply_op(bytecode_context& ctx) -> void
     }
 }
 
-auto print_op(const bytecode_program& prog, std::size_t ptr) -> std::size_t
+auto print_op(bytecode_context& ctx) -> std::size_t
 {
-    std::size_t start = ptr;
-    std::print("[{:>3}] ", ptr);
-    const auto op_code = static_cast<op>(prog.code[ptr++]);
+    std::size_t start = ctx.frames.back().prog_ptr;
+    std::print("[{:>3}] ", start);
+    const auto op_code = read_advance<op>(ctx);
     switch (op_code) {
         case op::push_i32: {
-            const auto value = read_advance<std::int32_t>(prog, ptr);
+            const auto value = read_advance<std::int32_t>(ctx);
             std::print("PUSH_I32: {}\n", value);
         } break;
         case op::push_i64: {
-            const auto value = read_advance<std::int64_t>(prog, ptr);
+            const auto value = read_advance<std::int64_t>(ctx);
             std::print("PUSH_I64: {}\n", value);
         } break;
         case op::push_u64: {
-            const auto value = read_advance<std::uint64_t>(prog, ptr);
+            const auto value = read_advance<std::uint64_t>(ctx);
             std::print("PUSH_U64: {}\n", value);
         } break;
         case op::push_f64: {
-            const auto value = read_advance<double>(prog, ptr);
+            const auto value = read_advance<double>(ctx);
             std::print("PUSH_F64: {}\n", value);
         } break;
         case op::push_char: {
-            const auto value = read_advance<char>(prog, ptr);
+            const auto value = read_advance<char>(ctx);
             std::print("PUSH_CHAR: {}\n", value);
         } break;
         case op::push_bool: {
-            const auto value = read_advance<bool>(prog, ptr);
+            const auto value = read_advance<bool>(ctx);
             std::print("PUSH_BOOL: {}\n", value);
         } break;
         case op::push_null: {
             std::print("PUSH_NULL\n");
         } break;
         case op::push_string_literal: {
-            const auto index = read_advance<std::uint64_t>(prog, ptr);
-            const auto size = read_advance<std::uint64_t>(prog, ptr);
-            const auto data = reinterpret_cast<const char*>(&prog.rom[index]);
+            const auto index = read_advance<std::uint64_t>(ctx);
+            const auto size = read_advance<std::uint64_t>(ctx);
+            const auto data = &ctx.rom[index];
             const auto m = std::string_view(data, size);
             std::print("PUSH_STRING_LITERAL: '{}'\n", m);
         } break;
         case op::push_ptr_global: {
-            const auto offset = read_advance<std::uint64_t>(prog, ptr);
+            const auto offset = read_advance<std::uint64_t>(ctx);
             std::print("PUSH_PTR_GLOBAL: {}\n", offset);
         } break;
         case op::push_ptr_local: {
-            const auto offset = read_advance<std::uint64_t>(prog, ptr);
+            const auto offset = read_advance<std::uint64_t>(ctx);
             std::print("PUSH_PTR_LOCAL: base_ptr + {}\n", offset);
         } break;
         case op::load: {
-            const auto size = read_advance<std::uint64_t>(prog, ptr);
+            const auto size = read_advance<std::uint64_t>(ctx);
             std::print("LOAD: {}\n", size);
         } break;
         case op::save: {
-            const auto size = read_advance<std::uint64_t>(prog, ptr);
+            const auto size = read_advance<std::uint64_t>(ctx);
             std::print("SAVE: {}\n", size);
         } break;
         case op::pop: {
-            const auto size = read_advance<std::uint64_t>(prog, ptr);
+            const auto size = read_advance<std::uint64_t>(ctx);
             std::print("POP: {}\n", size);
         } break;
         case op::alloc_span: {
-            const auto type_size = read_advance<std::uint64_t>(prog, ptr);
+            const auto type_size = read_advance<std::uint64_t>(ctx);
             std::print("ALLOC_SPAN: type_size={}\n", type_size);
         } break;
         case op::dealloc_span: {
-            const auto type_size = read_advance<std::uint64_t>(prog, ptr);
+            const auto type_size = read_advance<std::uint64_t>(ctx);
             std::print("DEALLOC_SPAN: type_size={}\n", type_size);
         } break;
         case op::alloc_ptr: {
-            const auto type_size = read_advance<std::uint64_t>(prog, ptr);
+            const auto type_size = read_advance<std::uint64_t>(ctx);
             std::print("ALLOC_PTR: type_size={}\n", type_size);
         } break;
         case op::dealloc_ptr: {
-            const auto type_size = read_advance<std::uint64_t>(prog, ptr);
+            const auto type_size = read_advance<std::uint64_t>(ctx);
             std::print("DEALLOC_PTR: type_size={}\n", type_size);
         } break;
         case op::jump: {
-            const auto jump = read_advance<std::uint64_t>(prog, ptr);
+            const auto jump = read_advance<std::uint64_t>(ctx);
             std::print("JUMP: jump={}\n", jump);
         } break;
         case op::jump_if_false: {
-            const auto jump = read_advance<std::uint64_t>(prog, ptr);
+            const auto jump = read_advance<std::uint64_t>(ctx);
             std::print("JUMP_IF_FALSE: jump={}\n", jump);
         } break;
         case op::ret: {
-            const auto type_size = read_advance<std::uint64_t>(prog, ptr);
+            const auto type_size = read_advance<std::uint64_t>(ctx);
             std::print("RETURN: type_size={}\n", type_size);
         } break;
         case op::call: {
-            const auto args_size = read_advance<std::uint64_t>(prog, ptr);
+            const auto args_size = read_advance<std::uint64_t>(ctx);
             std::print("CALL: args_size={}\n", args_size);
         } break;
         case op::builtin_call: {
-            const auto id = read_advance<std::uint64_t>(prog, ptr);
+            const auto id = read_advance<std::uint64_t>(ctx);
             const auto& b = get_builtin(id);
             std::print("BUILTIN_CALL: {}({}) -> {}\n",
                   b.name, format_comma_separated(b.args), b.return_type);
         } break;
         case op::assert: {
-            const auto index = read_advance<std::uint64_t>(prog, ptr);
-            const auto size = read_advance<std::uint64_t>(prog, ptr);
-            const auto data = reinterpret_cast<const char*>(&prog.rom[index]);
+            const auto index = read_advance<std::uint64_t>(ctx);
+            const auto size = read_advance<std::uint64_t>(ctx);
+            const auto data = &ctx.rom[index];
             std::print("ASSERT: msg={}\n", std::string_view{data, size});
         } break;
         case op::char_eq: { std::print("CHAR_EQ\n"); } break;
@@ -437,7 +438,9 @@ auto print_op(const bytecode_program& prog, std::size_t ptr) -> std::size_t
             return 0;
         } break;
     }
-    return ptr - start;
+    const auto op_size = ctx.frames.back().prog_ptr - start;
+    ctx.frames.back().prog_ptr = start; // unwind back to the original position
+    return op_size;
 }
 
 }
@@ -447,7 +450,6 @@ auto run_program(const bytecode_program& prog) -> void
     const auto timer = scope_timer{};
 
     bytecode_context ctx{prog};
-    ctx.frames.emplace_back();
     while (ctx.frames.back().prog_ptr < prog.code.size()) {
         apply_op(ctx);
     }
@@ -466,10 +468,9 @@ auto run_program_debug(const bytecode_program& prog) -> void
     const auto timer = scope_timer{};
 
     bytecode_context ctx{prog};
-    ctx.frames.emplace_back();
     std::print("stack_base = {}\nrom_base = {}\n", (void*)&ctx.stack.at(0), (void*)&ctx.rom.at(0));
     while (ctx.frames.back().prog_ptr < prog.code.size()) {
-        print_op(prog, ctx.frames.back().prog_ptr);
+        print_op(ctx);
         apply_op(ctx);
     }
 
@@ -480,11 +481,10 @@ auto run_program_debug(const bytecode_program& prog) -> void
 
 auto print_program(const bytecode_program& prog) -> void
 {
-    auto ptr = std::size_t{0};
-    while (ptr < prog.code.size()) {
-        const auto offset = print_op(prog, ptr);
-        if (offset == 0) return;
-        ptr += offset;
+    auto ctx = bytecode_context{prog};
+    while (ctx.frames.back().prog_ptr < ctx.code.size()) {
+        const auto op_size = print_op(ctx);
+        ctx.frames.back().prog_ptr += op_size;
     }
 }
 

--- a/src/bytecode.hpp
+++ b/src/bytecode.hpp
@@ -110,20 +110,24 @@ struct call_frame
     std::size_t base_ptr = 0;
 };
 
-struct bytecode_context
-{
-    std::vector<call_frame> frames;
-    vm_stack stack;
-    vm_rom rom;
-    std::int64_t heap_size = 0;
-
-    bytecode_context(std::string_view rom) : rom{rom} {}
-};
-
 struct bytecode_program
 {
     std::vector<std::byte> code;
     std::string            rom;
+};
+
+struct bytecode_context
+{
+    std::vector<std::byte> code;
+    std::vector<call_frame> frames;
+    vm_stack stack;
+    std::string rom;
+    std::int64_t heap_size = 0;
+
+    bytecode_context(const bytecode_program& program)
+        : code{program.code}
+        , rom{program.rom} 
+    {}
 };
 
 auto run_program(const bytecode_program& prog) -> void;

--- a/src/bytecode.hpp
+++ b/src/bytecode.hpp
@@ -127,7 +127,9 @@ struct bytecode_context
     bytecode_context(const bytecode_program& program)
         : code{program.code}
         , rom{program.rom} 
-    {}
+    {
+        frames.emplace_back();
+    }
 };
 
 auto run_program(const bytecode_program& prog) -> void;

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -1277,15 +1277,10 @@ void push_stmt(compiler& com, const node_continue_stmt& node)
 
 auto push_stmt(compiler& com, const node_declaration_stmt& node) -> void
 {
-    const auto type = [&] {
-        switch (node.qual) {
-            using enum node_declaration_stmt::qualifier;
-            case var: return push_object_copy(com, *node.expr, node.token);
-            case let: return push_object_copy(com, *node.expr, node.token).add_const();
-            case ref: return push_expr_ptr(com, *node.expr);
-            default: node.token.error("Logic error: declaration isn't using var, let or ref");
-        }
-    }();
+    auto type = push_object_copy(com, *node.expr, node.token);
+    if (node.add_const) {
+        type = type.add_const();
+    }
     
     declare_var(com, node.token, node.name, type);
 }

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -459,7 +459,7 @@ auto push_assert(compiler& com, std::string_view message) -> void
 
 auto push_expr_ptr(compiler& com, const node_name_expr& node) -> type_name
 {
-    if (auto func = get_function(com, "", node.name)) {
+    if (auto func = get_function(com, to_string(global_namespace), node.name)) {
         node.token.error("cannot take address of a function pointer");
     }
 
@@ -471,7 +471,7 @@ auto push_expr_ptr(compiler& com, const node_name_expr& node) -> type_name
 // are lvalues, so that may cause trouble; we should find out how.
 auto push_expr_val(compiler& com, const node_name_expr& node) -> type_name
 {
-    if (auto func = get_function(com, "", node.name)) {
+    if (auto func = get_function(com, to_string(global_namespace), node.name)) {
         const auto& info = *func;
         push_value(com.program, op::push_u64, info.ptr);
 

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -495,7 +495,7 @@ auto push_expr_ptr(compiler& com, const node_field_expr& node) -> type_name
 
     // Allow for field access on a pointer
     while (type.is_ptr()) {
-        push_value(com.program, op::load, size_of_ptr());
+        push_value(com.program, op::load, sizeof(std::byte*));
         type = type.remove_ptr();
     }
 
@@ -525,7 +525,7 @@ auto push_expr_ptr(compiler& com, const node_subscript_expr& node) -> type_name
     // If we are a span, we want the address that it holds rather than its own address,
     // so switch the pointer by loading what it's pointing at.
     if (is_span) {
-        push_value(com.program, op::load, size_of_ptr());
+        push_value(com.program, op::load, sizeof(std::byte*));
     }
 
     // Bounds checking on the subscript, it's unsigned so only need to check upper bound
@@ -536,7 +536,7 @@ auto push_expr_ptr(compiler& com, const node_subscript_expr& node) -> type_name
             push_value(com.program, op::push_u64, array_length(real_type));
         } else {
             push_expr_ptr(com, *node.expr);
-            push_value(com.program, op::push_u64, size_of_ptr());
+            push_value(com.program, op::push_u64, sizeof(std::byte*));
             push_value(com.program, op::u64_add); // offset to the size value
             push_value(com.program, op::load, com.types.size_of(u64_type())); // load the size
         }
@@ -883,7 +883,7 @@ auto push_expr_val(compiler& com, const node_member_call_expr& node) -> type_nam
     if (type.is_span() && node.function_name == "size") {
         node.token.assert(node.other_args.empty(), "{}.size() takes no extra arguments", type);
         push_expr_ptr(com, *node.expr); // push pointer to span
-        push_value(com.program, op::push_u64, size_of_ptr());
+        push_value(com.program, op::push_u64, sizeof(std::byte*));
         push_value(com.program, op::u64_add); // offset to the size value
         push_value(com.program, op::load, com.types.size_of(u64_type())); // load the size
         return u64_type();
@@ -907,7 +907,7 @@ auto push_expr_val(compiler& com, const node_member_call_expr& node) -> type_nam
 
     auto t = push_expr_ptr(com, *node.expr); // self
     while (t.is_ptr()) { // allow for calling member functions through pointers
-        push_value(com.program, op::load, size_of_ptr());
+        push_value(com.program, op::load, sizeof(std::byte*));
         t = t.remove_ptr();
     }
     for (std::size_t i = 0; i != node.other_args.size(); ++i) {
@@ -988,7 +988,7 @@ auto push_expr_val(compiler& com, const node_span_expr& node) -> type_name
     // If we are a span, we want the address that it holds rather than its own address,
     // so switch the pointer by loading what it's pointing at.
     if (type.is_span()) {
-        push_value(com.program, op::load, size_of_ptr());
+        push_value(com.program, op::load, sizeof(std::byte*));
     }
 
     if (node.lower_bound) {// move first index of span up
@@ -1007,7 +1007,7 @@ auto push_expr_val(compiler& com, const node_span_expr& node) -> type_name
     } else if (type.is_span()) {
         // Push the span pointer, offset to the size, and load the size
         push_expr_ptr(com, *node.expr);
-        push_value(com.program, op::push_u64, size_of_ptr(), op::u64_add);
+        push_value(com.program, op::push_u64, sizeof(std::byte*), op::u64_add);
         push_value(com.program, op::load, com.types.size_of(u64_type()));
     } else {
         push_value(com.program, op::push_u64, array_length(type));
@@ -1171,7 +1171,7 @@ void push_stmt(compiler& com, const node_for_stmt& node)
     } else {
         node.token.assert(is_lvalue_expr(*node.iter), "for-loops only supported for lvalue spans");
         push_expr_ptr(com, *node.iter); // push pointer to span
-        push_value(com.program, op::push_u64, size_of_ptr());
+        push_value(com.program, op::push_u64, sizeof(std::byte*));
         push_value(com.program, op::u64_add); // offset to the size value
         push_value(com.program, op::load, com.types.size_of(u64_type()));       
         declare_var(com, node.token, "#:size", u64_type());
@@ -1195,7 +1195,7 @@ void push_stmt(compiler& com, const node_for_stmt& node)
         } else {
             push_expr_ptr(com, *node.iter);
             if (iter_type.is_span()) {
-                push_value(com.program, op::load, size_of_ptr());
+                push_value(com.program, op::load, sizeof(std::byte*));
             }
         }
         load_variable(com, node.token, "#:idx");

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -29,12 +29,6 @@ enum class type_fundamental : std::uint8_t
     f64_type,
 };
 
-//struct type_fundamental
-//{
-//    fundamental type;
-//    auto operator==(const type_fundamental&) const -> bool = default;
-//};
-
 struct type_struct
 {
     std::string name;

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -175,18 +175,6 @@ auto to_string(const type_struct& type) -> std::string;
 auto to_string(const type_function_ptr& type) -> std::string;
 auto to_string(const type_const& type) -> std::string;
 
-// Runtime pointer helpers to determine if the pointer is in stack, heap or read-only memory.
-static constexpr auto heap_bit = std::uint64_t{1} << 63;
-static constexpr auto rom_bit  = std::uint64_t{1} << 62;
-
-inline auto set_heap_bit(std::uint64_t x)   -> std::uint64_t { return x | heap_bit; }
-inline auto unset_heap_bit(std::uint64_t x) -> std::uint64_t { return x & ~heap_bit; }
-inline auto is_heap_ptr(std::uint64_t x)    -> bool          { return x & heap_bit; }
- 
-inline auto set_rom_bit(std::uint64_t x)   -> std::uint64_t { return x | rom_bit; }
-inline auto unset_rom_bit(std::uint64_t x) -> std::uint64_t { return x & ~rom_bit; }
-inline auto is_rom_ptr(std::uint64_t x)    -> bool          { return x & rom_bit; }
-
 }
 
 template <>

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -18,7 +18,7 @@ static_assert(std::is_same_v<std::uint64_t, std::size_t>);
 
 struct type_name;
 
-enum class fundamental : std::uint8_t
+enum class type_fundamental : std::uint8_t
 {
     null_type,
     bool_type,
@@ -29,11 +29,11 @@ enum class fundamental : std::uint8_t
     f64_type,
 };
 
-struct type_fundamental
-{
-    fundamental type;
-    auto operator==(const type_fundamental&) const -> bool = default;
-};
+//struct type_fundamental
+//{
+//    fundamental type;
+//    auto operator==(const type_fundamental&) const -> bool = default;
+//};
 
 struct type_struct
 {
@@ -141,8 +141,6 @@ auto u64_type() -> type_name;
 auto f64_type() -> type_name;
 
 auto make_type(const std::string& name) -> type_name;
-
-auto size_of_ptr() -> std::size_t;
 
 // Extracts the single inner type of the given t. Undefined if the given t is not a compound
 // type with a single subtype.

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -326,13 +326,13 @@ auto parse_expression(tokenstream& tokens) -> node_expr_ptr
 auto parse_simple_type(tokenstream& tokens) -> type_name
 {
     const auto tok = tokens.consume();
-    if (tok.text == "null") return { type_fundamental{ .type=fundamental::null_type }};
-    if (tok.text == "bool") return { type_fundamental{ .type=fundamental::bool_type }};
-    if (tok.text == "char") return { type_fundamental{ .type=fundamental::char_type }};
-    if (tok.text == "i32")  return { type_fundamental{ .type=fundamental::i32_type  }};
-    if (tok.text == "i64")  return { type_fundamental{ .type=fundamental::i64_type  }};
-    if (tok.text == "u64")  return { type_fundamental{ .type=fundamental::u64_type  }};
-    if (tok.text == "f64")  return { type_fundamental{ .type=fundamental::f64_type  }};
+    if (tok.text == "null") return type_fundamental::null_type;
+    if (tok.text == "bool") return type_fundamental::bool_type;
+    if (tok.text == "char") return type_fundamental::char_type;
+    if (tok.text == "i32")  return type_fundamental::i32_type;
+    if (tok.text == "i64")  return type_fundamental::i64_type;
+    if (tok.text == "u64")  return type_fundamental::u64_type;
+    if (tok.text == "f64")  return type_fundamental::f64_type;
     return {type_struct{ .name=std::string{tok.text} }};
 }
 

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -587,9 +587,8 @@ auto parse_declaration_stmt(tokenstream& tokens) -> node_stmt_ptr
     stmt.token = tokens.consume();
 
     switch (stmt.token.type) {
-        using enum node_declaration_stmt::qualifier;
-        case token_type::kw_let: { stmt.qual = let; } break;
-        case token_type::kw_var: { stmt.qual = var; } break;
+        case token_type::kw_let: { stmt.add_const = true; } break;
+        case token_type::kw_var: { stmt.add_const = false; } break;
         default: stmt.token.error("declaration must start with 'let' or 'var', not {}",
                                   stmt.token.text);
     }

--- a/src/utility/stack.hpp
+++ b/src/utility/stack.hpp
@@ -9,23 +9,6 @@
 
 namespace anzu {
 
-class vm_rom
-{
-    std::unique_ptr<std::byte[]> d_data;
-    std::size_t d_size;
-
-public:
-    vm_rom(std::string_view data)
-        : d_data{std::make_unique<std::byte[]>(data.size())}
-        , d_size{data.size()}
-    {
-        std::memcpy(d_data.get(), data.data(), data.size());
-    }
-
-    inline auto at(std::size_t index) -> std::byte& { return d_data[index]; }
-    inline auto at(std::size_t index) const -> const std::byte& { return d_data[index]; }
-};
-
 class vm_stack
 {
     std::unique_ptr<std::byte[]> d_data;

--- a/src/utility/stack.hpp
+++ b/src/utility/stack.hpp
@@ -22,6 +22,32 @@ public:
         , d_current_size{0}
     {}
 
+    auto push(const std::byte* src, std::size_t count) -> void
+    {
+        if (d_current_size + count > d_max_size) {
+            std::print("Stack overflow\n");
+            std::exit(27);
+        }
+        std::memcpy(&d_data[d_current_size], src, count);
+        d_current_size += count;
+    }
+
+    template <typename T>
+    auto push(const T& obj) -> void
+    {
+        push(reinterpret_cast<const std::byte*>(&obj), sizeof(T));
+    }
+
+    auto pop_and_save(std::byte* dst, std::size_t count) -> void
+    {
+        if (d_current_size < count) {
+            std::print("Stack underflow\n");
+            std::exit(28);
+        }
+        d_current_size -= count;
+        std::memcpy(dst, &d_data[d_current_size], count);
+    }
+
     template <typename T>
     auto pop() -> T
     {
@@ -29,17 +55,6 @@ public:
         d_current_size -= sizeof(T);
         std::memcpy(&ret, &d_data[d_current_size], sizeof(T));
         return ret;
-    }
-
-    template <typename T>
-    auto push(const T& obj) -> void
-    {
-        if (d_current_size + sizeof(T) > d_max_size) {
-            std::print("Stack overflow");
-            std::exit(27);
-        }
-        std::memcpy(&d_data[d_current_size], &obj, sizeof(T));
-        d_current_size += sizeof(T);
     }
 
     inline auto size() const -> std::size_t { return d_current_size; }


### PR DESCRIPTION
* Store the rom as just a string. Remove vm_rom.
* Simplify the `read_advance` function usage.
* Fix function pointer usage, it broke at some point.
* Store `type_fundamental` directly as the enum in the variant, no need for wrapper function.
* Remove some old functions that are no longer used.