### PR TITLE
Template Member Functions

### DIFF
--- a/examples/feature_test.az
+++ b/examples/feature_test.az
@@ -317,6 +317,11 @@ struct foo
 {
     x: i64;
     y: i64;
+
+    fn bar|T|(self: foo const&, x: T)
+    {
+        print("{}\n", x);
+    }
 }
 
 let f := foo(1, 2);
@@ -325,3 +330,6 @@ print("{} {}\n", g.x, g.y);
 
 var x := 10;
 ptr|i64|(x&);
+
+f.bar|i64|(6);
+f.bar|f64|(10.0);

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,11 +1,11 @@
 # The next thing to implement; template member functions
 struct foo
 {
-    fn bar|T|(self: foo const&)
+    fn bar|T|(self: foo const&, x: T)
     {
-        print("{}\n", sizeof(T));
+        print("{}\n", sizeof(x));
     }
 }
 
 let f := foo();
-f.bar|i64|(6);
+f.bar|i64|(5);

--- a/examples/test.az
+++ b/examples/test.az
@@ -3,9 +3,10 @@ struct foo
 {
     fn bar|T|(self: foo const&, x: T)
     {
-        print("{}\n", 12);
+        print("{}\n", x);
     }
 }
 
 let f := foo();
-f.bar|i64|(5);
+f.bar|i64|(6);
+f.bar|f64|(10.0);

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,11 +1,11 @@
 # The next thing to implement; template member functions
-#struct foo
-#{
-#    fn bar|T|(self: foo const&)
-#    {
-#        print("{}\n", sizeof(T));
-#    }
-#}
-#
-#let f := foo();
-#f.bar|i64|(6);
+struct foo
+{
+    fn bar|T|(self: foo const&)
+    {
+        print("{}\n", sizeof(T));
+    }
+}
+
+let f := foo();
+f.bar|i64|(6);

--- a/examples/test.az
+++ b/examples/test.az
@@ -3,7 +3,7 @@ struct foo
 {
     fn bar|T|(self: foo const&, x: T)
     {
-        print("{}\n", sizeof(x));
+        print("{}\n", 12);
     }
 }
 

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -80,8 +80,11 @@ auto print_node(const node_expr& root, int indent) -> void
             print("{}- Expr:\n", spaces);
             print_node(*node.expr, indent + 1);
             print("{}- FunctionName: {}\n", spaces, node.function_name);
-            if (node.template_type) {
-                print("{}- TemplateType: {}\n", spaces, *node.template_type);
+            if (!node.template_args.empty()) {
+                print("{}- TemplateArgs:\n", spaces);
+                for (const auto& arg : node.template_args) {
+                    print_node(*arg, indent + 1);
+                }
             }
             print("{}- OtherArgs:\n", spaces);
             for (const auto& arg : node.other_args) {

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -232,7 +232,15 @@ auto print_node(const node_stmt& root, int indent) -> void
             print_node(*node.body, indent + 1);
         },
         [&](const node_member_function_def_stmt& node) {
-            print("{}MemberFunction: {}::{} (", spaces, node.struct_name, node.function_name);
+            print("{}MemberFunction: {}::{}", spaces, node.struct_name, node.function_name);
+            if (!node.template_types.empty()) {
+                std::print("|");
+                print_comma_separated(node.template_types, [](const auto& arg) {
+                    return arg;
+                });
+                std::print("|");
+            }
+            std::print("(");
             print_comma_separated(node.sig.params, [](const auto& arg) {
                 return std::format("{}: {}", arg.name, *arg.type);
             });

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -145,7 +145,7 @@ struct node_member_call_expr
 {
     node_expr_ptr              expr;
     std::string                function_name;
-    node_type_ptr              template_type; // used only for arena.create<type>() calls for now
+    std::vector<node_type_ptr> template_args;
     std::vector<node_expr_ptr> other_args;
 
     anzu::token token;

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -328,10 +328,11 @@ struct node_function_def_stmt
 
 struct node_member_function_def_stmt
 {
-    std::string    struct_name;
-    std::string    function_name;
-    node_signature sig;
-    node_stmt_ptr  body;
+    std::string              struct_name;
+    std::string              function_name;
+    std::vector<std::string> template_types;
+    node_signature           sig;
+    node_stmt_ptr            body;
 
     anzu::token token;
 };

--- a/src/compiler.hpp
+++ b/src/compiler.hpp
@@ -38,9 +38,10 @@ struct compiler
 
     type_manager types;
 
-    std::unordered_map<std::string, std::size_t>            functions_by_name;
-    std::unordered_map<std::string, node_function_def_stmt> function_templates;
-    std::vector<std::size_t>                                current_compiling;
+    std::unordered_map<std::string, std::size_t>                   functions_by_name;
+    std::unordered_map<std::string, node_function_def_stmt>        function_templates;
+    std::unordered_map<std::string, node_member_function_def_stmt> member_function_templates;
+    std::vector<std::size_t>                                       current_compiling;
 };
 
 auto compile(const anzu_module& ast) -> bytecode_program;

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -507,6 +507,12 @@ auto parse_member_function_def_stmt(const std::string& struct_name, tokenstream&
     stmt.struct_name = struct_name;
     stmt.function_name = parse_name(tokens);
 
+    if (tokens.consume_maybe(token_type::bar)) {
+        tokens.consume_comma_separated_list(token_type::bar, [&]{
+            stmt.template_types.push_back(std::string{parse_name(tokens)});
+        });
+    }
+
     tokens.consume_only(token_type::left_paren);
     tokens.consume_comma_separated_list(token_type::right_paren, [&]{
         auto param = node_parameter{};

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -168,7 +168,6 @@ auto parse_member_access(tokenstream& tokens, node_expr_ptr& node)
         expr.expr = node;
         expr.token = tok;
         expr.function_name = parse_name(tokens);
-        expr.template_type = nullptr;
         tokens.consume_only(token_type::left_paren);
         tokens.consume_comma_separated_list(token_type::right_paren, [&] {
             expr.other_args.push_back(parse_expression(tokens));
@@ -180,8 +179,9 @@ auto parse_member_access(tokenstream& tokens, node_expr_ptr& node)
         expr.token = tok;
         expr.function_name = parse_name(tokens);
         tokens.consume_only(token_type::bar);
-        expr.template_type = parse_type_node(tokens);
-        tokens.consume_only(token_type::bar);
+        tokens.consume_comma_separated_list(token_type::bar, [&] {
+            expr.template_args.push_back(parse_type_node(tokens));
+        });
         tokens.consume_only(token_type::left_paren);
         tokens.consume_comma_separated_list(token_type::right_paren, [&] {
             expr.other_args.push_back(parse_expression(tokens));


### PR DESCRIPTION
* Made it possible to have templated member functions.
* The implementation is largely the same as normal template functions; the compiler stashes the AST when it sees it and compiles it when needed.
* Generalises `node_member_call_expr` to be able to have multiple template types.