### PR TITLE
Template Functions

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
             "request": "launch",
             "program": "${workspaceFolder}/build/src/Debug/anzu.exe",
             "args": [
-                "${workspaceFolder}/examples/euler.az",
+                "${workspaceFolder}/examples/feature_test.az",
                 "run"
             ],
             "stopAtEntry": false,

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
             "request": "launch",
             "program": "${workspaceFolder}/build/src/Debug/anzu.exe",
             "args": [
-                "${workspaceFolder}/examples/feature_test.az",
+                "${workspaceFolder}/examples/test.az",
                 "run"
             ],
             "stopAtEntry": false,

--- a/examples/feature_test.az
+++ b/examples/feature_test.az
@@ -258,7 +258,7 @@ fn print_success() -> null
 # Arena test
 fn get(a: arena&, count: u64) -> u64[]
 {
-    var p := a@.new_array<u64>(count);
+    var p := a@.new_array|u64|(count);
     var idx := 0u;
     while (idx < p.size()) {
         p[idx] = idx;

--- a/examples/feature_test.az
+++ b/examples/feature_test.az
@@ -303,3 +303,25 @@ print("\nsize={}\n", contents.size());
     p = x&;
     print("comparison of a pointer {} to nullptr: {}\n", p, p == nullptr);
 }
+
+# template tests
+fn do|T|(x: T) -> T
+{
+    print("{} {}\n", x.x, x.y);
+    return T(10, 20);
+}
+
+fn ptr|T|(x: T&) { print("{}\n", x); }
+
+struct foo
+{
+    x: i64;
+    y: i64;
+}
+
+let f := foo(1, 2);
+let g := do|foo|(f);
+print("{} {}\n", g.x, g.y);
+
+var x := 10;
+ptr|i64|(x&);

--- a/examples/feature_test.az
+++ b/examples/feature_test.az
@@ -258,7 +258,7 @@ fn print_success() -> null
 # Arena test
 fn get(a: arena&, count: u64) -> u64[]
 {
-    var p := a@.new_array|u64|(count);
+    var p := a.new_array|u64|(count);
     var idx := 0u;
     while (idx < p.size()) {
         p[idx] = idx;

--- a/examples/test.az
+++ b/examples/test.az
@@ -5,4 +5,7 @@ fn foo|T, U|(x: T, y: U)
     let a : T = x;
 }
 
+
+
 let x := foo|i64, u64|(4, 5u);
+let y := foo|null, null|(null, null);

--- a/examples/test.az
+++ b/examples/test.az
@@ -2,6 +2,7 @@
 
 fn foo|T, U|(x: T, y: U)
 {
+    let a : T = x;
 }
 
 let x := foo|i64, u64|(4, 5u);

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,8 +1,7 @@
 
 
-fn foo|T|(x: T, y: T) -> T
+fn foo|T, U|(x: T, y: U)
 {
-    return x + y;
 }
 
-let x := foo|i64|(4, 5);
+let x := foo|i64, u64|(4, 5u);

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,2 +1,11 @@
-arena a;
-let p := a.new|i64|(6);
+struct foo
+{
+    fn bar(self: foo const&) { print("in bar\n"); }
+}
+
+let f := foo();
+let p := f&;
+let q := p&;
+__dump_type(p, q);
+
+f.bar();

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,9 +1,17 @@
 
 
-fn do|T|(x: T&)
+fn do|T|(x: T) -> T
 {
-    print("{}\n", x@);
+    print("{} {}\n", x.x, x.y);
+    return T(10, 20);
 }
 
-var x := 6;
-do|i64|(x&);
+struct foo
+{
+    x: i64;
+    y: i64;
+}
+
+let f := foo(1, 2);
+let g := do|foo|(f);
+print("{} {}\n", g.x, g.y);

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,11 +1,11 @@
-arena a;
-let ap := a&;
-
-print("{} {}\n", a.size(), a.capacity());
-print("{} {}\n", ap.size(), ap.capacity());
-let p := a.new|i64|(10);
-print("{} {}\n", a.size(), a.capacity());
-print("{} {}\n", ap.size(), ap.capacity());
-
-let ap2 := ap&;
-print("{} {}\n", ap2.size(), ap2.capacity());
+# The next thing to implement; template member functions
+#struct foo
+#{
+#    fn bar|T|(self: foo const&)
+#    {
+#        print("{}\n", sizeof(T));
+#    }
+#}
+#
+#let f := foo();
+#f.bar|i64|(6);

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,2 +1,8 @@
 
 
+fn foo|T|(x: T, y: T) -> T
+{
+    return x + y;
+}
+
+let x := foo|i64|(4, 5);

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,5 +1,3 @@
-
-
 fn do|T|(x: T) -> T
 {
     print("{} {}\n", x.x, x.y);

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,9 +1,9 @@
 
 
-fn do|T|(x: T)
+fn do|T|(x: T&)
 {
-    print("{}\n", x);
+    print("{}\n", x@);
 }
 
-do|i64|(5);
-do|f64|(6.0);
+let x := 6;
+do|i64|(x&);

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,15 +1,9 @@
 
 
-fn do|T|(x: T&)
+fn do|T|(x: T)
 {
-    x.x = x.x + 1;
+    print("{}\n", x);
 }
 
-struct foo
-{
-    x: i64;
-    y: i64;
-}
-
-let f := foo(1, 2);
-do|foo|(f);
+do|i64|(5);
+do|f64|(6.0);

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,20 +1,2 @@
-fn do|T|(x: T) -> T
-{
-    print("{} {}\n", x.x, x.y);
-    return T(10, 20);
-}
-
-fn ptr|T|(x: T&) { print("{}\n", x); }
-
-struct foo
-{
-    x: i64;
-    y: i64;
-}
-
-let f := foo(1, 2);
-let g := do|foo|(f);
-print("{} {}\n", g.x, g.y);
-
-var x := 10;
-ptr|i64|(x&);
+arena a;
+let p := a.new|i64|(6);

--- a/examples/test.az
+++ b/examples/test.az
@@ -5,5 +5,5 @@ fn do|T|(x: T&)
     print("{}\n", x@);
 }
 
-let x := 6;
+var x := 6;
 do|i64|(x&);

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,6 +1,8 @@
 
 
-let x := 10;
-var y := x&;
-y@ = 15;
-__dump_type(x, y);
+
+
+fn make_pair<T>(x: T, y: T) -> T
+{
+    return x + y;
+}

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,11 +1,5 @@
-struct foo
-{
-    fn bar(self: foo const&) { print("in bar\n"); }
-}
+let x := [1, 2, 3, 4, 5];
+let p := x[];
+let v := p&;
 
-let f := foo();
-let p := f&;
-let q := p&;
-__dump_type(p, q);
-
-f.bar();
+print("{}\n", v.size());

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,5 +1,11 @@
-let x := [1, 2, 3, 4, 5];
-let p := x[];
-let v := p&;
+arena a;
+let ap := a&;
 
-print("{}\n", v.size());
+print("{} {}\n", a.size(), a.capacity());
+print("{} {}\n", ap.size(), ap.capacity());
+let p := a.new|i64|(10);
+print("{} {}\n", a.size(), a.capacity());
+print("{} {}\n", ap.size(), ap.capacity());
+
+let ap2 := ap&;
+print("{} {}\n", ap2.size(), ap2.capacity());

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,2 +1,15 @@
 
 
+fn do|T|(x: T&)
+{
+    x.x = x.x + 1;
+}
+
+struct foo
+{
+    x: i64;
+    y: i64;
+}
+
+let f := foo(1, 2);
+do|foo|(f);

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,8 +1,2 @@
 
 
-
-
-fn make_pair<T>(x: T, y: T) -> T
-{
-    return x + y;
-}

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,11 +1,2 @@
 
 
-fn foo|T, U|(x: T, y: U)
-{
-    let a : T = x;
-}
-
-
-
-let x := foo|i64, u64|(4, 5u);
-let y := foo|null, null|(null, null);

--- a/examples/test.az
+++ b/examples/test.az
@@ -6,6 +6,8 @@ fn do|T|(x: T) -> T
     return T(10, 20);
 }
 
+fn ptr|T|(x: T&) { print("{}\n", x); }
+
 struct foo
 {
     x: i64;
@@ -15,3 +17,6 @@ struct foo
 let f := foo(1, 2);
 let g := do|foo|(f);
 print("{} {}\n", g.x, g.y);
+
+var x := 10;
+ptr|i64|(x&);

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -196,6 +196,10 @@ auto print_node(const node_stmt& root, int indent) -> void
         [&](const node_declaration_stmt& node) {
             print("{}Declaration:\n", spaces);
             print("{}- Name: {}\n", spaces, node.name);
+            if (node.explicit_type) {
+                print("{}- ExplicitType:\n", spaces);
+                print_node(*node.explicit_type, indent + 1);
+            }
             print("{}- AddConst: {}\n", spaces, node.add_const);
             print("{}- Value:\n", spaces);
             print_node(*node.expr, indent + 1);

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -214,11 +214,11 @@ auto print_node(const node_stmt& root, int indent) -> void
         [&](const node_function_def_stmt& node) {
             print("{}Function: {}", spaces, node.name);
             if (!node.template_types.empty()) {
-                std::print("<");
+                std::print("|");
                 print_comma_separated(node.template_types, [](const auto& arg) {
                     return arg;
                 });
-                std::print(">");
+                std::print("|");
             }
             std::print("(");
             print_comma_separated(node.sig.params, [](const auto& arg) {
@@ -263,7 +263,7 @@ auto print_node(const anzu::node_type& root, int indent) -> void
     const auto spaces = std::string(4 * indent, ' ');
     std::visit(overloaded {
         [&](const node_named_type& node) {
-            print("{}NamedType:\n {}", spaces, node.type);
+            print("{}NamedType: {}\n", spaces, node.type);
         },
         [&](const node_expr_type& node) {
             print("{}ExprType:\n", spaces);

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -64,6 +64,12 @@ auto print_node(const node_expr& root, int indent) -> void
             print("{}Call:\n", spaces);
             print("{}- Expr:\n", spaces);
             print_node(*node.expr, indent + 1);
+            if (!node.template_args.empty()) {
+                print("{}- TemplateArgs:\n", spaces);
+                for (const auto& arg : node.template_args) {
+                    print_node(*arg, indent + 1);
+                }
+            }
             print("{}- Args:\n", spaces);
             for (const auto& arg : node.args) {
                 print_node(*arg, indent + 1);

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -206,7 +206,15 @@ auto print_node(const node_stmt& root, int indent) -> void
             print_node(*node.expr, indent + 1);
         },
         [&](const node_function_def_stmt& node) {
-            print("{}Function: {} (", spaces, node.name);
+            print("{}Function: {}", spaces, node.name);
+            if (!node.template_types.empty()) {
+                std::print("<");
+                print_comma_separated(node.template_types, [](const auto& arg) {
+                    return arg;
+                });
+                std::print(">");
+            }
+            std::print("(");
             print_comma_separated(node.sig.params, [](const auto& arg) {
                 return std::format("{}: {}", arg.name, *arg.type);
             });

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -136,6 +136,7 @@ struct node_binary_op_expr
 struct node_call_expr
 {
     node_expr_ptr expr;
+    std::vector<node_type_ptr> template_args;
     std::vector<node_expr_ptr> args;
 
     anzu::token token;

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -104,7 +104,6 @@ struct node_literal_string_expr
 
 struct node_name_expr
 {
-    node_type_ptr struct_name = nullptr;
     std::string name;
 
     anzu::token token;

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -318,9 +318,10 @@ struct node_assignment_stmt
 
 struct node_function_def_stmt
 {
-    std::string    name;
-    node_signature sig;
-    node_stmt_ptr  body;
+    std::string              name;
+    std::vector<std::string> template_types;
+    node_signature           sig;
+    node_stmt_ptr            body;
 
     anzu::token token;
 };

--- a/src/compilation/type_manager.cpp
+++ b/src/compilation/type_manager.cpp
@@ -14,10 +14,6 @@ auto type_manager::add(const type_name& name, const type_fields& fields) -> bool
 
 auto type_manager::contains(const type_name& type) const -> bool
 {
-    if (!d_template_args.empty() && d_template_args.top().contains(type)) {
-        return contains(d_template_args.top().at(type));
-    }
-
     return std::visit(overloaded{
         [](type_fundamental)          { return true; },
         [&](const type_struct&)       { return d_classes.contains(type); },
@@ -31,19 +27,11 @@ auto type_manager::contains(const type_name& type) const -> bool
 
 auto type_manager::make_type(const std::string& name) -> type_name
 {
-    const auto simple = type_name{ type_struct{ .name=name } };
-    if (!d_template_args.empty() && d_template_args.top().contains(simple)) {
-        return d_template_args.top().at(simple);
-    }
-    return simple;
+    return type_name{ type_struct{ .name=name } };
 }
 
 auto type_manager::size_of(const type_name& type) const -> std::size_t
 {
-    if (!d_template_args.empty() && d_template_args.top().contains(type)) {
-        return size_of(d_template_args.top().at(type));
-    }
-    
     const auto size = std::visit(overloaded{
         [](type_fundamental t) -> std::size_t {
             switch (t) {
@@ -63,7 +51,7 @@ auto type_manager::size_of(const type_name& type) const -> std::size_t
                 return 0;
             }
         },
-        [&](const type_struct& t) -> std::size_t {
+        [&](const type_struct&) -> std::size_t {
             if (!d_classes.contains(type)) {
                 panic("unknown type '{}'", type);
             }
@@ -104,7 +92,7 @@ auto type_manager::fields_of(const type_name& t) const -> type_fields
     return {};
 }
 
-auto type_manager::resolve_template(const type_name& type) -> type_name
+auto type_manager::resolve_template(const type_name& type) const -> type_name
 {
     const auto resolved = std::visit(overloaded{
         [&](type_fundamental) { return

--- a/src/compilation/type_manager.cpp
+++ b/src/compilation/type_manager.cpp
@@ -25,9 +25,10 @@ auto type_manager::contains(const type_name& type) const -> bool
     }, type);
 }
 
-auto type_manager::make_type(const std::string& name) -> type_name
+auto type_manager::get(const std::string& name) -> type_name
 {
-    return type_name{ type_struct{ .name=name } };
+    const auto simple = type_name{ type_struct{ .name=name } };
+    return resolve_template(simple);
 }
 
 auto type_manager::size_of(const type_name& type) const -> std::size_t
@@ -82,10 +83,6 @@ auto type_manager::size_of(const type_name& type) const -> std::size_t
 
 auto type_manager::fields_of(const type_name& t) const -> type_fields
 {
-    if (!d_template_args.empty() && d_template_args.top().contains(t)) {
-        return fields_of(d_template_args.top().at(t));
-    }
-
     if (auto it = d_classes.find(t.remove_const()); it != d_classes.end()) {
         return it->second;
     }

--- a/src/compilation/type_manager.cpp
+++ b/src/compilation/type_manager.cpp
@@ -25,12 +25,6 @@ auto type_manager::contains(const type_name& type) const -> bool
     }, type);
 }
 
-auto type_manager::get(const std::string& name) -> type_name
-{
-    const auto simple = type_name{ type_struct{ .name=name } };
-    return resolve_template(simple);
-}
-
 auto type_manager::size_of(const type_name& type) const -> std::size_t
 {
     const auto size = std::visit(overloaded{
@@ -87,29 +81,6 @@ auto type_manager::fields_of(const type_name& t) const -> type_fields
         return it->second;
     }
     return {};
-}
-
-auto type_manager::resolve_template(const type_name& type) const -> type_name
-{
-    const auto resolved = std::visit(overloaded{
-        [&](type_fundamental) { return
-            (!d_template_args.empty() && d_template_args.top().contains(type)) ? d_template_args.top().at(type)
-                                                                               : type;
-        },
-        [&](const type_struct& t) { return
-            (!d_template_args.empty() && d_template_args.top().contains(type)) ? d_template_args.top().at(type)
-                                                                               : type;
-        },
-        [&](const type_array& t)      { return type_name{type_array{resolve_template(*t.inner_type), t.count}}; },
-        [&](const type_span& t)       { return type_name{type_span{resolve_template(*t.inner_type)}}; },
-        [&](const type_ptr& t)        { return type_name{type_ptr{resolve_template(*t.inner_type)}}; },
-        [&](const type_function_ptr&) { return type; }, // TODO: resolve function ptr types too
-        [&](const type_arena&) { return
-            (!d_template_args.empty() && d_template_args.top().contains(type)) ? d_template_args.top().at(type)
-                                                                               : type;
-        },
-    }, type);
-    return resolved;
 }
 
 }

--- a/src/compilation/type_manager.cpp
+++ b/src/compilation/type_manager.cpp
@@ -27,7 +27,7 @@ auto type_manager::contains(const type_name& type) const -> bool
 
 auto type_manager::size_of(const type_name& type) const -> std::size_t
 {
-    const auto size = std::visit(overloaded{
+    return std::visit(overloaded{
         [](type_fundamental t) -> std::size_t {
             switch (t) {
                 case type_fundamental::null_type:
@@ -72,7 +72,6 @@ auto type_manager::size_of(const type_name& type) const -> std::size_t
             return sizeof(std::byte*); // the runtime will store the arena separately
         }
     }, type);
-    return size;
 }
 
 auto type_manager::fields_of(const type_name& t) const -> type_fields

--- a/src/compilation/type_manager.hpp
+++ b/src/compilation/type_manager.hpp
@@ -45,7 +45,7 @@ public:
         d_template_args.pop();
     }
 
-    auto resolve_template(const type_name& type) -> type_name;
+    auto resolve_template(const type_name& type) const -> type_name;
 };
 
 }

--- a/src/compilation/type_manager.hpp
+++ b/src/compilation/type_manager.hpp
@@ -39,6 +39,12 @@ public:
     {
         d_template_args.pop();
     }
+
+    auto resolve_template(const type_name& type) -> type_name
+    {
+        if (!d_template_args.empty() && d_template_args.top().contains(type)) return d_template_args.top().at(type);
+        return type;
+    }
 };
 
 }

--- a/src/compilation/type_manager.hpp
+++ b/src/compilation/type_manager.hpp
@@ -14,7 +14,6 @@ struct type_field
 
 class type_manager
 {
-    using type_hash = decltype([](const type_name& t) { return anzu::hash(t); });
     using type_fields = std::vector<type_field>;
     std::unordered_map<type_name, type_fields, type_hash> d_classes;
 

--- a/src/compilation/type_manager.hpp
+++ b/src/compilation/type_manager.hpp
@@ -2,7 +2,6 @@
 #include "object.hpp"
 
 #include <unordered_map>
-#include <stack>
 
 namespace anzu {
 
@@ -18,34 +17,12 @@ class type_manager
     using type_fields = std::vector<type_field>;
     std::unordered_map<type_name, type_fields, type_hash> d_classes;
 
-    // When compiling a function template, the template names need to be
-    // available, so we push them here. This is a stack since we can pause
-    // compiling one function to start compiling another
-    std::stack<template_map> d_template_args;
-
 public:
     auto add(const type_name& name, const type_fields& fields) -> bool;
     auto contains(const type_name& t) const -> bool;
 
-    // If the string doesn't match an existing type, a new type_struct is returned,
-    // but not added to the store (since you'll add it with fields). Otherwise, it will
-    // return the existing type or resolve it to a templated type.
-    auto get(const std::string& name) -> type_name;
-
     auto size_of(const type_name& t) const -> std::size_t;
     auto fields_of(const type_name& t) const -> type_fields;
-
-    auto push_template_types(const template_map& map) -> void
-    {
-        d_template_args.push(map);
-    }
-
-    auto pop_template_types() -> void
-    {
-        d_template_args.pop();
-    }
-
-    auto resolve_template(const type_name& type) const -> type_name;
 };
 
 }

--- a/src/compilation/type_manager.hpp
+++ b/src/compilation/type_manager.hpp
@@ -30,7 +30,7 @@ public:
     // If the string doesn't match an existing type, a new type_struct is returned,
     // but not added to the store (since you'll add it with fields). Otherwise, it will
     // return the existing type or resolve it to a templated type.
-    auto make_type(const std::string& name) -> type_name;
+    auto get(const std::string& name) -> type_name;
 
     auto size_of(const type_name& t) const -> std::size_t;
     auto fields_of(const type_name& t) const -> type_fields;

--- a/src/compilation/type_manager.hpp
+++ b/src/compilation/type_manager.hpp
@@ -2,6 +2,7 @@
 #include "object.hpp"
 
 #include <unordered_map>
+#include <stack>
 
 namespace anzu {
 
@@ -17,12 +18,27 @@ class type_manager
     using type_fields = std::vector<type_field>;
     std::unordered_map<type_name, type_fields, type_hash> d_classes;
 
+    // When compiling a function template, the template names need to be
+    // available, so we push them here. This is a stack since we can pause
+    // compiling one function to start compiling another
+    std::stack<template_map> d_template_args;
+
 public:
     auto add(const type_name& name, const type_fields& fields) -> bool;
     auto contains(const type_name& t) const -> bool;
 
     auto size_of(const type_name& t) const -> std::size_t;
     auto fields_of(const type_name& t) const -> type_fields;
+
+    auto push_template_types(const template_map& map) -> void
+    {
+        d_template_args.push(map);
+    }
+
+    auto pop_template_types() -> void
+    {
+        d_template_args.pop();
+    }
 };
 
 }

--- a/src/compilation/type_manager.hpp
+++ b/src/compilation/type_manager.hpp
@@ -27,6 +27,11 @@ public:
     auto add(const type_name& name, const type_fields& fields) -> bool;
     auto contains(const type_name& t) const -> bool;
 
+    // If the string doesn't match an existing type, a new type_struct is returned,
+    // but not added to the store (since you'll add it with fields). Otherwise, it will
+    // return the existing type or resolve it to a templated type.
+    auto make_type(const std::string& name) -> type_name;
+
     auto size_of(const type_name& t) const -> std::size_t;
     auto fields_of(const type_name& t) const -> type_fields;
 
@@ -40,11 +45,7 @@ public:
         d_template_args.pop();
     }
 
-    auto resolve_template(const type_name& type) -> type_name
-    {
-        if (!d_template_args.empty() && d_template_args.top().contains(type)) return d_template_args.top().at(type);
-        return type;
-    }
+    auto resolve_template(const type_name& type) -> type_name;
 };
 
 }

--- a/src/compilation/variable_manager.cpp
+++ b/src/compilation/variable_manager.cpp
@@ -98,33 +98,33 @@ auto variable_manager::size() -> std::size_t
     return d_scopes.size();
 }
 
-auto variable_manager::handle_loop_exit() -> void
+auto variable_manager::handle_loop_exit(std::vector<std::byte>& code) -> void
 {
     auto pop_size = std::size_t{0};
     for (const auto& scope : d_scopes | std::views::reverse) {
-        delete_arenas_in_scope(d_compiler->code(), scope);
+        delete_arenas_in_scope(code, scope);
         pop_size += scope.next - scope.start;
         if (std::holds_alternative<loop_scope>(scope.info)) break;
     }
-    push_value(d_compiler->code(), op::pop, pop_size);
+    push_value(code, op::pop, pop_size);
 }
 
 // This should NOT pop data from the stack like handle_loop_exit since the
 // op::ret op code does this for us.
-auto variable_manager::handle_function_exit() -> void
+auto variable_manager::handle_function_exit(std::vector<std::byte>& code) -> void
 {
     for (const auto& scope : d_scopes | std::views::reverse) {
-        delete_arenas_in_scope(d_compiler->code(), scope);
+        delete_arenas_in_scope(code, scope);
         if (std::holds_alternative<function_scope>(scope.info)) break;
     }
 }
 
-void variable_manager::pop_scope() {
-    delete_arenas_in_scope(d_compiler->code(), d_scopes.back());
+void variable_manager::pop_scope(std::vector<std::byte>& code) {
+    delete_arenas_in_scope(code, d_scopes.back());
     const auto& scope = d_scopes.back();
     const auto size = scope.next - scope.start;
     d_scopes.pop_back();
-    if (size > 0) push_value(d_compiler->code(), op::pop, size); 
+    if (size > 0) push_value(code, op::pop, size); 
 }
 
 }

--- a/src/compilation/variable_manager.hpp
+++ b/src/compilation/variable_manager.hpp
@@ -50,12 +50,9 @@ struct scope
 
 class variable_manager
 {
-    compiler* d_compiler;
     std::vector<scope> d_scopes;
 
 public:
-    auto set_compiler(compiler& c) { d_compiler = &c; }
-
     auto declare(const std::string& name, const type_name& type, std::size_t size) -> bool;
     auto find(const std::string& name) const -> std::optional<variable>;
     auto scopes() const -> std::span<const scope> { return d_scopes; }
@@ -71,12 +68,12 @@ public:
     void new_scope();
     void new_function_scope();
     void new_loop_scope();
-    void pop_scope();
+    void pop_scope(std::vector<std::byte>& code);
 
     // Functions to handle changes to control flow, ie- break, continue and return.
     // All of these can result in control flow not reaching the end of a scope
-    auto handle_loop_exit() -> void;
-    auto handle_function_exit() -> void;
+    auto handle_loop_exit(std::vector<std::byte>& code) -> void;
+    auto handle_function_exit(std::vector<std::byte>& code) -> void;
 };
 
 }

--- a/src/compilation/variable_manager.hpp
+++ b/src/compilation/variable_manager.hpp
@@ -27,17 +27,13 @@ struct simple_scope
 {
 };
 
-struct function_scope
-{
-};
-
 struct loop_scope
 {
     std::vector<std::size_t> continues;
     std::vector<std::size_t> breaks;
 };
 
-using scope_info = std::variant<simple_scope, function_scope, loop_scope>;
+using scope_info = std::variant<simple_scope, loop_scope>;
 
 struct scope
 {
@@ -62,12 +58,10 @@ public:
     auto get_loop_info() -> loop_scope&;
     
     auto in_function() const -> bool;
-    auto get_function_info() -> function_scope&;
 
     auto size() -> std::size_t;
 
     void new_scope();
-    void new_function_scope();
     void new_loop_scope();
     void pop_scope(std::vector<std::byte>& code);
 

--- a/src/compilation/variable_manager.hpp
+++ b/src/compilation/variable_manager.hpp
@@ -30,7 +30,6 @@ struct simple_scope
 
 struct function_scope
 {
-    type_name return_type;
 };
 
 struct loop_scope
@@ -49,22 +48,10 @@ struct scope
     std::vector<variable> variables = {};
 };
 
-class scope_guard
-{
-    variable_manager* d_manager;
-    scope_guard(const scope_guard&) = delete;
-    scope_guard& operator=(const scope_guard&) = delete;
-
-public:
-    scope_guard(variable_manager& manager);
-    ~scope_guard();
-};
-
 class variable_manager
 {
     compiler* d_compiler;
     std::vector<scope> d_scopes;
-    friend scope_guard;
 
 public:
     auto set_compiler(compiler& c) { d_compiler = &c; }
@@ -81,9 +68,10 @@ public:
 
     auto size() -> std::size_t;
 
-    auto new_scope() -> scope_guard;
-    auto new_function_scope(const type_name& return_type) -> scope_guard;
-    auto new_loop_scope() -> scope_guard;
+    void new_scope();
+    void new_function_scope();
+    void new_loop_scope();
+    void pop_scope();
 
     // Functions to handle changes to control flow, ie- break, continue and return.
     // All of these can result in control flow not reaching the end of a scope

--- a/src/compilation/variable_manager.hpp
+++ b/src/compilation/variable_manager.hpp
@@ -21,7 +21,6 @@ struct variable
     type_name   type;
     std::size_t location;
     std::size_t size;
-    bool        is_local;
 };
 
 struct simple_scope
@@ -51,8 +50,10 @@ struct scope
 class variable_manager
 {
     std::vector<scope> d_scopes;
+    bool d_local;
 
 public:
+    variable_manager(bool local) : d_local{local} {}
     auto declare(const std::string& name, const type_name& type, std::size_t size) -> bool;
     auto find(const std::string& name) const -> std::optional<variable>;
     auto scopes() const -> std::span<const scope> { return d_scopes; }

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -806,12 +806,12 @@ auto push_expr_val(compiler& com, const node_member_call_expr& node) -> type_nam
     
     // We wrap the LHS in a addrof so that we can use push_copy_typechecked to push it
     // like a regular function arg.
-    auto synthetic_node = std::make_shared<node_expr>();
-    auto& inner = synthetic_node->emplace<node_addrof_expr>();
+    auto self_ptr_node = std::make_shared<node_expr>();
+    auto& inner = self_ptr_node->emplace<node_addrof_expr>();
     inner.expr = node.expr;
     inner.token = node.token;
 
-    push_copy_typechecked(com, *synthetic_node, func->sig.params[0], node.token);
+    push_copy_typechecked(com, *self_ptr_node, func->sig.params[0], node.token);
     auto t = type;
     while (t.is_ptr()) { // allow for calling member functions through pointers
         push_value(code(com), op::load, sizeof(std::byte*));

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -64,7 +64,7 @@ auto new_function(compiler& com, const std::string& name, const token& tok, cons
     com.current_compiling.push_back(id);
     const auto [it, success] = com.functions_by_name.emplace(name, id);
     tok.assert(success, "a function with the name '{}' already exists", name);
-    variables(com).new_function_scope();
+    variables(com).new_scope();
 }
 
 auto finish_function(compiler& com)

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -73,8 +73,9 @@ auto finish_function(compiler& com)
 
 auto resolve_templates(compiler& com, const type_name& type) -> type_name
 {
+    const auto& map = current(com).template_types;
     const auto try_resolve = [&](const type_name& t) {
-        if (auto it = current(com).map.find(type); it != current(com).map.end()) return it->second;
+        if (auto it = map.find(type); it != map.end()) return it->second;
         return type;
     };
 

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -48,6 +48,13 @@ auto push_expr_ptr(compiler& com, const node_expr& node) -> type_name;
 auto push_expr_val(compiler& com, const node_expr& expr) -> type_name;
 auto push_stmt(compiler& com, const node_stmt& root) -> void;
 auto type_of_expr(compiler& com, const node_expr& node) -> type_name;
+auto compile_function(
+    compiler& com,
+    const token& tok,
+    const std::string& full_name,
+    const node_signature& node_sig,
+    const node_stmt_ptr& body
+) -> void;
 
 auto new_function(compiler& com, const std::string& name, const token& tok)
 {
@@ -633,8 +640,9 @@ auto push_expr_val(compiler& com, const node_call_expr& node) -> type_name
         // Third, this might be a template function with this being the first time we're calling it with specific
         // types, so we need to compile that instantiation and call it here
         if (!node.template_args.empty() and com.function_templates.contains(inner.name)) {
+            const auto function_ast = com.function_templates.at(inner.name);
             const auto full_name = full_function_name(com, global_namespace, inner.name, node.template_args);
-            std::print("compiling {}\n", full_name);
+            compile_function(com, node.token, full_name, function_ast.sig, function_ast.body);
         }
 
         // Lastly, it might be a builtin function

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -1111,7 +1111,16 @@ void push_stmt(compiler& com, const node_function_def_stmt& node)
     if (com.types.contains(make_type(node.name))) {
         node.token.error("'{}' cannot be a function name, it is a type def", node.name);
     }
-    compile_function_body(com, node.token, global_namespace, node.name, node.sig, node.body);
+
+    // Template functions only get compiled at the call site, so we just stash the ast
+    if (!node.template_types.empty()) {
+        const auto [it, success] = com.function_templates.emplace(node.name, node);
+        if (!success) {
+            node.token.error("function template named '{}' already defined", node.name);
+        }
+    } else {
+        compile_function_body(com, node.token, global_namespace, node.name, node.sig, node.body);
+    }
 }
 
 void push_stmt(compiler& com, const node_member_function_def_stmt& node)

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -86,12 +86,6 @@ auto resolve_type(compiler& com, const token& tok, const node_type_ptr& type) ->
 
     const auto resolved_type = std::visit(overloaded {
         [&](const node_named_type& node) {
-            // This possibly could be deleted, feels like there's a better place to do this
-            // since we need to be able to resolve compound types like T& where T is a template
-            const auto& map = current(com).map;
-            if (auto it = map.find(node.type); it != map.end()) {
-                return it->second;
-            }
             return node.type;
         },
         [&](const node_expr_type& node) {
@@ -99,8 +93,9 @@ auto resolve_type(compiler& com, const token& tok, const node_type_ptr& type) ->
         }
     }, *type);
 
-    tok.assert(com.types.contains(resolved_type), "{} is not a recognised type", resolved_type);
-    return resolved_type;
+    const auto ret = com.types.resolve_template(resolved_type);
+    tok.assert(com.types.contains(ret), "{} is not a recognised type", ret);
+    return ret;
 }
 
 auto full_function_name(

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -231,7 +231,7 @@ auto type_of_expr(compiler& com, const node_expr& node) -> type_name
     const auto program_size = code(com).size();
     const auto type = push_expr_val(com, node);
     code(com).resize(program_size);
-    return com.types.resolve_template(type);
+    return type;
 }
 
 // Fetches the given literal from read only memory, or adds it if it is not there, and
@@ -558,7 +558,7 @@ auto push_copy_typechecked(
     // 'u64 const' for a 'u64', but not a 'u64 const&' for a 'u64&' (though passing a 'u64&'
     // for a 'u64 const&' is fine)
     const auto actual = type_of_expr(com, expr).remove_const();
-    const auto expected = com.types.resolve_template(expected_raw.remove_const());
+    const auto expected = expected_raw.remove_const();
 
     if (actual.is_arena() || expected.is_arena()) {
         tok.error("arenas can not be copied or assigned");
@@ -1351,9 +1351,7 @@ void push_stmt(compiler& com, const node_print_stmt& node)
 
 auto push_expr_val(compiler& com, const node_expr& expr) -> type_name
 {
-    return std::visit([&](const auto& node) {
-        return com.types.resolve_template(push_expr_val(com, node));
-    }, expr);
+    return std::visit([&](const auto& node) { return push_expr_val(com, node); }, expr);
 }
 
 auto push_stmt(compiler& com, const node_stmt& root) -> void

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -60,7 +60,7 @@ auto compile_function(
 auto new_function(compiler& com, const std::string& name, const token& tok, const template_map& map)
 {
     const auto id = com.functions.size();
-    com.functions.emplace_back(name, id, variable_manager{true});
+    com.functions.emplace_back(name, id, variable_manager{true}, map);
     com.current_compiling.push_back(id);
     const auto [it, success] = com.functions_by_name.emplace(name, id);
     tok.assert(success, "a function with the name '{}' already exists", name);

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -60,7 +60,6 @@ auto compile_function(
 auto new_function(
     compiler& com, const std::string& name, const token& tok, const template_map& map)
 {
-    if (in_function(com)) tok.error("cannot create a new function while one is already being compiled");
     const auto id = com.functions.size();
 
     // The function signature can only be filled in after declaring the function parameters
@@ -89,7 +88,6 @@ auto resolve_type(compiler& com, const token& tok, const node_type_ptr& type) ->
         [&](const node_named_type& node) {
             const auto& map = current(com).map;
             if (auto it = map.find(node.type); it != map.end()) {
-                std::print("resolving {} to {}\n", node.type, it->second);
                 return it->second;
             }
             return node.type;

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -666,7 +666,7 @@ auto push_expr_val(compiler& com, const node_call_expr& node) -> type_name
             compile_function(com, node.token, full_name, function_ast.sig, function_ast.body, map);
         }
 
-        // Now with the new template function compiled, we can call it, this is just a copy of step 2
+        // Thirdly, if it's a function, call it
         if (const auto func = get_function(com, full_name); func) {
             node.token.assert_eq(node.args.size(), func->sig.params.size(), "bad number of arguments to function call");
             for (std::size_t i = 0; i != node.args.size(); ++i) {

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -37,12 +37,12 @@ auto new_function(compiler& com, const std::string& name, const token& tok)
 
     if (com.functions_by_name.contains(name)) tok.error("a function with the name '{}' already exists", name);
     com.functions_by_name.emplace(name, id);
-    com.current_compiling.push(id);
+    com.current_compiling.push_back(id);
 }
 
 auto finish_function(compiler& com)
 {
-    com.current_compiling.pop();
+    com.current_compiling.pop_back();
 }
 
 

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -86,6 +86,8 @@ auto resolve_type(compiler& com, const token& tok, const node_type_ptr& type) ->
 
     const auto resolved_type = std::visit(overloaded {
         [&](const node_named_type& node) {
+            // This possibly could be deleted, feels like there's a better place to do this
+            // since we need to be able to resolve compound types like T& where T is a template
             const auto& map = current(com).map;
             if (auto it = map.find(node.type); it != map.end()) {
                 return it->second;
@@ -579,8 +581,7 @@ auto push_copy_typechecked(
     }
 }
 
-auto get_builtin_id(const std::string& name)
-    -> std::optional<std::size_t>
+auto get_builtin_id(const std::string& name) -> std::optional<std::size_t>
 {
     auto index = std::size_t{0};
     for (const auto& b : get_builtins()) {
@@ -1187,6 +1188,7 @@ auto compile_function(
     -> void
 {
     new_function(com, full_name, tok, map);
+    com.types.push_template_types(map);
     {
         variables(com).new_function_scope();
 
@@ -1212,6 +1214,7 @@ auto compile_function(
 
         variables(com).pop_scope(code(com));
     }
+    com.types.pop_template_types();
     finish_function(com);
 }
 

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -42,7 +42,7 @@ auto globals(compiler& com) -> variable_manager& {
     return com.functions.front().variables;
 }
 
-static const auto global_namespace = make_type("");
+static const auto global_namespace = type_name{type_struct{""}};
 
 auto push_expr_ptr(compiler& com, const node_expr& node) -> type_name;
 auto push_expr_val(compiler& com, const node_expr& expr) -> type_name;
@@ -231,7 +231,7 @@ auto type_of_expr(compiler& com, const node_expr& node) -> type_name
     const auto program_size = code(com).size();
     const auto type = push_expr_val(com, node);
     code(com).resize(program_size);
-    return type;
+    return com.types.resolve_template(type);
 }
 
 // Fetches the given literal from read only memory, or adds it if it is not there, and
@@ -558,7 +558,7 @@ auto push_copy_typechecked(
     // 'u64 const' for a 'u64', but not a 'u64 const&' for a 'u64&' (though passing a 'u64&'
     // for a 'u64 const&' is fine)
     const auto actual = type_of_expr(com, expr).remove_const();
-    const auto expected = expected_raw.remove_const();
+    const auto expected = com.types.resolve_template(expected_raw.remove_const());
 
     if (actual.is_arena() || expected.is_arena()) {
         tok.error("arenas can not be copied or assigned");
@@ -595,7 +595,7 @@ auto push_expr_val(compiler& com, const node_call_expr& node) -> type_name
         auto& inner = std::get<node_name_expr>(*node.expr);
 
         // First, it might be a constructor call
-        const auto type = make_type(inner.name);
+        const auto type = com.types.make_type(inner.name);
         if (com.types.contains(type)) {
             const auto expected_params = get_constructor_params(com, type);
             node.token.assert(node.template_args.empty(), "no support for template structs yet");
@@ -648,7 +648,7 @@ auto push_expr_val(compiler& com, const node_call_expr& node) -> type_name
 
             auto map = template_map{};
             for (const auto& [actual, expected_str] : zip(node.template_args, function_ast.template_types)) {
-                const auto expected = make_type(expected_str);
+                const auto expected = com.types.make_type(expected_str);
                 if (com.types.contains(expected)) node.token.error("template argument {} is already a real type name", expected_str);
                 const auto [it, success] = map.emplace(expected, resolve_type(com, node.token, actual));
                 if (!success) { node.token.error("duplicate template name {} for function {}", expected, full_name); }
@@ -1100,7 +1100,7 @@ void push_stmt(compiler& com, const node_if_stmt& node)
 void push_stmt(compiler& com, const node_struct_stmt& node)
 {
     const auto message = std::format("type '{}' already defined", node.name);
-    node.token.assert(!com.types.contains(make_type(node.name)), "{}", message);
+    node.token.assert(!com.types.contains(com.types.make_type(node.name)), "{}", message);
     node.token.assert(!com.functions_by_name.contains(node.name), "{}", message);
 
     auto fields = std::vector<type_field>{};
@@ -1108,7 +1108,7 @@ void push_stmt(compiler& com, const node_struct_stmt& node)
         fields.emplace_back(type_field{ .name=p.name, .type=resolve_type(com, node.token, p.type) });
     }
 
-    com.types.add(make_type(node.name), fields);
+    com.types.add(com.types.make_type(node.name), fields);
     for (const auto& function : node.functions) {
         push_stmt(com, *function);
     }
@@ -1215,7 +1215,7 @@ auto compile_function(
 
 void push_stmt(compiler& com, const node_function_def_stmt& node)
 {
-    if (com.types.contains(make_type(node.name))) {
+    if (com.types.contains(com.types.make_type(node.name))) {
         node.token.error("'{}' cannot be a function name, it is a type def", node.name);
     }
 
@@ -1233,7 +1233,7 @@ void push_stmt(compiler& com, const node_function_def_stmt& node)
 
 void push_stmt(compiler& com, const node_member_function_def_stmt& node)
 {
-    const auto struct_type = make_type(node.struct_name);
+    const auto struct_type = com.types.make_type(node.struct_name);
 
     // First argument must be a pointer to an instance of the class
     node.token.assert(node.sig.params.size() > 0, "member functions must have at least one arg");
@@ -1351,7 +1351,9 @@ void push_stmt(compiler& com, const node_print_stmt& node)
 
 auto push_expr_val(compiler& com, const node_expr& expr) -> type_name
 {
-    return std::visit([&](const auto& node) { return push_expr_val(com, node); }, expr);
+    return std::visit([&](const auto& node) {
+        return com.types.resolve_template(push_expr_val(com, node));
+    }, expr);
 }
 
 auto push_stmt(compiler& com, const node_stmt& root) -> void

--- a/src/compiler.hpp
+++ b/src/compiler.hpp
@@ -20,8 +20,6 @@ struct signature
     type_name              return_type;
 };
 
-using template_map = std::unordered_map<type_name, type_name, type_hash>;
-
 struct function_info
 {
     std::string      name;

--- a/src/compiler.hpp
+++ b/src/compiler.hpp
@@ -9,6 +9,7 @@
 #include <filesystem>
 #include <map>
 #include <string>
+#include <stack>
 #include <unordered_map>
 
 namespace anzu {
@@ -35,8 +36,7 @@ struct compiler
 {
     // Returns the current function
     auto current() -> function_info& {
-        return in_function ? compiled_functions.back()   // current function
-                           : compiled_functions.front(); // $main function
+        return functions[current_compiling.top()];
     }
 
     // Returns the bytecode that we are currently writing to
@@ -44,11 +44,16 @@ struct compiler
         return current().code;
     }
 
+    auto in_function() const -> bool {
+        return current_compiling.size() > 1;
+    }
+
+    std::stack<std::size_t> current_compiling;
+
     std::string rom;
 
-    bool in_function = false;
     std::unordered_map<std::string, std::size_t> functions_by_name;
-    std::vector<function_info>                   compiled_functions;
+    std::vector<function_info>                   functions;
     
     type_manager     types;
     variable_manager variables;

--- a/src/compiler.hpp
+++ b/src/compiler.hpp
@@ -25,6 +25,7 @@ struct function_info
     std::string            name;
     signature              sig;
     token                  tok;
+    variable_manager       variables;
     
     std::size_t            id;
     std::vector<std::byte> code;
@@ -44,6 +45,10 @@ struct compiler
         return current().code;
     }
 
+    auto variables() -> variable_manager& {
+        return current().variables;
+    }
+
     auto in_function() const -> bool {
         return current_compiling.size() > 1;
     }
@@ -57,7 +62,6 @@ struct compiler
     std::vector<function_info>                   functions;
     
     type_manager     types;
-    variable_manager variables;
 };
 
 auto compile(const anzu_module& ast) -> bytecode_program;

--- a/src/compiler.hpp
+++ b/src/compiler.hpp
@@ -49,6 +49,7 @@ struct compiler
     }
 
     std::stack<std::size_t> current_compiling;
+    std::unordered_map<std::string, node_function_def_stmt> function_templates;
 
     std::string rom;
 

--- a/src/compiler.hpp
+++ b/src/compiler.hpp
@@ -35,24 +35,6 @@ struct function_info
 // as well as information such as function definitions.
 struct compiler
 {
-    // Returns the current function
-    auto current() -> function_info& {
-        return functions[current_compiling.back()];
-    }
-
-    // Returns the bytecode that we are currently writing to
-    auto code() -> std::vector<std::byte>& {
-        return current().code;
-    }
-
-    auto variables() -> variable_manager& {
-        return current().variables;
-    }
-
-    auto in_function() const -> bool {
-        return current_compiling.size() > 1;
-    }
-
     std::vector<std::size_t> current_compiling;
     std::unordered_map<std::string, node_function_def_stmt> function_templates;
 

--- a/src/compiler.hpp
+++ b/src/compiler.hpp
@@ -9,7 +9,7 @@
 #include <filesystem>
 #include <map>
 #include <string>
-#include <stack>
+#include <vector>
 #include <unordered_map>
 
 namespace anzu {
@@ -36,7 +36,7 @@ struct compiler
 {
     // Returns the current function
     auto current() -> function_info& {
-        return functions[current_compiling.top()];
+        return functions[current_compiling.back()];
     }
 
     // Returns the bytecode that we are currently writing to
@@ -48,7 +48,7 @@ struct compiler
         return current_compiling.size() > 1;
     }
 
-    std::stack<std::size_t> current_compiling;
+    std::vector<std::size_t> current_compiling;
     std::unordered_map<std::string, node_function_def_stmt> function_templates;
 
     std::string rom;

--- a/src/compiler.hpp
+++ b/src/compiler.hpp
@@ -25,10 +25,10 @@ struct function_info
     std::string      name;
     std::size_t      id;
     variable_manager variables;
+    template_map     map;
     
     std::vector<std::byte> code = {};
     signature              sig  = {};
-    template_map           map  = {};
 };
 
 struct compiler

--- a/src/compiler.hpp
+++ b/src/compiler.hpp
@@ -23,14 +23,12 @@ struct signature
 struct function_info
 {
     std::string      name;
-    signature        sig;
-    token            tok;
+    std::size_t      id;
     variable_manager variables;
     
-    std::size_t            id;
-    std::vector<std::byte> code;
-
-    template_map map = {};
+    std::vector<std::byte> code = {};
+    signature              sig = {};
+    template_map           map = {};
 };
 
 // Struct used to store information while compiling an AST. Contains the output program

--- a/src/compiler.hpp
+++ b/src/compiler.hpp
@@ -20,6 +20,8 @@ struct signature
     type_name              return_type;
 };
 
+using template_map = std::unordered_map<type_name, type_name, type_hash>;
+
 struct function_info
 {
     std::string      name;
@@ -30,7 +32,7 @@ struct function_info
     std::size_t            id;
     std::vector<std::byte> code;
 
-    std::unordered_map<std::string, type_name> template_map = {};
+    template_map map = {};
 };
 
 // Struct used to store information while compiling an AST. Contains the output program

--- a/src/compiler.hpp
+++ b/src/compiler.hpp
@@ -22,13 +22,15 @@ struct signature
 
 struct function_info
 {
-    std::string            name;
-    signature              sig;
-    token                  tok;
-    variable_manager       variables;
+    std::string      name;
+    signature        sig;
+    token            tok;
+    variable_manager variables;
     
     std::size_t            id;
     std::vector<std::byte> code;
+
+    std::unordered_map<std::string, type_name> template_map = {};
 };
 
 // Struct used to store information while compiling an AST. Contains the output program

--- a/src/compiler.hpp
+++ b/src/compiler.hpp
@@ -25,7 +25,7 @@ struct function_info
     std::string      name;
     std::size_t      id;
     variable_manager variables;
-    template_map     map;
+    template_map     template_types;
     
     std::vector<std::byte> code = {};
     signature              sig  = {};

--- a/src/compiler.hpp
+++ b/src/compiler.hpp
@@ -27,23 +27,20 @@ struct function_info
     variable_manager variables;
     
     std::vector<std::byte> code = {};
-    signature              sig = {};
-    template_map           map = {};
+    signature              sig  = {};
+    template_map           map  = {};
 };
 
-// Struct used to store information while compiling an AST. Contains the output program
-// as well as information such as function definitions.
 struct compiler
 {
-    std::vector<std::size_t> current_compiling;
+    std::vector<function_info> functions;
+    std::string                rom;
+
+    type_manager types;
+
+    std::unordered_map<std::string, std::size_t>            functions_by_name;
     std::unordered_map<std::string, node_function_def_stmt> function_templates;
-
-    std::string rom;
-
-    std::unordered_map<std::string, std::size_t> functions_by_name;
-    std::vector<function_info>                   functions;
-    
-    type_manager     types;
+    std::vector<std::size_t>                                current_compiling;
 };
 
 auto compile(const anzu_module& ast) -> bytecode_program;

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -21,13 +21,12 @@ auto type_name::is_ptr() const -> bool
 
 auto type_name::add_ptr() const -> type_name
 {
-    if (is_ptr()) return *this;
     return { type_ptr{ .inner_type{*this} } };
 }
 
 auto type_name::remove_ptr() const -> type_name
 {
-    if (!is_ptr()) return *this;
+    if (!is_ptr()) panic("tried to remove_ptr on a non-ptr type\n");
     return *std::get<type_ptr>(*this).inner_type;
 }
 

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -216,7 +216,7 @@ auto arena_type() -> type_name
 
 auto string_literal_type() -> type_name
 {
-    return char_type().add_const().add_span()
+    return char_type().add_const().add_span();
 }
 
 auto make_type(const std::string& name) -> type_name

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -219,11 +219,6 @@ auto string_literal_type() -> type_name
     return char_type().add_const().add_span();
 }
 
-auto make_type(const std::string& name) -> type_name
-{
-    return { type_struct{ .name=name } };
-}
-
 auto type_name::is_array() const -> bool
 {
     return std::holds_alternative<type_array>(*this);

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -128,8 +128,6 @@ auto f64_type() -> type_name;
 auto arena_type() -> type_name;
 auto string_literal_type() -> type_name;
 
-auto make_type(const std::string& name) -> type_name;
-
 // Extracts the single inner type of the given t. Undefined if the given t is not a compound
 // type with a single subtype.
 auto inner_type(const type_name& t) -> type_name;

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -114,6 +114,9 @@ auto hash(const type_arena& type) -> std::size_t;
 auto hash(std::span<const type_name> types) -> std::size_t;
 using type_hash = decltype([](const type_name& t) { return anzu::hash(t); });
 
+// Used for resolving template types. In the future could also be used for type aliases
+using template_map = std::unordered_map<type_name, type_name, type_hash>;
+
 auto null_type() -> type_name;
 auto nullptr_type() -> type_name;
 auto bool_type() -> type_name;

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -112,6 +112,7 @@ auto hash(const type_span& type) -> std::size_t;
 auto hash(const type_function_ptr& type) -> std::size_t;
 auto hash(const type_arena& type) -> std::size_t;
 auto hash(std::span<const type_name> types) -> std::size_t;
+using type_hash = decltype([](const type_name& t) { return anzu::hash(t); });
 
 auto null_type() -> type_name;
 auto nullptr_type() -> type_name;

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -153,7 +153,7 @@ auto parse_name(tokenstream& tokens)
 {
     const auto token = tokens.consume();
     if (token.type != token_type::identifier) {
-        token.error("'{}' is not a valid name", token.text);
+        token.error("'{}' is not a valid name (type={})", token.text, token.type);
     }
     return token.text;
 }
@@ -174,14 +174,14 @@ auto parse_member_access(tokenstream& tokens, node_expr_ptr& node)
             expr.other_args.push_back(parse_expression(tokens));
         });
     }
-    else if (tokens.peek_next(token_type::less)) {
+    else if (tokens.peek_next(token_type::bar)) {
         auto& expr = new_node->emplace<node_member_call_expr>();
         expr.expr = node;
         expr.token = tok;
         expr.function_name = parse_name(tokens);
-        tokens.consume_only(token_type::less);
+        tokens.consume_only(token_type::bar);
         expr.template_type = parse_type_node(tokens);
-        tokens.consume_only(token_type::greater);
+        tokens.consume_only(token_type::bar);
         tokens.consume_only(token_type::left_paren);
         tokens.consume_comma_separated_list(token_type::right_paren, [&] {
             expr.other_args.push_back(parse_expression(tokens));

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -457,9 +457,15 @@ auto parse_function_def_stmt(tokenstream& tokens) -> node_stmt_ptr
 {
     auto node = std::make_shared<node_stmt>();
     auto& stmt = node->emplace<node_function_def_stmt>();
-
     stmt.token = tokens.consume_only(token_type::kw_function);
     stmt.name = parse_name(tokens);
+
+    if (tokens.consume_maybe(token_type::less)) {
+        tokens.consume_comma_separated_list(token_type::greater, [&]{
+            stmt.template_types.push_back(std::string{parse_name(tokens)});
+        });
+    }
+
     tokens.consume_only(token_type::left_paren);
     tokens.consume_comma_separated_list(token_type::right_paren, [&]{
         auto param = node_parameter{};


### PR DESCRIPTION
* Finally added template functions. The syntax is `fn foo|T|(args) { ... }`, using bars to denote the template list. I was originally going to do `<T>` like in C++, but that makes it much harder to parse and would require big changes to the lexer to allow going backwards through the token stream. Consider how would you parse `let x := foo < bar;`; as oppose to `let x := foo<bar>();` without requiring type information.
* When the compiler encounters the definition of a template function, it just stashes the AST for later. When a template function call appears, the compiler first compiles the function if it doesn't already exist and then the usual code for handling function calls works as normal (now that we use a fully qualified name everywhere).
* The `function_info` now contains a `type_name -> type_name` map for mapping template names to concrete instantiations for compilation. The functions `make_type` and `resolve_type` which are responsible to creating `type_name` objects from the source code now run their return values through the new `resolve_templates` which uses this map to substitute template args. This lets the rest of compilation work almost the same as before.
* Improved the API for `get_function`, which now just takes a string for a fully qualified function name, and added `full_function_name` function for creating this name from a struct type, function name and template arguments.
* Changed `arena.new` and `arena.new_array` to use the bar syntax.
* Moved the `variable_manager` from the `compiler` struct to the `function_info` struct. In other words, there is now one variable manager per function rather than one global one. This is because if we pause compiling one function to compile another (first instantiation of a template function), then we don't want variable discovery to end up in the previous function. Now, if a variable cannot be found in the current function scope, it jumps to the global scope.
* Removed scope guards and a bunch of other stuff related to the variable manager to handle this refactor. They can probably be added back but I haven't bothered yet.
* As such, the variable manager no longer needs a pointer to the compiler.
* Removed the `is_local` value from each variable definition since that can just live on the variable manager directly now.
* Remove the `function_scope` related functions from the variable manager since there is one per function (and one for the globals).
* Bugfix: Make it possible to call member functions through pointers for builtin types (arrays, spans and arenas).
* Bugfix: `object.add_ptr` was idempotent, which was probably correct at one point, but is inconsistent with the other `add_*` functions and unexpected to me, and caused pointers to pointers to not work.
* Todo: template member functions and template structs.