### PR TITLE
Templated Named AST Node

### DIFF
--- a/examples/feature_test.az
+++ b/examples/feature_test.az
@@ -311,7 +311,7 @@ fn do!(T)(x: T) -> T
     return T(10, 20);
 }
 
-fn ptr!(T)(x: T&) { print("{}\n", x); }
+fn ptr!(T)(x: T&) { print("{} {}\n", x, x@); }
 
 struct foo
 {
@@ -332,3 +332,7 @@ var x := 10;
 ptr!(i64)(x&);
 
 f.bar!(i64)(6);
+
+let fp := ptr!(u64);
+var arg := 60u;
+fp(arg&);

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,12 +1,5 @@
 
-struct vec2
-{
-    x: i64;
-    y: i64;
+fn foo!(T)() -> null { print("hello world\n") }
 
-    fn bar(self: vec2&) { print("here i am\n"); }
-}
-
-var v := vec2(1, 2);
-v.bar();
-
+let f := foo!(i64);
+f();

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,5 +1,7 @@
 
 fn foo!(T)() -> null { print("hello world\n") }
 
-let f := foo!(i64);
+var f := foo!(i64);
 f();
+
+__dump_type(f);

--- a/examples/test.az
+++ b/examples/test.az
@@ -7,5 +7,5 @@ struct foo
     }
 }
 
+
 let f := foo(5);
-f.bar(f&);

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,7 +1,11 @@
 
-fn foo!(T)() -> null { print("hello world\n") }
+struct foo
+{
+    x: i64;
+    fn bar(self: foo const&) -> null {
+        print("hello world {}\n", self.x);
+    }
+}
 
-var f := foo!(i64);
-f();
-
-__dump_type(f);
+let f := foo(5);
+f.bar(f&);

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -71,12 +71,6 @@ auto print_node(const node_expr& root, int indent) -> void
             std::print("{}Call:\n", spaces);
             std::print("{}- Expr:\n", spaces);
             print_node(*node.expr, indent + 1);
-            if (!node.template_args.empty()) {
-                std::print("{}- TemplateArgs:\n", spaces);
-                for (const auto& arg : node.template_args) {
-                    print_node(*arg, indent + 1);
-                }
-            }
             std::print("{}- Args:\n", spaces);
             for (const auto& arg : node.args) {
                 print_node(*arg, indent + 1);

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -266,6 +266,7 @@ auto print_node(const node_stmt& root, int indent) -> void
                 });
                 std::print(")");
             }
+            std::print("\n");
             std::print("{}- FunctionArguments:\n", spaces);
             for (const auto& param : node.sig.params) {
                 std::print("    {}:\n", param.name);

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -40,6 +40,13 @@ auto print_node(const node_expr& root, int indent) -> void
         [&](const node_name_expr& node) {
             std::print("{}Name: {}\n", spaces, node.name);
         },
+        [&](const node_templated_name_expr& node) {
+            std::print("{}TemplatedName: {}\n", spaces, node.name);
+            std::print("{}- Args:\n", spaces);
+            for (const auto& arg : node.templates) {
+                print_node(*arg, indent + 1);
+            }
+        },
         [&](const node_field_expr& node) {
             std::print("{}Field: \n", spaces);
             std::print("{}- Expr:\n", spaces);

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -108,7 +108,6 @@ struct node_binary_op_expr
 struct node_call_expr
 {
     node_expr_ptr expr;
-    std::vector<node_expr_ptr> template_args;
     std::vector<node_expr_ptr> args;
 
     anzu::token token;

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -74,6 +74,14 @@ struct node_name_expr
     anzu::token token;
 };
 
+struct node_templated_name_expr
+{
+    std::string name;
+    std::vector<node_expr_ptr> templates;
+
+    anzu::token token;
+};
+
 struct node_field_expr
 {
     node_expr_ptr expr;
@@ -214,6 +222,7 @@ struct node_expr : std::variant<
     node_function_ptr_type_expr,
     node_const_expr,
     node_name_expr,
+    node_templated_name_expr,
     node_field_expr,
     node_deref_expr,
     node_subscript_expr>

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -662,7 +662,6 @@ auto push_expr(compiler& com, compile_type ct, const node_call_expr& node) -> ty
         // TODO- fix type checking
         if (const auto b = get_builtin_id(inner.name); b.has_value()) {
             const auto& builtin = get_builtin(*b);
-            node.token.assert(node.template_args.empty(), "no support for template builtins yet");
             node.token.assert_eq(node.args.size(), builtin.args.size(), "bad number of arguments to builtin call");
             for (std::size_t i = 0; i != builtin.args.size(); ++i) {
                 push_copy_typechecked(com, *node.args.at(i), builtin.args[i], node.token);

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -131,9 +131,19 @@ auto parse_nullptr(tokenstream& tokens) -> node_expr_ptr
 auto parse_name(tokenstream& tokens) -> node_expr_ptr
 {
     const auto token = tokens.consume();
-    auto [node, inner] = new_node<node_name_expr>(token);
-    inner.name = token.text;
-    return node;
+    if (tokens.consume_maybe(token_type::bang)) {
+        auto [node, inner] = new_node<node_templated_name_expr>(token);
+        inner.name = token.text;
+        tokens.consume_only(token_type::left_paren);
+        tokens.consume_comma_separated_list(token_type::right_paren, [&] {
+            inner.templates.push_back(parse_expression(tokens));
+        });
+        return node;
+    } else {
+        auto [node, inner] = new_node<node_name_expr>(token);
+        inner.name = token.text;
+        return node;
+    }
 }
 
 auto parse_grouping(tokenstream& tokens) -> node_expr_ptr

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -236,12 +236,6 @@ auto parse_call(tokenstream& tokens, const node_expr_ptr& left) -> node_expr_ptr
 {
     auto [node, inner] = new_node<node_call_expr>(tokens.curr());
     inner.expr = left;
-    if (tokens.consume_maybe(token_type::bang)) {
-        tokens.consume_only(token_type::left_paren);
-        tokens.consume_comma_separated_list(token_type::right_paren, [&] {
-            inner.template_args.push_back(parse_expression(tokens));
-        });
-    }
     tokens.consume_only(token_type::left_paren);
     tokens.consume_comma_separated_list(token_type::right_paren, [&] {
         inner.args.push_back(parse_expression(tokens));


### PR DESCRIPTION
* Rather than having the template args on the call expression, they should instead be on whatever it is we're calling. This is a first step towards that.
* `node_call_expr` no longer accepts template arguments.
* Added `node_templated_name_expr`. This is similar to `node_name_expr` but contains a list of templates.
* When compiling a templated name expression, since it can only be a free function (for now), it first checks to see if it needs to compile the function, before returning a function pointer.
* Enables function pointers to template instantiations, eg `let f := func!(u64)` will stamp out a function and return a pointer to it.