### PR TITLE
Reading File Contents

### DIFF
--- a/examples/test.az
+++ b/examples/test.az
@@ -1,9 +1,30 @@
+fn read_file(filename: (const char)[], a: arena&) -> (const char)[]
 {
-    arena a;
-    var f := fopen("contents.txt", "r");
-    let contents := fread(f, a&);
+    let f := fopen(filename, "rb");
+    let contents := fread(f, a);
     fclose(f);
-
-    print("{}\n", contents);
-    print("\nsize={}\n", contents.size());
+    return contents;
 }
+
+struct tokenizer
+{
+    input: (const char)[];
+    start: (const char)&;
+    curr:  (const char)&;
+}
+
+#{
+#    arena a;
+#    let contents := read_file("examples/test_contents.txt", a&);
+#
+#    print("'{}'\n", contents);
+#    print("\nsize={}\n", contents.size());
+#}
+
+let x := "hello world";
+let start := x[3u]&;
+let end := x[7u]&;
+__dump_type(start);
+
+let substr := span_from_chars(start, end);
+print("{}\n", substr);

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,22 +1,9 @@
-
-
-fn get(a: arena&, count: u64) -> u64[]
 {
-    var p := a@.new_array<u64>(count);
-    var idx := 0u;
-    while (idx < p.size()) {
-        p[idx] = idx;
-        idx = idx + 1u;
-    }
-    return p;
-}
+    arena a;
+    var f := fopen("contents.txt", "r");
+    let contents := fread(f, a&);
+    fclose(f);
 
-arena a;
-var z := get(a&, 20u);
-print("size={} capacity={}\n", a.size(), a.capacity());
-
-var idx := 0u;
-while (idx < z.size()) {
-    print("{}\n", z[idx])
-    idx = idx + 1u;
+    print("{}\n", contents);
+    print("\nsize={}\n", contents.size());
 }

--- a/examples/test.az
+++ b/examples/test.az
@@ -11,7 +11,3 @@ let contents := read_file("examples/test_contents.txt", a&);
 
 print("'{}'\n", contents);
 print("\nsize={}\n", contents.size());
-
-let X := 10;
-var Y := X;
-Y = 15;

--- a/examples/test.az
+++ b/examples/test.az
@@ -11,3 +11,7 @@ let contents := read_file("examples/test_contents.txt", a&);
 
 print("'{}'\n", contents);
 print("\nsize={}\n", contents.size());
+
+let X := 10;
+var Y := X;
+Y = 15;

--- a/examples/test.az
+++ b/examples/test.az
@@ -6,17 +6,8 @@ fn read_file(filename: (const char)[], a: arena&) -> (const char)[]
     return contents;
 }
 
-struct tokenizer
-{
-    input: (const char)[];
-    start: (const char)&;
-    curr:  (const char)&;
-}
+arena a;
+let contents := read_file("examples/test_contents.txt", a&);
 
-{
-    arena a;
-    let contents := read_file("examples/test_contents.txt", a&);
-
-    print("'{}'\n", contents);
-    print("\nsize={}\n", contents.size());
-}
+print("'{}'\n", contents);
+print("\nsize={}\n", contents.size());

--- a/examples/test.az
+++ b/examples/test.az
@@ -20,4 +20,3 @@ struct tokenizer
     print("'{}'\n", contents);
     print("\nsize={}\n", contents.size());
 }
-

--- a/examples/test.az
+++ b/examples/test.az
@@ -13,18 +13,11 @@ struct tokenizer
     curr:  (const char)&;
 }
 
-#{
-#    arena a;
-#    let contents := read_file("examples/test_contents.txt", a&);
-#
-#    print("'{}'\n", contents);
-#    print("\nsize={}\n", contents.size());
-#}
+{
+    arena a;
+    let contents := read_file("examples/test_contents.txt", a&);
 
-let x := "hello world";
-let start := x[3u]&;
-let end := x[7u]&;
-__dump_type(start);
+    print("'{}'\n", contents);
+    print("\nsize={}\n", contents.size());
+}
 
-let substr := span_from_chars(start, end);
-print("{}\n", substr);

