### PR TITLE
New Implementation of Const

### DIFF
--- a/examples/feature_test.az
+++ b/examples/feature_test.az
@@ -171,7 +171,7 @@ struct vec3
     y: f64;
     z: f64;
 
-    fn length(self: (const vec3)&) -> f64
+    fn length(self: vec3 const&) -> f64
     {
         let x_squared := square(self.x);
         let y_squared := square(self.y);
@@ -279,7 +279,7 @@ fn get(a: arena&, count: u64) -> u64[]
     }
 }
 
-fn read_file(filename: (const char)[], a: arena&) -> (const char)[]
+fn read_file(filename: char const[], a: arena&) -> char const[]
 {
     let f := fopen(filename, "rb");
     let contents := fread(f, a);

--- a/examples/recursion.az
+++ b/examples/recursion.az
@@ -11,4 +11,4 @@ fn fibb(n: i64) -> i64
     return fibb(n - 1) + fibb(n - 2);
 }
 
-print("{}", fibb(33));
+print("{}", fibb(10));

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,6 +1,6 @@
 
 
-var x := [1, 2, 3, 4];
-var s := x[];
-
-__dump_type(x, s);
+let x := 10;
+var y := x&;
+y@ = 15;
+__dump_type(x, y);

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,4 +1,6 @@
 
 
-var p : i64& = nullptr;
-p = nullptr;
+var x := [1, 2, 3, 4];
+var s := x[];
+
+__dump_type(x, s);

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,15 +1,8 @@
 
-struct foo
-{
-    i: i64;
 
-    fn hello(self: (const foo)&) -> null
-    {
-        self.i = 10;
-        print("hello\n");
-    }
+fn hello(x: i64 const&) -> null
+{
+    print("hello\n");
 }
 
-var f := foo(1);
-f.hello();
-print("{}\n", f.i);
+let arr := [hello, hello, hello];

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,8 +1,4 @@
 
 
-fn hello(x: i64 const&) -> null
-{
-    x@ = 10;
-    print("hello\n");
-}
-
+var p : i64& = nullptr;
+p = nullptr;

--- a/examples/test.az
+++ b/examples/test.az
@@ -2,7 +2,7 @@
 
 fn hello(x: i64 const&) -> null
 {
+    x@ = 10;
     print("hello\n");
 }
 
-let arr := [hello, hello, hello];

--- a/src/compilation/type_manager.cpp
+++ b/src/compilation/type_manager.cpp
@@ -20,8 +20,7 @@ auto type_manager::contains(const type_name& type) const -> bool
         [&](const type_span& t)       { return contains(*t.inner_type); },
         [&](const type_ptr& t)        { return contains(*t.inner_type); },
         [&](const type_function_ptr&) { return true; },
-        [&](const type_arena&)        { return true; },
-        [&](const type_const& t)      { return contains(*t.inner_type); }
+        [&](const type_arena&)        { return true; }
     }, type);
 }
 
@@ -70,9 +69,6 @@ auto type_manager::size_of(const type_name& type) const -> std::size_t
         },
         [](const type_arena& arena) {
             return sizeof(std::byte*); // the runtime will store the arena separately
-        },
-        [&](const type_const& t) {
-            return size_of(*t.inner_type);
         }
     }, type);
 }

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -232,14 +232,14 @@ auto push_expr_ptr(compiler& com, const node_field_expr& node) -> type_name
     // step since wrapping a type in const will stop this from stripping away
     // further pointers.
     while (type.is_ptr()) {
-        while (type.is_const()) type = type.remove_const();
+        while (type.is_const) type = type.remove_const();
         push_value(com.code(), op::load, sizeof(std::byte*));
         type = type.remove_ptr();
     }
 
     const auto field_type = push_field_offset(com, node.token, type, node.field_name);
     push_value(com.code(), op::u64_add); // modify ptr
-    if (type.is_const()) return field_type.add_const(); // propagate const to fields
+    if (type.is_const) return field_type.add_const(); // propagate const to fields
     return field_type;
 }
 
