### PR TITLE
Reimplement For Loops

### DIFF
--- a/examples/aoc2015-1.az
+++ b/examples/aoc2015-1.az
@@ -2,14 +2,12 @@ var data := "()()(()()()(()()((()((()))((()((((()()((((()))()((((())(((((((()(((
 
 var count := 0;
 for c in data {
-    print("__dump_type", c);
-    print("{}\n", __idx);
     if c@ == '(' {
-        #count = count + 1;
+        count = count + 1;
     }
-    #else if c@ == ')' {
-    #    count = count - 1;
-    #}
+    else if c@ == ')' {
+        count = count - 1;
+    }
 }
 
-#print("{}", count);
+print("{}", count);

--- a/examples/aoc2015-1.az
+++ b/examples/aoc2015-1.az
@@ -2,12 +2,14 @@ var data := "()()(()()()(()()((()((()))((()((((()()((((()))()((((())(((((((()(((
 
 var count := 0;
 for c in data {
+    print("__dump_type", c);
+    print("{}\n", __idx);
     if c@ == '(' {
-        count = count + 1;
+        #count = count + 1;
     }
-    else if c@ == ')' {
-        count = count - 1;
-    }
+    #else if c@ == ')' {
+    #    count = count - 1;
+    #}
 }
 
-print("{}", count);
+#print("{}", count);