--- a/examples/test_contents.txt
+++ b/examples/test_contents.txt
@@ -1,0 +1,7 @@
+Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been
+the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley
+of type and scrambled it to make a type specimen book. It has survived not only five centuries,
+but also the leap into electronic typesetting, remaining essentially unchanged. It was
+popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages,
+and more recently with desktop publishing software like Aldus PageMaker including versions of
+Lorem Ipsum.

--- a/examples/test_contents.txt
+++ b/examples/test_contents.txt
@@ -1,7 +1,5 @@
-Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been
-the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley
-of type and scrambled it to make a type specimen book. It has survived not only five centuries,
-but also the leap into electronic typesetting, remaining essentially unchanged. It was
-popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages,
-and more recently with desktop publishing software like Aldus PageMaker including versions of
-Lorem Ipsum.
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
+labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris
+nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit
+esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
+culpa qui officia deserunt mollit anim id est laborum.

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -1023,7 +1023,7 @@ void push_stmt(compiler& com, const node_continue_stmt& node)
 
 auto push_stmt(compiler& com, const node_declaration_stmt& node) -> void
 {
-    const auto type = push_expr_val(com, *node.expr);
+    const auto type = push_expr_val(com, *node.expr).remove_const(); // new copy, constness doesn't transfer
     node.token.assert(!type.is_arena(), "cannot create copies of arenas");
     declare_var(com, node.token, node.name, node.add_const ? type.add_const() : type);
 }

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -92,7 +92,7 @@ auto builtin_span_from_chars(bytecode_context& ctx) -> void
 auto construct_builtin_array() -> std::vector<builtin>
 {
     const auto char_span = char_type().add_const().add_span();
-    const auto char_ptr = char_type().add_ptr();
+    const auto char_ptr = char_type().add_const().add_ptr();
 
     auto b = std::vector<builtin>{};
 

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -78,7 +78,7 @@ auto builtin_fread(bytecode_context& ctx) -> void
     ctx.stack.push(size);
 }
 
-auto builtin_span_from_chars(bytecode_context& ctx) -> void
+auto builtin_span_from_ptrs(bytecode_context& ctx) -> void
 {
     auto end = ctx.stack.pop<const char*>();
     auto start = ctx.stack.pop<const char*>();
@@ -103,7 +103,7 @@ auto construct_builtin_array() -> std::vector<builtin>
     b.push_back(builtin{"fputs", builtin_fputs, {u64_type(), char_span}, null_type()});
     b.push_back(builtin{"fread", builtin_fread, {u64_type(), arena_type().add_ptr()}, char_span});
 
-    b.push_back(builtin{"span_from_chars", builtin_span_from_chars, {char_ptr, char_ptr}, char_span});
+    b.push_back(builtin{"span_from_ptrs", builtin_span_from_ptrs, {char_ptr, char_ptr}, char_span});
 
     return b;
 }


### PR DESCRIPTION
* Add `fread` as a builtin function, making it possible to load file contents into a `(const char)[]`.
* Add `span_from_ptrs` builtin function which converts a pair of char pointers to a char span. This isn't safe but will be used to implement a tokeniser in the future. 
* Doing so highlighted some issues in the compiler; this makes is more robust (not perfect, just better), in particular, cleaning up all the type conversion code as most of the complexity still lingered from when functions could be overloaded. Now, conversions only relate to constness.
* Remove `verify_function_call` since it was a relic of function overloading.
* Remove `are_types_convertible_to` for the same reason.
* Remove `get_converter` which was already complicated logic. Arrays no longer auto convert to spans, this must be done explicitly, so no "conversion" ever actually happens; we only decide to allow certain types to mismatch based on constness. Eg, you can pass a `const T` to a function accepting a `T` because a copy is made, and you can also pass a `T&` to a function accepting a `(const T)&`. In both bases you're still just `memcpy`ing the object.
* Remove `assert_assignable` and `assert_assignable_function_arg`, again another copy of the logic above.
* Now, `push_function_arg` does all the type checks before doing the pushing, so it can be used for assignments too. Assignment additionally just needs to check that the LHS isn't const.
* Lookup builtins by name only rather than by name and function args, this is another place where complexity was added due to function overloading.