### PR TITLE
Template Cleanup

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,7 @@
             "program": "${workspaceFolder}/build/src/Debug/anzu.exe",
             "args": [
                 "${workspaceFolder}/examples/test.az",
-                "parse"
+                "run"
             ],
             "stopAtEntry": false,
             "cwd": "${fileDirname}",

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,17 +1,14 @@
-struct pair!(T)
-{
-    x: T;
-    y: T;
 
-    fn print_struct(self: pair!(T) const&) -> null
-    {
-        print("{} {}\n", self.x, self.y);
-    }
+struct bar {
+    x: i64;
+    fn foo(self: bar&) { self.x = 10; print("foo\n"); }
+
 }
 
-{
-    var f := pair!(i64)(1, 2);
-    var g := pair!(f64)(12.3, 45.6);
-    f.print_struct();
-    g.print_struct();
-}
+let f := bar(5);
+var p := f&;
+
+var q := p.foo;
+
+q.foo();
+print("{}\n", f.x);

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,5 +1,4 @@
 
-var x := 10;
+let x := 10;
 var p := x&;
 p@ = 15;
-print("{}\n", x);

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,4 +1,5 @@
 
 let x := 10;
 var p := x&;
-p@ = 15;
+
+print("__dump_type", x, p);

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,14 +1,5 @@
 
-struct bar {
-    x: i64;
-    fn foo(self: bar&) { self.x = 10; print("foo\n"); }
-
-}
-
-let f := bar(5);
-var p := f&;
-
-var q := p.foo;
-
-q.foo();
-print("{}\n", f.x);
+var x := 10;
+var p := x&;
+p@ = 15;
+print("{}\n", x);

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -236,7 +236,7 @@ auto print_node(const node_stmt& root, int indent) -> void
             print_node(*node.expr, indent + 1);
         },
         [&](const node_function_stmt& node) {
-            std::print("{}FunctionDef {}", spaces, node.function_name);
+            std::print("{}FunctionDef {}", spaces, node.name);
             if (!node.templates.empty()) {
                 std::print("!({})", format_comma_separated(node.templates));
             }

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -236,11 +236,7 @@ auto print_node(const node_stmt& root, int indent) -> void
             print_node(*node.expr, indent + 1);
         },
         [&](const node_function_stmt& node) {
-            if (node.struct_name.empty()) {
-                std::print("{}FunctionDef {}", spaces, node.function_name);
-            } else {
-                std::print("{}FunctionDef: {}::{}", spaces, node.struct_name, node.function_name);
-            }
+            std::print("{}FunctionDef {}", spaces, node.function_name);
             if (!node.templates.empty()) {
                 std::print("!({})", format_comma_separated(node.templates));
             }

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -235,7 +235,7 @@ auto print_node(const node_stmt& root, int indent) -> void
             std::print("{}- Value:\n", spaces);
             print_node(*node.expr, indent + 1);
         },