--- a/examples/feature_test.az
+++ b/examples/feature_test.az
@@ -201,12 +201,8 @@ struct vec3
 # for loops
 # rvalue
 {
-    for v in [vec2(1, 2), vec2(3, 4), vec2(5, 6)] {
-        print("({}, {})\n", v.x, v.y);
-    }
-
     var arr := [vec2(1, 2), vec2(3, 4), vec2(5, 6)];
-    for v in arr {
+    for v in arr[] {
         print("({}, {})\n", v.x, v.y);
     }
 }

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,4 +1,6 @@
-var a := [1, 2, 3, 4];
-var s := a const[];
-var b := 6 const;
-print("__dump_type", s, b);
+
+
+
+let c := "c";
+var p := c&;
+print("{}\n", p@);

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,0 +1,4 @@
+var a := [1, 2, 3, 4];
+var s := a const[];
+var b := 6 const;
+print("__dump_type", s, b);

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,6 +1,4 @@
 
-
-
-let c := "c";
-var p := c&;
-print("{}\n", p@);
+for c in "hello world" {
+    print("{}\n", c@);
+}

--- a/examples/vector.az
+++ b/examples/vector.az
@@ -73,8 +73,7 @@ while idx < 20 {
     idx = idx + 1;
 }
 
-let range := v.to_span();
-for a in range {
+for a in v.to_span() {
     print("{}\n", a@);
 }
 print("{} {} {}\n", v.capacity(), v.size(), a.size());

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -1155,7 +1155,7 @@ void push_stmt(compiler& com, const node_for_stmt& node)
 
     // var idx := 0u;
     push_value(code(com), op::push_u64, std::uint64_t{0});
-    declare_var(com, node.token, "__idx", u64_type());
+    declare_var(com, node.token, "$idx", u64_type());
 
     // var size := length of iter;
     push_var_addr(com, node.token, "$iter"); // push pointer to span
@@ -1166,7 +1166,7 @@ void push_stmt(compiler& com, const node_for_stmt& node)
 
     push_loop(com, [&] {
         // if idx == size break;
-        load_variable(com, node.token, "__idx");
+        load_variable(com, node.token, "$idx");
         load_variable(com, node.token, "$size");
         push_value(code(com), op::u64_eq, op::jump_if_false);
         const auto jump_pos = push_value(code(com), std::uint64_t{0});
@@ -1177,16 +1177,15 @@ void push_stmt(compiler& com, const node_for_stmt& node)
         const auto inner = inner_type(iter_type);
         push_var_addr(com, node.token, "$iter");
         push_value(code(com), op::load, sizeof(std::byte*));  
-        load_variable(com, node.token, "__idx");
+        load_variable(com, node.token, "$idx");
         push_value(code(com), op::push_u64, com.types.size_of(inner));
-        push_value(code(com), op::u64_mul);
-        push_value(code(com), op::u64_add);
+        push_value(code(com), op::u64_mul, op::u64_add);
         declare_var(com, node.token, node.name, inner.add_ptr());
 
         // idx = idx + 1;
-        load_variable(com, node.token, "__idx");
+        load_variable(com, node.token, "$idx");
         push_value(code(com), op::push_u64, std::uint64_t{1}, op::u64_add);
-        save_variable(com, node.token, "__idx");
+        save_variable(com, node.token, "$idx");
 
         // main body
         push_stmt(com, *node.body);

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -1050,7 +1050,7 @@ auto push_expr(compiler& com, compile_type ct, const node_deref_expr& node) -> t
     const auto type = push_expr(com, compile_type::val, *node.expr); // Push the address
     node.token.assert(type.is_ptr(), "cannot use deref operator on non-ptr type '{}'", type);
     if (ct == compile_type::val) {
-        push_value(code(com), op::load, com.types.size_of(type));
+        push_value(code(com), op::load, com.types.size_of(type.remove_ptr()));
     }
     return type.remove_ptr();
 }

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -1151,56 +1151,42 @@ void push_stmt(compiler& com, const node_for_stmt& node)
 
     const auto iter_type = push_expr(com, compile_type::val, *node.iter);
     node.token.assert(iter_type.is_span(), "can only iterate spans, got {}", iter_type);
-    declare_var(com, node.token, "#:iter", iter_type);
+    declare_var(com, node.token, "$iter", iter_type);
 
-    // idx := 0u;
+    // var idx := 0u;
     push_value(code(com), op::push_u64, std::uint64_t{0});
-    declare_var(com, node.token, "#:idx", u64_type());
+    declare_var(com, node.token, "__idx", u64_type());
 
-    // size := length of iter;
-    if (iter_type.is_array()) {
-        push_value(code(com), op::push_u64, array_length(iter_type));
-        declare_var(com, node.token, "#:size", u64_type());
-    } else {
-        node.token.assert(is_lvalue_expr(*node.iter), "for-loops only supported for lvalue spans");
-        push_expr(com, compile_type::ptr, *node.iter); // push pointer to span
-        push_value(code(com), op::push_u64, sizeof(std::byte*));
-        push_value(code(com), op::u64_add); // offset to the size value
-        push_value(code(com), op::load, com.types.size_of(u64_type()));       
-        declare_var(com, node.token, "#:size", u64_type());
-    }
+    // var size := length of iter;
+    push_var_addr(com, node.token, "$iter"); // push pointer to span
+    push_value(code(com), op::push_u64, sizeof(std::byte*));
+    push_value(code(com), op::u64_add); // offset to the size value
+    push_value(code(com), op::load, com.types.size_of(u64_type()));       
+    declare_var(com, node.token, "$size", u64_type());
 
     push_loop(com, [&] {
         // if idx == size break;
-        load_variable(com, node.token, "#:idx");
-        load_variable(com, node.token, "#:size");
-        push_value(code(com), op::u64_eq);
-        push_value(code(com), op::jump_if_false);
+        load_variable(com, node.token, "__idx");
+        load_variable(com, node.token, "$size");
+        push_value(code(com), op::u64_eq, op::jump_if_false);
         const auto jump_pos = push_value(code(com), std::uint64_t{0});
         push_break(com, node.token);
         write_value(code(com), jump_pos, code(com).size());
 
-        // name := iter[idx]~;
-        const auto iter_type = type_of_expr(com, *node.iter);
+        // var name := iter[idx]&;
         const auto inner = inner_type(iter_type);
-        if (is_rvalue_expr(*node.iter)) {
-            push_var_addr(com, node.token, "#:iter");
-        } else {
-            push_expr(com, compile_type::ptr, *node.iter);
-            if (iter_type.is_span()) {
-                push_value(code(com), op::load, sizeof(std::byte*));
-            }
-        }
-        load_variable(com, node.token, "#:idx");
+        push_var_addr(com, node.token, "$iter");
+        push_value(code(com), op::load, sizeof(std::byte*));  
+        load_variable(com, node.token, "__idx");
         push_value(code(com), op::push_u64, com.types.size_of(inner));
         push_value(code(com), op::u64_mul);
         push_value(code(com), op::u64_add);
         declare_var(com, node.token, node.name, inner.add_ptr());
 
         // idx = idx + 1;
-        load_variable(com, node.token, "#:idx");
+        load_variable(com, node.token, "__idx");
         push_value(code(com), op::push_u64, std::uint64_t{1}, op::u64_add);
-        save_variable(com, node.token, "#:idx");
+        save_variable(com, node.token, "__idx");
 
         // main body
         push_stmt(com, *node.body);


### PR DESCRIPTION
* For loops now only operate on spans. Reason being; I disliked how the implementation was different depending on the arg being an lvalue or an rvalue (though I may bring this back in the future), because the impl to decide that was really bad and likely incorrect. Now, the container arg is always copied, which for arrays is likely always an error as it could be a huge copy, so is always disallowed.
* Made is possible to append `const` to a variable name, similarly to `&`. Only really useful for pointers and spans, but in particular for loops when you dont want to modify the underlying data. eg, if `x` is a `i64`, then `x const&` is a `i64 const&`, making it easy to explicitly create a pointer to const. To loop an array `arr` and make it read only, use `for x in arr const[] { ... }`.
* Fixed a bug in `node_deref_expr` where it would only correctly work if the type was the size of a pointer, went unnoticed for a while since I was always using `i64` as examples.