@@ -1032,7 +1032,7 @@ auto push_stmt(compiler& com, const node_arena_declaration_stmt& node) -> void
 void push_stmt(compiler& com, const node_assignment_stmt& node)
 {
     const auto lhs_type = type_of_expr(com, *node.position);
-    node.token.assert(!lhs_type.is_const(), "cannot assign to a const variable");
+    node.token.assert(!lhs_type.is_const, "cannot assign to a const variable");
     push_function_arg(com, *node.expr, lhs_type, node.token);
     const auto lhs = push_expr_ptr(com, *node.position);
     push_value(com.code(), op::save, com.types.size_of(lhs));

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -344,8 +344,8 @@ auto push_expr_val(compiler& com, const node_literal_nullptr_expr& node) -> type
 auto push_expr_val(compiler& com, const node_binary_op_expr& node) -> type_name
 {
     using tt = token_type;
-    auto lhs = push_expr_val(com, *node.lhs).remove_const();
-    auto rhs = push_expr_val(com, *node.rhs).remove_const();
+    auto lhs = push_expr_val(com, *node.lhs);
+    auto rhs = push_expr_val(com, *node.rhs);
 
     // Pointers can compare to nullptr
     if ((lhs.is_ptr() && rhs == nullptr_type()) || (rhs.is_ptr() && lhs == nullptr_type())) {
@@ -445,7 +445,7 @@ auto push_expr_val(compiler& com, const node_binary_op_expr& node) -> type_name
 auto push_expr_val(compiler& com, const node_unary_op_expr& node) -> type_name
 {
     using tt = token_type;
-    const auto type = push_expr_val(com, *node.expr).remove_const();
+    const auto type = push_expr_val(com, *node.expr);
     print_node(*node.expr);
 
     switch (node.token.type) {
@@ -507,7 +507,7 @@ auto push_copy_typechecked(
         return;
     }
 
-    if (const_convertable_to(tok, actual, expected.remove_const())) {
+    if (const_convertable_to(tok, actual, expected)) {
         push_expr_val(com, expr);
     } else {
         tok.error("Cannot convert '{}' to '{}'", actual, expected);
@@ -807,7 +807,7 @@ auto push_expr_val(compiler& com, const auto& node) -> type_name
 {
     const auto type = push_expr_ptr(com, node);
     push_value(com.code(), op::load, com.types.size_of(type));
-    return type.remove_const();
+    return type;
 }
 
 void push_stmt(compiler& com, const node_sequence_stmt& node)

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -271,7 +271,7 @@ auto push_expr_ptr(compiler& com, const node_subscript_expr& node) -> type_name
     push_value(com.code(), op::u64_mul);
     push_value(com.code(), op::u64_add); // modify ptr
     if (is_array && type.is_const) {
-        return inner.add_const();
+        return inner.add_const(); // propagate const to elements
     }
     return inner;
 }
@@ -320,7 +320,7 @@ auto push_expr_val(compiler& com, const node_literal_string_expr& node) -> type_
 {
     push_value(com.code(), op::push_string_literal);
     push_value(com.code(), insert_into_rom(com, node.value), node.value.size());
-    return char_type().add_const().add_span();
+    return string_literal_type();
 }
 
 auto push_expr_val(compiler& com, const node_literal_bool_expr& node) -> type_name
@@ -796,7 +796,7 @@ auto push_expr_val(compiler& com, const node_span_expr& node) -> type_name
     }
 
     if (type.is_const && type.is_array()) {
-        return type.remove_array().add_const().add_span();
+        return type.remove_array().add_const().add_span(); // propagate const into the span
     }
     return type.remove_array().add_span();
 }
@@ -1200,7 +1200,7 @@ auto push_print_fundamental(compiler& com, const node_expr& node, const token& t
     else if (type == i64_type()) { push_value(com.code(), op::print_i64); }
     else if (type == u64_type()) { push_value(com.code(), op::print_u64); }
     else if (type == f64_type()) { push_value(com.code(), op::print_f64); }
-    else if (type == char_type().add_const().add_span() || type == char_type().add_span()) {
+    else if (type == char_type().add_span()) {
         push_value(com.code(), op::print_char_span);
     }
     else if (type == nullptr_type()) { push_value(com.code(), op::print_ptr); }

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -61,7 +61,10 @@ auto to_string_paren(const type_name& type) -> std::string
 
 auto to_string(const type_name& type) -> std::string
 {
-    return std::visit([](const auto& t) { return ::anzu::to_string(t); }, type);
+    const auto string_inner = std::visit([](const auto& t) {
+        return ::anzu::to_string(t);
+    }, type);
+    return type.is_const ? std::format("{} const", string_inner) : string_inner;
 }
 
 auto to_string(type_fundamental t) -> std::string

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -45,11 +45,6 @@ auto type_name::remove_const() const -> type_name
     return copy;
 }
 
-auto type_name::strip_const() const -> std::pair<type_name, bool>
-{
-    return {remove_const(), is_const};
-}
-
 auto to_string_paren(const type_name& type) -> std::string
 {
     const auto str = to_string(type);

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -214,6 +214,11 @@ auto arena_type() -> type_name
     return {type_arena{}};
 }
 
+auto string_literal_type() -> type_name
+{
+    return char_type().add_const().add_span()
+}
+
 auto make_type(const std::string& name) -> type_name
 {
     return { type_struct{ .name=name } };

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -31,26 +31,23 @@ auto type_name::remove_ptr() const -> type_name
     return *std::get<type_ptr>(*this).inner_type;
 }
 
-auto type_name::is_const() const -> bool
-{
-    return std::holds_alternative<type_const>(*this);
-}
-
 auto type_name::add_const() const -> type_name
 {
-    if (is_const()) return *this;
-    return { type_const{ .inner_type{*this} } };
+    auto copy = *this;
+    copy.is_const = true;
+    return copy;
 }
 
 auto type_name::remove_const() const -> type_name
 {
-    if (!is_const()) return *this;
-    return *std::get<type_const>(*this).inner_type;
+    auto copy = *this;
+    copy.is_const = false;
+    return copy;
 }
 
 auto type_name::strip_const() const -> std::pair<type_name, bool>
 {
-    return {remove_const(), is_const()};
+    return {remove_const(), is_const};
 }
 
 auto to_string_paren(const type_name& type) -> std::string
@@ -100,11 +97,6 @@ auto to_string(const type_ptr& type) -> std::string
 auto to_string(const type_span& type) -> std::string
 {
     return std::format("{}[]", to_string_paren(*type.inner_type));
-}
-
-auto to_string(const type_const& type) -> std::string
-{
-    return std::format("{} const", to_string_paren(*type.inner_type));
 }
 
 auto to_string(const type_function_ptr& type) -> std::string
@@ -168,12 +160,6 @@ auto hash(const type_arena& type) -> std::size_t
 {
     static const auto base = std::hash<std::string_view>{}("type_arena");
     return base;
-}
-
-auto hash(const type_const& type) -> std::size_t
-{
-    static const auto base = std::hash<std::string_view>{}("type_const");
-    return hash(*type.inner_type) ^ base;
 }
 
 auto hash(std::span<const type_name> types) -> std::size_t

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -56,7 +56,7 @@ auto type_name::strip_const() const -> std::pair<type_name, bool>
 auto to_string_paren(const type_name& type) -> std::string
 {
     const auto str = to_string(type);
-    if (str.contains(' ')) {
+    if (type.is_function_ptr()) {
         return std::format("({})", str);
     }
     return str;
@@ -102,13 +102,18 @@ auto to_string(const type_span& type) -> std::string
     return std::format("{}[]", to_string_paren(*type.inner_type));
 }
 
+auto to_string(const type_const& type) -> std::string
+{
+    return std::format("{} const", to_string_paren(*type.inner_type));
+}
+
 auto to_string(const type_function_ptr& type) -> std::string
 {
     return std::format(
         "{}({}) -> {}",
         to_string(token_type::kw_function),
-        format_comma_separated(type.param_types, to_string_paren),
-        *type.return_type
+        format_comma_separated(type.param_types),
+        to_string_paren(*type.return_type)
     );
 }
 
@@ -117,10 +122,6 @@ auto to_string(const type_arena& type) -> std::string
     return std::string{"arena"};
 }
 
-auto to_string(const type_const& type) -> std::string
-{
-    return std::format("const {}", to_string(*type.inner_type));
-}
 
 auto hash(const type_name& type) -> std::size_t
 {

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -68,12 +68,6 @@ struct type_arena
     auto operator==(const type_arena&) const -> bool = default;
 };
 
-struct type_const
-{
-    value_ptr<type_name> inner_type;
-    auto operator==(const type_const&) const -> bool = default;
-};
-
 
 struct type_name : public std::variant<
     type_fundamental,
@@ -82,10 +76,11 @@ struct type_name : public std::variant<
     type_ptr,
     type_span,
     type_function_ptr,
-    type_arena,
-    type_const>
+    type_arena>
 {
     using variant::variant;
+    
+    bool is_const = false;
 
     [[nodiscard]] auto is_fundamental() const -> bool;
 
@@ -93,7 +88,6 @@ struct type_name : public std::variant<
     [[nodiscard]] auto add_ptr() const -> type_name;
     [[nodiscard]] auto remove_ptr() const -> type_name;
  
-    [[nodiscard]] auto is_const() const -> bool;
     [[nodiscard]] auto add_const() const -> type_name;
     [[nodiscard]] auto remove_const() const -> type_name;
 
@@ -119,7 +113,6 @@ auto hash(const type_ptr& type) -> std::size_t;
 auto hash(const type_span& type) -> std::size_t;
 auto hash(const type_function_ptr& type) -> std::size_t;
 auto hash(const type_arena& type) -> std::size_t;
-auto hash(const type_const& type) -> std::size_t;
 auto hash(std::span<const type_name> types) -> std::size_t;
 
 auto null_type() -> type_name;
@@ -149,7 +142,6 @@ auto to_string(const type_span& type) -> std::string;
 auto to_string(const type_struct& type) -> std::string;
 auto to_string(const type_function_ptr& type) -> std::string;
 auto to_string(const type_arena& type) -> std::string;
-auto to_string(const type_const& type) -> std::string;
 
 }
 

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -101,8 +101,6 @@ struct type_name : public std::variant<
 
     [[nodiscard]] auto is_function_ptr() const -> bool;
     [[nodiscard]] auto is_arena() const -> bool;
-
-    [[nodiscard]] auto strip_const() const -> std::pair<type_name, bool>;
 };
 
 auto hash(const type_name& type) -> std::size_t;

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -122,6 +122,7 @@ auto i64_type() -> type_name;
 auto u64_type() -> type_name;
 auto f64_type() -> type_name;
 auto arena_type() -> type_name;
+auto string_literal_type() -> type_name;
 
 auto make_type(const std::string& name) -> type_name;
 

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -356,13 +356,6 @@ auto parse_simple_type(tokenstream& tokens) -> type_name
 
 auto parse_type_inner(tokenstream& tokens) -> type_name
 {
-    // Const
-    if (tokens.consume_maybe(token_type::kw_const)) {
-        auto ret = type_const{};
-        ret.inner_type = make_value<type_name>(parse_type_inner(tokens));
-        return ret;
-    }
-
     // Function pointers
     if (tokens.consume_maybe(token_type::kw_function)) {
         tokens.consume_only(token_type::left_paren);
@@ -395,6 +388,9 @@ auto parse_type_inner(tokenstream& tokens) -> type_name
         }
         else if (tokens.consume_maybe(token_type::ampersand)) {
             type = type_name{type_ptr{ .inner_type=type }};
+        }
+        else if (tokens.consume_maybe(token_type::kw_const)) {
+            type = type_name{type_const{ .inner_type=type }};
         }
         else {
             break;

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -390,7 +390,7 @@ auto parse_type_inner(tokenstream& tokens) -> type_name
             type = type_name{type_ptr{ .inner_type=type }};
         }
         else if (tokens.consume_maybe(token_type::kw_const)) {
-            type = type_name{type_const{ .inner_type=type }};
+            type.is_const = true;
         }
         else {
             break;
@@ -421,8 +421,7 @@ auto validate_type_inner(const type_name& type) -> std::optional<std::string_vie
             }
             return Ret{};
         },
-        [](const type_arena&) { return Ret{}; },
-        [](const type_const& t) { return validate_type_inner(*t.inner_type); }
+        [](const type_arena&) { return Ret{}; }
     }, type);
 }
 


### PR DESCRIPTION
* Remove `type_const` from the `type_name` variant, instead `type_name` just has an `is_const` bool stored directly on it.
* The bool doesn't count in the equality check, so `i64` would compare true to `i64 const`.
* This is because const only really matters for assignment, declaration and copying arguments into functions.
* Returns values from `push_expr_val` should have the top level const stripped away as it's up to the surrounding context if it should be const or not. For example, you should be able to use the value from a const variable to assign to a mutable variable since a copy is being made, but only top level const since a `u64 const&` should not be convertible to a `u64&`.
* Make `const` apply as a suffix, so `(const char)[]` is now spelled `char const[]` and `const (char[])` is `char []const`.
* `.remove_const()` is now only used in 2 places; one to strip off the top level const when calling `push_copy_typechecked` (previously named `push_function_arg`) and another to look up functions for a struct which is done by stringifying the name - don't want const in that.
* `.add_const()` is now only used in a few places; to propagate constness to struct fields, to array elements and to elements of spans over const arrays.