-        [&](const node_function_def& node) {
+        [&](const node_function_stmt& node) {
             if (node.struct_name.empty()) {
                 std::print("{}FunctionDef {}", spaces, node.function_name);
             } else {

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -318,7 +318,7 @@ struct node_assignment_stmt
 
 struct node_function_stmt
 {
-    std::string              function_name;
+    std::string              name;
     std::vector<std::string> templates;
     node_signature           sig;
     node_stmt_ptr            body;

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -316,7 +316,7 @@ struct node_assignment_stmt
     anzu::token token;
 };
 
-struct node_function_def
+struct node_function_stmt
 {
     std::string              struct_name;
     std::string              function_name;
@@ -376,7 +376,7 @@ struct node_stmt : std::variant<
     node_declaration_stmt,
     node_arena_declaration_stmt,
     node_assignment_stmt,
-    node_function_def,
+    node_function_stmt,
     node_expression_stmt,
     node_return_stmt,
     node_assert_stmt,

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -318,7 +318,6 @@ struct node_assignment_stmt
 
 struct node_function_stmt
 {
-    std::string              struct_name;
     std::string              function_name;
     std::vector<std::string> templates;
     node_signature           sig;

--- a/src/compilation/variable_manager.hpp
+++ b/src/compilation/variable_manager.hpp
@@ -49,7 +49,7 @@ class variable_manager
     bool d_local;
 
 public:
-    variable_manager(bool local) : d_local{local} {}
+    variable_manager(bool local = true) : d_local{local} {}
     auto declare(const std::string& name, const type_name& type, std::size_t size) -> bool;
     auto find(const std::string& name) const -> std::optional<variable>;
     auto scopes() const -> std::span<const scope> { return d_scopes; }

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -1364,9 +1364,7 @@ void push_stmt(compiler& com, const node_function_stmt& node)
         );
     }
 
-    com.curr_func_templates.emplace_back();
     compile_function(com, node.token, function_name, node.sig, node.body);
-    com.curr_func_templates.pop_back();
 }
 
 void push_stmt(compiler& com, const node_expression_stmt& node)

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -1002,11 +1002,11 @@ auto push_expr(compiler& com, compile_type ct, const node_field_expr& node) -> t
     // Firstly, the field may be a member function
     if (auto info = get_function(com, full_name); info.has_value()) {
         node.token.assert(ct == compile_type::val, "cannot take the address of a bound method");
-        if (type.is_const && !info->sig.params[0].remove_ptr().is_const) {
+        push_expr(com, compile_type::ptr, *node.expr); // push pointer to the instance to bind to
+        const auto stripped = auto_deref_pointer(com, type); // allow for field access through a pointer
+        if (stripped.is_const && !info->sig.params[0].remove_ptr().is_const) {
             node.token.error("cannot bind a const variable to a non-const member function");
         }
-        push_expr(com, compile_type::ptr, *node.expr); // push pointer to the instance to bind to
-        auto_deref_pointer(com, type); // allow for field access through a pointer
         return type_bound_method{
             .param_types = info->sig.params,
             .return_type = info->sig.return_type,

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -936,7 +936,7 @@ auto push_expr(compiler& com, compile_type ct, const node_name_expr& node) -> ty
         com.struct_template_types.reset();
 
         for (const auto& func : struct_ast.functions) {
-            const auto& stmt = std::get<node_function_def>(*func);
+            const auto& stmt = std::get<node_function_stmt>(*func);
             const auto func_name = fn_name(com, node.token, name, stmt.function_name);
 
             // Template functions only get compiled at the call site, so we just stash the ast
@@ -1327,7 +1327,7 @@ void push_stmt(compiler& com, const node_assignment_stmt& node)
     return;
 }
 
-void push_stmt(compiler& com, const node_function_def& node)
+void push_stmt(compiler& com, const node_function_stmt& node)
 {
     const auto struct_type = node.struct_name.empty() ? global_namespace : make_type(com, node.struct_name);
 

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -20,7 +20,7 @@ namespace anzu {
 namespace {
 
 // Returns the current function
-auto current(compiler& com) -> function_info& {
+auto current(compiler& com) -> function& {
     if (com.curr_func.empty()) {
         return com.functions[0]; // global state
     }
@@ -132,21 +132,12 @@ auto fn_name(
     return name;
 }
 
-auto get_function(compiler& com, const std::string& full_name) -> std::optional<function_info>
+auto get_function(compiler& com, const std::string& full_name) -> std::optional<function>
 {
     if (const auto it = com.functions_by_name.find(full_name); it != com.functions_by_name.end()) {
         return com.functions[it->second];
     }
     return std::nullopt;
-}
-
-auto push_function_call(compiler& com, const function_info& function) -> void
-{
-    auto args_size = std::size_t{0};
-    for (const auto& param : function.sig.params) {
-        args_size += com.types.size_of(param);
-    }
-    push_value(code(com), op::push_u64, function.id, op::call, args_size);
 }
 
 // Registers the given name in the current scope
@@ -1416,12 +1407,10 @@ auto compile(const anzu_module& ast) -> bytecode_program
 {
     auto com = compiler{};
     com.functions.emplace_back("$main", 0, variable_manager{false});
-    com.curr_func.emplace_back();
     variables(com).new_scope();
     push_stmt(com, *ast.root);
     variables(com).pop_scope(code(com));
     push_value(code(com), op::end_program);
-    com.curr_func.pop_back();
 
     auto program = bytecode_program{};
     program.rom = com.rom;

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -937,7 +937,7 @@ auto push_expr(compiler& com, compile_type ct, const node_name_expr& node) -> ty
 
         for (const auto& func : ast.functions) {
             const auto& stmt = std::get<node_function_stmt>(*func);
-            const auto func_name = fn_name(com, node.token, name, stmt.function_name);
+            const auto func_name = fn_name(com, node.token, name, stmt.name);
 
             // Template functions only get compiled at the call site, so we just stash the ast
             const auto [it, success] = com.function_templates.emplace(func_name, stmt);
@@ -1310,12 +1310,11 @@ void push_stmt(compiler& com, const node_assignment_stmt& node)
 
 void push_stmt(compiler& com, const node_function_stmt& node)
 {
-    const auto struct_name = com.current_struct.back().name;
-
     // We always ignore the template types here because it is either not a template function and so
     // this is in fact the full name, or it is and we use this as the key for the function_templates
     // map which is just the name without the template section.
-    const auto function_name = fn_name(com, node.token, struct_name, node.function_name);
+    const auto struct_name = com.current_struct.back().name;
+    const auto function_name = fn_name(com, node.token, struct_name, node.name);
 
     // Template functions only get compiled at the call site, so we just stash the ast
     if (!node.templates.empty()) {

--- a/src/compiler.hpp
+++ b/src/compiler.hpp
@@ -41,7 +41,7 @@ struct compiler
     std::unordered_map<std::string, std::size_t>        functions_by_name;
     std::vector<std::size_t>                            current_compiling;
     
-    std::unordered_map<std::string, node_function_def> fn_templates;
+    std::unordered_map<std::string, node_function_stmt> fn_templates;
     std::unordered_map<std::string, node_struct_stmt>  struct_templates;
     std::optional<template_map>                        struct_template_types;
 };

--- a/src/compiler.hpp
+++ b/src/compiler.hpp
@@ -49,13 +49,13 @@ struct compiler
 
     type_manager types;
 
-    std::unordered_map<std::string, std::size_t>        functions_by_name;
+    std::unordered_map<std::string, std::size_t> functions_by_name;
     
-    std::unordered_map<std::string, node_function_stmt> fn_templates;
+    std::unordered_map<std::string, node_function_stmt> function_templates;
     std::unordered_map<std::string, node_struct_stmt>   struct_templates;
 
-    std::vector<struct_info> curr_struct;
-    std::vector<func_info>   curr_func;
+    std::vector<struct_info> current_struct;
+    std::vector<func_info>   current_function;
 };
 
 auto compile(const anzu_module& ast) -> bytecode_program;

--- a/src/compiler.hpp
+++ b/src/compiler.hpp
@@ -30,12 +30,6 @@ struct function_info
     signature              sig  = {};
 };
 
-struct func_info
-{
-    std::string  name;
-    template_map templates;
-};
-
 struct struct_info
 {
     type_name    name;
@@ -55,8 +49,8 @@ struct compiler
     std::unordered_map<std::string, node_function_stmt> fn_templates;
     std::unordered_map<std::string, node_struct_stmt>   struct_templates;
 
-    std::vector<struct_info> current_struct;
-    std::vector<func_info>   current_func;
+    std::vector<struct_info>  curr_struct_templates;
+    std::vector<template_map> curr_func_templates;
 };
 
 auto compile(const anzu_module& ast) -> bytecode_program;

--- a/src/compiler.hpp
+++ b/src/compiler.hpp
@@ -20,7 +20,7 @@ struct signature
     type_name              return_type;
 };
 
-struct function_info
+struct function
 {
     std::string      name;
     std::size_t      id;
@@ -44,8 +44,8 @@ struct struct_info
 
 struct compiler
 {
-    std::vector<function_info> functions;
-    std::string                rom;
+    std::vector<function> functions;
+    std::string           rom;
 
     type_manager types;
 

--- a/src/compiler.hpp
+++ b/src/compiler.hpp
@@ -25,10 +25,15 @@ struct function_info
     std::string      name;
     std::size_t      id;
     variable_manager variables;
-    template_map     template_types;
     
     std::vector<std::byte> code = {};
     signature              sig  = {};
+};
+
+struct func_info
+{
+    std::string  name;
+    template_map templates;
 };
 
 struct struct_info
@@ -45,11 +50,13 @@ struct compiler
     type_manager types;
 
     std::unordered_map<std::string, std::size_t>        functions_by_name;
-    std::vector<std::size_t>                            current_compiling;
+    std::vector<std::size_t>                            current_function;
     
     std::unordered_map<std::string, node_function_stmt> fn_templates;
     std::unordered_map<std::string, node_struct_stmt>   struct_templates;
-    std::optional<struct_info>                          current_struct;
+
+    std::vector<struct_info> current_struct;
+    std::vector<func_info>   current_func;
 };
 
 auto compile(const anzu_module& ast) -> bytecode_program;

--- a/src/compiler.hpp
+++ b/src/compiler.hpp
@@ -30,6 +30,12 @@ struct function_info
     signature              sig  = {};
 };
 
+struct func_info
+{
+    std::size_t  id;
+    template_map templates;
+};
+
 struct struct_info
 {
     type_name    name;
@@ -49,8 +55,8 @@ struct compiler
     std::unordered_map<std::string, node_function_stmt> fn_templates;
     std::unordered_map<std::string, node_struct_stmt>   struct_templates;
 
-    std::vector<struct_info>  curr_struct_templates;
-    std::vector<template_map> curr_func_templates;
+    std::vector<struct_info> curr_struct;
+    std::vector<func_info>   curr_func;
 };
 
 auto compile(const anzu_module& ast) -> bytecode_program;

--- a/src/compiler.hpp
+++ b/src/compiler.hpp
@@ -50,7 +50,6 @@ struct compiler
     type_manager types;
 
     std::unordered_map<std::string, std::size_t>        functions_by_name;
-    std::vector<std::size_t>                            current_function;
     
     std::unordered_map<std::string, node_function_stmt> fn_templates;
     std::unordered_map<std::string, node_struct_stmt>   struct_templates;

--- a/src/compiler.hpp
+++ b/src/compiler.hpp
@@ -31,6 +31,12 @@ struct function_info
     signature              sig  = {};
 };
 
+struct struct_info
+{
+    type_name    name;
+    template_map templates;
+};
+
 struct compiler
 {
     std::vector<function_info> functions;
@@ -42,8 +48,8 @@ struct compiler
     std::vector<std::size_t>                            current_compiling;
     
     std::unordered_map<std::string, node_function_stmt> fn_templates;
-    std::unordered_map<std::string, node_struct_stmt>  struct_templates;
-    std::optional<template_map>                        struct_template_types;
+    std::unordered_map<std::string, node_struct_stmt>   struct_templates;
+    std::optional<struct_info>                          current_struct;
 };
 
 auto compile(const anzu_module& ast) -> bytecode_program;

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -517,8 +517,7 @@ auto parse_struct_stmt(tokenstream& tokens) -> node_stmt_ptr
         if (tokens.peek(token_type::kw_function)) {
             stmt.functions.emplace_back(parse_function_def_stmt(tokens));
         } else {
-            stmt.fields.emplace_back();
-            auto& f = stmt.fields.back();
+            auto& f = stmt.fields.emplace_back();
             f.name = parse_identifier(tokens);
             tokens.consume_only(token_type::colon);
             f.type = parse_expression(tokens);

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -407,7 +407,7 @@ auto parse_identifier(tokenstream& tokens) -> std::string
 auto parse_function_def_stmt(tokenstream& tokens) -> node_stmt_ptr
 {
     auto node = std::make_shared<node_stmt>();
-    auto& stmt = node->emplace<node_function_def>();
+    auto& stmt = node->emplace<node_function_stmt>();
     stmt.token = tokens.consume_only(token_type::kw_function);
     stmt.struct_name = "";
     stmt.function_name = parse_identifier(tokens);
@@ -439,7 +439,7 @@ auto parse_member_function_def_stmt(const std::string& struct_name, tokenstream&
     -> node_stmt_ptr
 {
     auto node = std::make_shared<node_stmt>();
-    auto& stmt = node->emplace<node_function_def>();
+    auto& stmt = node->emplace<node_function_stmt>();
 
     stmt.token = tokens.consume_only(token_type::kw_function);
     stmt.struct_name = struct_name;

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -409,7 +409,7 @@ auto parse_function_def_stmt(tokenstream& tokens) -> node_stmt_ptr
     auto node = std::make_shared<node_stmt>();
     auto& stmt = node->emplace<node_function_stmt>();
     stmt.token = tokens.consume_only(token_type::kw_function);
-    stmt.function_name = parse_identifier(tokens);
+    stmt.name = parse_identifier(tokens);
 
     if (tokens.consume_maybe(token_type::bang)) {
         tokens.consume_only(token_type::left_paren);


### PR DESCRIPTION
* Refine the implementation of templates.
* The compiler now stores the currently compiling struct as well as function, which the `make_type` function now looks at.
* When compiling a member function, the struct is set so templates get resolved properly. It might be able to make it more simple by removing the type manager and just having the maps in the compiler, but I've not bothered.
* Parsing member functions now uses the same function as parsing regular functions since the node doesn't need to store the struct name anymore (as it just gets fetched from the compiler).
* Moved the `__dump_type` hack. It is now a special invocation of the print statement, spelled `print("__dump_type", <objects>)`. This means the call expression never needs to inspect the node type of its expression, and also removes all runtime overhead; in the previous implementation, it was an expression, so has to result in a value on the stack, which was null. Now that doesn't need to happen since print is a statement.
* Moved the member function first arg check into `compile_function`, which removes duplicated code.