### PR TITLE
Make the Instruction Pointer an Actual Pointer

### DIFF
--- a/examples/test.az
+++ b/examples/test.az
@@ -1,6 +1,2 @@
 
-
-var p : i64& = nullptr;
-var q : i64& = nullptr;
-
-print("{}\n", p == q);
+let x := 10;

--- a/src/bytecode.hpp
+++ b/src/bytecode.hpp
@@ -12,10 +12,12 @@ struct bytecode_program
 };
 
 auto print_program(const bytecode_program& prog) -> void;
-auto print_op(const bytecode_program& prog, std::size_t ptr) -> std::size_t;
+auto print_op(std::string_view rom, const std::byte* start, const std::byte* ptr) -> const std::byte*;
 
 enum class op : std::uint8_t
 {
+    end_program,
+    
     push_i32,
     push_i64,
     push_u64,

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -1332,6 +1332,7 @@ auto compile(
         );
     }
 
+    push_value(com.program, op::end_program);
     return { com.program, com.read_only_data };
 }
 

--- a/src/runtime.hpp
+++ b/src/runtime.hpp
@@ -13,7 +13,7 @@ namespace anzu {
 
 struct call_frame
 {
-    std::size_t prog_ptr = 0;
+    std::byte* ip = nullptr; // instruction pointer
     std::size_t base_ptr = 0;
 };
 


### PR DESCRIPTION
* We read into the program by using a `std::size_t` instruction pointer, this is now changed to an actual `std::byte*`. This is in prep for splitting the code into separate chunks of bytecode for each function.
* The `print_op` now no longer needs the whole program passed in, since it doesn't need to code vector to convert the instruction pointer to a pointer.
* Added a `op::end_program` op code to decide when to end the program rather than using the size of the program vector, as that vector is going away. Plus it also fixed an off-by-one bug with the new implementation.