### PR TITLE
Simplify Variable Manager Again

### DIFF
--- a/src/compilation/variable_manager.cpp
+++ b/src/compilation/variable_manager.cpp
@@ -5,7 +5,7 @@ namespace {
 
 auto delete_arenas_in_scope(std::vector<std::byte>& program, const scope& scope)
 {
-    for (const auto& var : scope.varibles | std::views::reverse) {
+    for (const auto& var : scope.variables | std::views::reverse) {
         if (var.type.is_arena()) {
             const auto op = var.is_local ? op::push_ptr_local : op::push_ptr_global;
             push_value(program, op, var.location, op::load, sizeof(std::byte*), op::arena_delete);
@@ -41,10 +41,10 @@ auto variable_manager::declare(
 ) -> bool
 {
     auto& scope = d_scopes.back();
-    for (const auto& var : scope.varibles) {
+    for (const auto& var : scope.variables) {
         if (var.name == name) return false;
     }
-    scope.varibles.emplace_back(name, type, scope.next, size, in_function());
+    scope.variables.emplace_back(name, type, scope.next, size, in_function());
     scope.next += size;
     return true;
 }
@@ -52,7 +52,7 @@ auto variable_manager::declare(
 auto variable_manager::find(const std::string& name) const -> std::optional<variable>
 {
     for (const auto& scope : d_scopes | std::views::reverse) {
-        for (const auto& var : scope.varibles) {
+        for (const auto& var : scope.variables) { // no need to reverse here, var names are unique per scope
             if (var.name == name) return var;
         }
     }

--- a/src/compilation/variable_manager.cpp
+++ b/src/compilation/variable_manager.cpp
@@ -3,21 +3,12 @@
 namespace anzu {
 namespace {
 
-auto delete_arena(std::vector<std::byte>& program, const variable& arena)
-{
-     // Push the arena onto the stack
-    const auto op = arena.is_local ? op::push_ptr_local : op::push_ptr_global;
-    push_value(program, op, arena.location, op::load, sizeof(std::byte*));
-
-    // and delete it
-    push_value(program, op::arena_delete);
-}
-
 auto delete_arenas_in_scope(std::vector<std::byte>& program, const scope& scope)
 {
-    for (const auto& variable : scope.varibles | std::views::reverse) {
-        if (variable.type == arena_type()) {
-            delete_arena(program, variable);
+    for (const auto& var : scope.varibles | std::views::reverse) {
+        if (var.type.is_arena()) {
+            const auto op = var.is_local ? op::push_ptr_local : op::push_ptr_global;
+            push_value(program, op, var.location, op::load, sizeof(std::byte*), op::arena_delete);
         }
     }
 }

--- a/src/compilation/variable_manager.cpp
+++ b/src/compilation/variable_manager.cpp
@@ -126,18 +126,11 @@ scope_guard::scope_guard(variable_manager& manager)
 {}
 
 scope_guard::~scope_guard() {
-    // Delete any arenas in the current scope
     delete_arenas_in_scope(*d_manager->d_program, d_manager->d_scopes.back());
-
-    // Then pop all local variables
-    panic_if(d_manager->d_scopes.empty(), "Tried to pop a scope, but there are none!");
     const auto& scope = d_manager->d_scopes.back();
     const auto size = scope.next - scope.start;
     d_manager->d_scopes.pop_back();
-
-    if (size > 0) {
-        push_value(*d_manager->d_program, op::pop, size);
-    }    
+    if (size > 0) push_value(*d_manager->d_program, op::pop, size); 
 }
 
 }

--- a/src/compilation/variable_manager.cpp
+++ b/src/compilation/variable_manager.cpp
@@ -15,7 +15,7 @@ auto delete_arena(std::vector<std::byte>& program, const variable& arena)
 
 auto delete_arenas_in_scope(std::vector<std::byte>& program, const scope& scope)
 {
-    for (const auto& variable : scope.d_variables | std::views::reverse) {
+    for (const auto& variable : scope.varibles | std::views::reverse) {
         if (variable.type == arena_type()) {
             delete_arena(program, variable);
         }
@@ -24,94 +24,45 @@ auto delete_arenas_in_scope(std::vector<std::byte>& program, const scope& scope)
 
 }
 
-scope::scope(const scope_info& info, std::size_t start_location)
-    : d_info{info}
-    , d_variables{}
-    , d_start(start_location)
-    , d_next(start_location)
-{}
-
-auto scope::scope_size() const -> std::size_t { return d_next - d_start; }
-
-auto scope::find(const std::string& name) const -> std::optional<variable>
-{
-    for (const auto& var : d_variables) {
-        if (var.name == name) return var;
-    }
-    return std::nullopt;
-}
-
-auto scope::next_location() -> std::size_t { return d_next; }
-
-auto variable_manager::push_scope() -> void
+auto variable_manager::new_scope() -> scope_guard
 {
     d_scopes.emplace_back(
         simple_scope{},
-        d_scopes.empty() ? 0 : d_scopes.back().next_location()
+        d_scopes.empty() ? 0 : d_scopes.back().next
     );
-}
-
-auto variable_manager::new_scope() -> scope_guard
-{
-    push_scope();
     return scope_guard{*this};
 }
 
 auto variable_manager::new_function_scope(const type_name& return_type) -> scope_guard
 {
-    push_function_scope(return_type);
+    d_scopes.emplace_back(function_scope{return_type}, 0);
     return scope_guard{*this};
 }
 
 auto variable_manager::new_loop_scope() -> scope_guard
 {
-    push_loop_scope();
+    d_scopes.emplace_back(loop_scope{}, d_scopes.back().next);
     return scope_guard{*this};
-}
-
-auto variable_manager::push_function_scope(const type_name& return_type) -> void
-{
-    d_scopes.emplace_back(function_scope{return_type}, 0);
-}
-
-auto variable_manager::push_loop_scope() -> void
-{
-    d_scopes.emplace_back(loop_scope{}, d_scopes.back().next_location());
-}
-
-auto variable_manager::pop_scope() -> std::size_t
-{
-    panic_if(d_scopes.empty(), "Tried to pop a scope, but there are none!");
-    const auto size = d_scopes.back().scope_size();
-    d_scopes.pop_back();
-    return size;
 }
 
 auto variable_manager::declare(
     const std::string& name, const type_name& type, std::size_t size
 ) -> bool
 {
-    const auto in_function = [&] {
-        for (const auto& scope : d_scopes | std::views::reverse) {
-            if (scope.is<function_scope>()) return true;
-        }
-        return false;
-    }();
-
     auto& scope = d_scopes.back();
-    for (const auto& var : scope.d_variables) {
+    for (const auto& var : scope.varibles) {
         if (var.name == name) return false;
     }
-    scope.d_variables.emplace_back(std::string{name}, type, scope.d_next, size, in_function);
-    scope.d_next += size;
+    scope.varibles.emplace_back(name, type, scope.next, size, in_function());
+    scope.next += size;
     return true;
 }
 
 auto variable_manager::find(const std::string& name) const -> std::optional<variable>
 {
     for (const auto& scope : d_scopes | std::views::reverse) {
-        if (const auto v = scope.find(name); v.has_value()) {
-            return v;
+        for (const auto& var : scope.varibles) {
+            if (var.name == name) return var;
         }
     }
     return std::nullopt;
@@ -120,7 +71,7 @@ auto variable_manager::find(const std::string& name) const -> std::optional<vari
 auto variable_manager::in_loop() const -> bool
 {
     for (const auto& scope : d_scopes | std::views::reverse) {
-        if (scope.is<loop_scope>()) return true;
+        if (std::holds_alternative<loop_scope>(scope.info)) return true;
     }
     return false;
 }
@@ -128,7 +79,7 @@ auto variable_manager::in_loop() const -> bool
 auto variable_manager::in_function() const -> bool
 {
     for (const auto& scope : d_scopes | std::views::reverse) {
-        if (scope.is<function_scope>()) return true;
+        if (std::holds_alternative<function_scope>(scope.info)) return true;
     }
     return false;
 }
@@ -136,8 +87,8 @@ auto variable_manager::in_function() const -> bool
 auto variable_manager::get_loop_info() -> loop_scope&
 {
     for (auto& scope : d_scopes | std::views::reverse) {
-        if (scope.is<loop_scope>()) {
-            return scope.as<loop_scope>();
+        if (auto loop = std::get_if<loop_scope>(&scope.info)) {
+            return *loop;
         }
     }
     panic("could not get loop info, not in a loop!");
@@ -146,8 +97,8 @@ auto variable_manager::get_loop_info() -> loop_scope&
 auto variable_manager::get_function_info() -> function_scope&
 {
     for (auto& scope : d_scopes | std::views::reverse) {
-        if (scope.is<function_scope>()) {
-            return scope.as<function_scope>();
+        if (auto func = std::get_if<function_scope>(&scope.info)) {
+            return *func;
         }
     }
     panic("could not get function info, not in a function!");
@@ -163,8 +114,8 @@ auto variable_manager::handle_loop_exit() -> void
     auto pop_size = std::size_t{0};
     for (const auto& scope : d_scopes | std::views::reverse) {
         delete_arenas_in_scope(*d_program, scope);
-        pop_size += scope.d_next - scope.d_start;
-        if (scope.is<loop_scope>()) break;
+        pop_size += scope.next - scope.start;
+        if (std::holds_alternative<loop_scope>(scope.info)) break;
     }
     push_value(*d_program, op::pop, pop_size);
 }
@@ -175,7 +126,7 @@ auto variable_manager::handle_function_exit() -> void
 {
     for (const auto& scope : d_scopes | std::views::reverse) {
         delete_arenas_in_scope(*d_program, scope);
-        if (scope.is<function_scope>()) break;
+        if (std::holds_alternative<function_scope>(scope.info)) break;
     }
 }
 
@@ -188,9 +139,13 @@ scope_guard::~scope_guard() {
     delete_arenas_in_scope(*d_manager->d_program, d_manager->d_scopes.back());
 
     // Then pop all local variables
-    const auto scope_size = d_manager->pop_scope();
-    if (scope_size > 0) {
-        push_value(*d_manager->d_program, op::pop, scope_size);
+    panic_if(d_manager->d_scopes.empty(), "Tried to pop a scope, but there are none!");
+    const auto& scope = d_manager->d_scopes.back();
+    const auto size = scope.next - scope.start;
+    d_manager->d_scopes.pop_back();
+
+    if (size > 0) {
+        push_value(*d_manager->d_program, op::pop, size);
     }    
 }
 

--- a/src/compilation/variable_manager.cpp
+++ b/src/compilation/variable_manager.cpp
@@ -31,16 +31,6 @@ scope::scope(const scope_info& info, std::size_t start_location)
     , d_next(start_location)
 {}
 
-auto scope::declare(std::string_view name, const type_name& type, std::size_t size, bool is_local) -> bool
-{
-    for (const auto& var : d_variables) {
-        if (var.name == name) return false;
-    }
-    d_variables.emplace_back(std::string{name}, type, d_next, size, is_local);
-    d_next += size;
-    return true;
-}
-
 auto scope::scope_size() const -> std::size_t { return d_next - d_start; }
 
 auto scope::find(const std::string& name) const -> std::optional<variable>
@@ -108,7 +98,13 @@ auto variable_manager::declare(
         return false;
     }();
 
-    return d_scopes.back().declare(name, type, size, in_function);
+    auto& scope = d_scopes.back();
+    for (const auto& var : scope.d_variables) {
+        if (var.name == name) return false;
+    }
+    scope.d_variables.emplace_back(std::string{name}, type, scope.d_next, size, in_function);
+    scope.d_next += size;
+    return true;
 }
 
 auto variable_manager::find(const std::string& name) const -> std::optional<variable>

--- a/src/compilation/variable_manager.hpp
+++ b/src/compilation/variable_manager.hpp
@@ -45,8 +45,8 @@ struct scope
 {
     scope_info            info;
     std::size_t           start;
-    std::size_t           next     = start;
-    std::vector<variable> varibles = {};
+    std::size_t           next      = start;
+    std::vector<variable> variables = {};
 };
 
 class scope_guard

--- a/src/compilation/variable_manager.hpp
+++ b/src/compilation/variable_manager.hpp
@@ -13,6 +13,8 @@
 
 namespace anzu {
 
+class variable_manager;
+
 struct variable
 {
     std::string name;
@@ -41,35 +43,28 @@ using scope_info = std::variant<simple_scope, function_scope, loop_scope>;
 
 struct scope
 {
-    scope_info            d_info;
-    std::vector<variable> d_variables;
-    std::size_t           d_start;
-    std::size_t           d_next;
-
-public:
-    scope(const scope_info& info, std::size_t start_location);
-    auto scope_size() const -> std::size_t;
-    auto find(const std::string& name) const -> std::optional<variable>;
-    auto next_location() -> std::size_t;
-
-    template <typename ScopeType>
-    auto is() const -> bool { return std::holds_alternative<ScopeType>(d_info); }
-
-    template <typename ScopeType>
-    auto as() -> ScopeType& { return std::get<ScopeType>(d_info); }
+    scope_info            info;
+    std::size_t           start;
+    std::size_t           next     = start;
+    std::vector<variable> varibles = {};
 };
 
-class scope_guard;
+class scope_guard
+{
+    variable_manager* d_manager;
+    scope_guard(const scope_guard&) = delete;
+    scope_guard& operator=(const scope_guard&) = delete;
+
+public:
+    scope_guard(variable_manager& manager);
+    ~scope_guard();
+};
 
 class variable_manager
 {
     std::vector<std::byte>* d_program;
     std::vector<scope> d_scopes;
-
-    auto push_scope() -> void;
-    auto push_function_scope(const type_name& return_type) -> void;
-    auto push_loop_scope() -> void;
-    auto pop_scope() -> std::size_t;
+    friend scope_guard;
 
 public:
     auto set_program(std::vector<std::byte>* program) { d_program = program; }
@@ -94,19 +89,6 @@ public:
     // All of these can result in control flow not reaching the end of a scope
     auto handle_loop_exit() -> void;
     auto handle_function_exit() -> void;
-
-    friend scope_guard;
-};
-
-class scope_guard
-{
-    variable_manager* d_manager;
-    scope_guard(const scope_guard&) = delete;
-    scope_guard& operator=(const scope_guard&) = delete;
-
-public:
-    scope_guard(variable_manager& manager);
-    ~scope_guard();
 };
 
 }

--- a/src/compilation/variable_manager.hpp
+++ b/src/compilation/variable_manager.hpp
@@ -48,7 +48,6 @@ struct scope
 
 public:
     scope(const scope_info& info, std::size_t start_location);
-    auto declare(std::string_view name, const type_name& type, std::size_t size, bool is_local) -> bool;
     auto scope_size() const -> std::size_t;
     auto find(const std::string& name) const -> std::optional<variable>;
     auto next_location() -> std::size_t;

--- a/src/utility/memory.hpp
+++ b/src/utility/memory.hpp
@@ -1,5 +1,4 @@
 #pragma once
-#include <array>
 #include <vector>
 #include <utility>
 #include <cstdint>


### PR DESCRIPTION
* Made `scope` a simple struct; all the logic now lies fully inside the `variable_manager`, which makes some of the functions simpler.
* Remove all the private `push_X_scope` functions, the logic is now done entirely in the functions that return scope guards.
* Simplify the arena cleanup code, it's just one function now.