### PR TITLE
Remove Modules and Debug Mode

### DIFF
--- a/examples/test.az
+++ b/examples/test.az
@@ -10,6 +10,6 @@ struct foo
     }
 }
 
-let f := foo(1);
+var f := foo(1);
 f.hello();
 print("{}\n", f.i);

--- a/src/anzu.m.cpp
+++ b/src/anzu.m.cpp
@@ -82,7 +82,7 @@ auto main(const int argc, const char* argv[]) -> int
     }
 
     std::print("-> Compiling\n");
-    const auto program = anzu::compile(root, parsed_program, true); // TODO: Make debug a switch
+    const auto program = anzu::compile(root, parsed_program);
     if (mode == "com") {
         print_program(program);
         return 0;

--- a/src/compiler.hpp
+++ b/src/compiler.hpp
@@ -52,14 +52,11 @@ struct compiler
     
     type_manager     types;
     variable_manager variables;
-    
-    bool debug = false;
 };
 
 auto compile(
     const std::filesystem::path& main_dir,
-    const std::map<std::filesystem::path, anzu_module>& modules,
-    bool debug = true
+    const std::map<std::filesystem::path, anzu_module>& modules
 ) -> bytecode_program;
 
 }

--- a/src/compiler.hpp
+++ b/src/compiler.hpp
@@ -54,9 +54,6 @@ struct compiler
     variable_manager variables;
 };
 
-auto compile(
-    const std::filesystem::path& main_dir,
-    const std::map<std::filesystem::path, anzu_module>& modules
-) -> bytecode_program;
+auto compile(const anzu_module& ast) -> bytecode_program;
 
 }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -758,18 +758,7 @@ auto parse(const std::filesystem::path& file) -> anzu_module
     auto stream = tokenstream{*new_module.source_code};
     while (stream.valid()) {
         while (stream.consume_maybe(token_type::semicolon));
-        if (stream.consume_maybe(token_type::kw_import)) {
-            auto module_name = std::string{};
-            while (!stream.peek(token_type::semicolon)) {
-                module_name += stream.consume().text;
-            }
-            new_module.required_modules.emplace(
-                std::filesystem::absolute(file.parent_path() / module_name)
-            );
-            stream.consume_only(token_type::semicolon);
-        } else {
-            seq.sequence.push_back(parse_top_level_statement(stream));
-        }
+        seq.sequence.push_back(parse_top_level_statement(stream));
     }
     return new_module;
 }

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -12,7 +12,6 @@ namespace anzu {
 struct anzu_module
 {
     std::unique_ptr<std::string> source_code; // TODO: make this a std::unique_ptr<char[]>
-    std::set<std::filesystem::path> required_modules;
     node_stmt_ptr root;
 };
 


### PR DESCRIPTION
* Modules were a half baked feature, and with the recent changes to the compiler and runtime, can likely be implemented in a smarter way, so they've been removed.
* "Debug" mode was always on and half baked, and implemented a bunch of checks in the language that added a load of extra op codes to the output. Removing it does make usage of some features more error prone, but that can be fixed in the future.
* Asserts now always fire, previously they were only enabled in debug mode.