### PR TITLE
Templates QOL

### DIFF
--- a/examples/vector.az
+++ b/examples/vector.az
@@ -5,12 +5,12 @@ struct vector!(T)
     _data: T[];
     _size: u64;
 
-    fn to_span(self: vector!(T)&) -> T const[]
+    fn to_span(self: &) -> T const[]
     {
         return self._data[0u : self._size];
     }
 
-    fn reserve(self: vector!(T)&, size: u64) -> null
+    fn reserve(self: &, size: u64) -> null
     {
         let cap := self.capacity();
         if cap < size {
@@ -28,22 +28,22 @@ struct vector!(T)
         }
     }
 
-    fn capacity(self: vector!(T) const&) -> u64
+    fn capacity(self: const&) -> u64
     {
         return self._data.size();
     }
 
-    fn size(self: vector!(T) const&) -> u64
+    fn size(self: const&) -> u64
     {
         return self._size;
     }
 
-    fn at(self: vector!(T) const&, index: u64) -> T
+    fn at(self: const&, index: u64) -> T
     {
         return self._data[index];
     }
 
-    fn push(self: vector!(T)&, value: T) -> null
+    fn push(self: &, value: T) -> null
     {
         let cap := self.capacity();
         if self._size == cap {

--- a/examples/vector.az
+++ b/examples/vector.az
@@ -28,7 +28,7 @@ struct vector!(T)
         }
     }
 
-    fn capacity(self: const&) -> u64
+    fn capacity(self: &) -> u64
     {
         return self._data.size();
     }

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -774,6 +774,10 @@ auto push_expr(compiler& com, compile_type ct, const node_repeat_array_expr& nod
 auto push_expr(compiler& com, compile_type ct, const node_addrof_expr& node) -> type_name
 {
     node.token.assert(ct == compile_type::val, "cannot take the address of an addrof expression");
+    if (!node.expr) {
+        node.token.assert(com.current_struct.back().name != global_namespace, "TODO: add message");
+        return type_type{com.current_struct.back().name.add_ptr()};
+    }
     const auto type = type_of_expr(com, *node.expr);
     if (type.is_type_value()) {
         return type_type{inner_type(type).add_ptr()};
@@ -878,6 +882,10 @@ auto push_expr(compiler& com, compile_type ct, const node_function_ptr_type_expr
 
 auto push_expr(compiler& com, compile_type ct, const node_const_expr& node) -> type_name
 {
+    if (!node.expr) {
+        node.token.assert(com.current_struct.back().name != global_namespace, "TODO: add message");
+        return type_type{com.current_struct.back().name.add_const()};
+    }
     const auto type = type_of_expr(com, *node.expr);
     if (type.is_type_value()) {
         node.token.assert(ct == compile_type::val, "cannot take the address of a const type-expression");

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -924,7 +924,9 @@ auto push_expr(compiler& com, compile_type ct, const node_name_expr& node) -> ty
     if (com.function_templates.contains(full_name_no_templates) && !get_function(com, full_name)) {
         const auto& ast = com.function_templates.at(full_name_no_templates);
         const auto map = build_template_map(com, node.token, ast.templates, node.templates);
+        com.current_struct.emplace_back(global_namespace, template_map{});
         compile_function(com, node.token, full_name, ast.sig, ast.body, map);
+        com.current_struct.pop_back();
     }
 
     // Next, it might be a template type

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -310,10 +310,7 @@ auto parse_const(tokenstream& tokens, const node_expr_ptr& left) -> node_expr_pt
 
 auto parse_const_pre(tokenstream& tokens) -> node_expr_ptr
 {
-    const auto token = tokens.consume_only(token_type::kw_const);
-    auto [node, inner] = new_node<node_const_expr>(token);
-    inner.expr = nullptr;
-    return node;
+    return parse_const(tokens, nullptr);
 }
 
 auto parse_at(tokenstream& tokens, const node_expr_ptr& left) -> node_expr_ptr
@@ -334,10 +331,7 @@ auto parse_ampersand(tokenstream& tokens, const node_expr_ptr& left) -> node_exp
 
 auto parse_ampersand_pre(tokenstream& tokens) -> node_expr_ptr
 {
-    const auto token = tokens.consume_only(token_type::ampersand);
-    auto [node, inner] = new_node<node_addrof_expr>(token);
-    inner.expr = nullptr;
-    return node;
+    return parse_ampersand(tokens, nullptr);
 }
 
 auto parse_precedence(tokenstream& tokens, precedence prec) -> node_expr_ptr
@@ -355,50 +349,50 @@ auto parse_precedence(tokenstream& tokens, precedence prec) -> node_expr_ptr
 
 static const auto rules = std::unordered_map<token_type, parse_rule>
 {
-    {token_type::left_paren,          {parse_grouping, parse_call,      precedence::call}},
-    {token_type::bang,                {parse_unary,    parse_call,      precedence::call}},
-    {token_type::minus,               {parse_unary,    parse_binary,    precedence::term}},
-    {token_type::plus,                {nullptr,        parse_binary,    precedence::term}},
-    {token_type::slash,               {nullptr,        parse_binary,    precedence::factor}},
-    {token_type::star,                {nullptr,        parse_binary,    precedence::factor}},
-    {token_type::percent,             {nullptr,        parse_binary,    precedence::factor}},
-    {token_type::int32,               {parse_i32,      nullptr,         precedence::none}},
-    {token_type::int64,               {parse_i64,      nullptr,         precedence::none}},
-    {token_type::uint64,              {parse_u64,      nullptr,         precedence::none}},
-    {token_type::float64,             {parse_f64,      nullptr,         precedence::none}},
-    {token_type::character,           {parse_char,     nullptr,         precedence::none}},
-    {token_type::kw_true,             {parse_true,     nullptr,         precedence::none}},
-    {token_type::kw_false,            {parse_false,    nullptr,         precedence::none}},
-    {token_type::kw_null,             {parse_null,     nullptr,         precedence::none}},
-    {token_type::kw_nullptr,          {parse_nullptr,  nullptr,         precedence::none}},
-    {token_type::string,              {parse_string,   nullptr,         precedence::none}},
-    {token_type::equal_equal,         {nullptr,        parse_binary,    precedence::equality}},
-    {token_type::bang_equal,          {nullptr,        parse_binary,    precedence::equality}},
-    {token_type::less,                {nullptr,        parse_binary,    precedence::comparison}},
-    {token_type::less_equal,          {nullptr,        parse_binary,    precedence::comparison}},
-    {token_type::greater,             {nullptr,        parse_binary,    precedence::comparison}},
-    {token_type::greater_equal,       {nullptr,        parse_binary,    precedence::comparison}},
-    {token_type::ampersand_ampersand, {nullptr,        parse_binary,    precedence::logical_and}},
-    {token_type::bar_bar,             {nullptr,        parse_binary,    precedence::logical_or}},
-    {token_type::identifier,          {parse_name,     nullptr,         precedence::none}},
-    {token_type::kw_i32,              {parse_name,     nullptr,         precedence::none}},
-    {token_type::kw_i64,              {parse_name,     nullptr,         precedence::none}},
-    {token_type::kw_f64,              {parse_name,     nullptr,         precedence::none}},
-    {token_type::kw_u64,              {parse_name,     nullptr,         precedence::none}},
-    {token_type::kw_char,             {parse_name,     nullptr,         precedence::none}},
-    {token_type::kw_bool,             {parse_name,     nullptr,         precedence::none}},
-    {token_type::kw_null,             {parse_name,     nullptr,         precedence::none}},
-    {token_type::kw_nullptr,          {parse_name,     nullptr,         precedence::none}},
-    {token_type::kw_arena,            {parse_name,     nullptr,         precedence::none}},
-    {token_type::kw_typeof,           {parse_typeof,   nullptr,         precedence::none}},
-    {token_type::kw_sizeof,           {parse_sizeof,   nullptr,         precedence::none}},
-    {token_type::left_bracket,        {parse_array,    parse_subscript, precedence::call}},
-    {token_type::dot,                 {nullptr,        parse_dot,       precedence::call}},
-    {token_type::kw_const,            {parse_const_pre, parse_const,     precedence::call}},
-    {token_type::at,                  {nullptr,        parse_at,        precedence::call}},
+    {token_type::left_paren,          {parse_grouping,      parse_call,      precedence::call}},
+    {token_type::bang,                {parse_unary,         parse_call,      precedence::call}},
+    {token_type::minus,               {parse_unary,         parse_binary,    precedence::term}},
+    {token_type::plus,                {nullptr,             parse_binary,    precedence::term}},
+    {token_type::slash,               {nullptr,             parse_binary,    precedence::factor}},
+    {token_type::star,                {nullptr,             parse_binary,    precedence::factor}},
+    {token_type::percent,             {nullptr,             parse_binary,    precedence::factor}},
+    {token_type::int32,               {parse_i32,           nullptr,         precedence::none}},
+    {token_type::int64,               {parse_i64,           nullptr,         precedence::none}},
+    {token_type::uint64,              {parse_u64,           nullptr,         precedence::none}},
+    {token_type::float64,             {parse_f64,           nullptr,         precedence::none}},
+    {token_type::character,           {parse_char,          nullptr,         precedence::none}},
+    {token_type::kw_true,             {parse_true,          nullptr,         precedence::none}},
+    {token_type::kw_false,            {parse_false,         nullptr,         precedence::none}},
+    {token_type::kw_null,             {parse_null,          nullptr,         precedence::none}},
+    {token_type::kw_nullptr,          {parse_nullptr,       nullptr,         precedence::none}},
+    {token_type::string,              {parse_string,        nullptr,         precedence::none}},
+    {token_type::equal_equal,         {nullptr,             parse_binary,    precedence::equality}},
+    {token_type::bang_equal,          {nullptr,             parse_binary,    precedence::equality}},
+    {token_type::less,                {nullptr,             parse_binary,    precedence::comparison}},
+    {token_type::less_equal,          {nullptr,             parse_binary,    precedence::comparison}},
+    {token_type::greater,             {nullptr,             parse_binary,    precedence::comparison}},
+    {token_type::greater_equal,       {nullptr,             parse_binary,    precedence::comparison}},
+    {token_type::ampersand_ampersand, {nullptr,             parse_binary,    precedence::logical_and}},
+    {token_type::bar_bar,             {nullptr,             parse_binary,    precedence::logical_or}},
+    {token_type::identifier,          {parse_name,          nullptr,         precedence::none}},
+    {token_type::kw_i32,              {parse_name,          nullptr,         precedence::none}},
+    {token_type::kw_i64,              {parse_name,          nullptr,         precedence::none}},
+    {token_type::kw_f64,              {parse_name,          nullptr,         precedence::none}},
+    {token_type::kw_u64,              {parse_name,          nullptr,         precedence::none}},
+    {token_type::kw_char,             {parse_name,          nullptr,         precedence::none}},
+    {token_type::kw_bool,             {parse_name,          nullptr,         precedence::none}},
+    {token_type::kw_null,             {parse_name,          nullptr,         precedence::none}},
+    {token_type::kw_nullptr,          {parse_name,          nullptr,         precedence::none}},
+    {token_type::kw_arena,            {parse_name,          nullptr,         precedence::none}},
+    {token_type::kw_typeof,           {parse_typeof,        nullptr,         precedence::none}},
+    {token_type::kw_sizeof,           {parse_sizeof,        nullptr,         precedence::none}},
+    {token_type::left_bracket,        {parse_array,         parse_subscript, precedence::call}},
+    {token_type::dot,                 {nullptr,             parse_dot,       precedence::call}},
+    {token_type::kw_const,            {parse_const_pre,     parse_const,     precedence::call}},
+    {token_type::at,                  {nullptr,             parse_at,        precedence::call}},
     {token_type::ampersand,           {parse_ampersand_pre, parse_ampersand, precedence::call}},
-    {token_type::kw_function,         {parse_func_ptr, nullptr,         precedence::none}},
-    {token_type::kw_new,              {parse_new,      nullptr,         precedence::none}}
+    {token_type::kw_function,         {parse_func_ptr,      nullptr,         precedence::none}},
+    {token_type::kw_new,              {parse_new,           nullptr,         precedence::none}}
 };
 
 auto get_rule(token_type tt) -> const parse_rule*

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -308,6 +308,14 @@ auto parse_const(tokenstream& tokens, const node_expr_ptr& left) -> node_expr_pt
     return node;
 }
 
+auto parse_const_pre(tokenstream& tokens) -> node_expr_ptr
+{
+    const auto token = tokens.consume_only(token_type::kw_const);
+    auto [node, inner] = new_node<node_const_expr>(token);
+    inner.expr = nullptr;
+    return node;
+}
+
 auto parse_at(tokenstream& tokens, const node_expr_ptr& left) -> node_expr_ptr
 {
     const auto token = tokens.consume_only(token_type::at);
@@ -321,6 +329,14 @@ auto parse_ampersand(tokenstream& tokens, const node_expr_ptr& left) -> node_exp
     const auto token = tokens.consume_only(token_type::ampersand);
     auto [node, inner] = new_node<node_addrof_expr>(token);
     inner.expr = left;
+    return node;
+}
+
+auto parse_ampersand_pre(tokenstream& tokens) -> node_expr_ptr
+{
+    const auto token = tokens.consume_only(token_type::ampersand);
+    auto [node, inner] = new_node<node_addrof_expr>(token);
+    inner.expr = nullptr;
     return node;
 }
 
@@ -378,9 +394,9 @@ static const auto rules = std::unordered_map<token_type, parse_rule>
     {token_type::kw_sizeof,           {parse_sizeof,   nullptr,         precedence::none}},
     {token_type::left_bracket,        {parse_array,    parse_subscript, precedence::call}},
     {token_type::dot,                 {nullptr,        parse_dot,       precedence::call}},
-    {token_type::kw_const,            {nullptr,        parse_const,     precedence::call}},
+    {token_type::kw_const,            {parse_const_pre, parse_const,     precedence::call}},
     {token_type::at,                  {nullptr,        parse_at,        precedence::call}},
-    {token_type::ampersand,           {nullptr,        parse_ampersand, precedence::call}},
+    {token_type::ampersand,           {parse_ampersand_pre, parse_ampersand, precedence::call}},
     {token_type::kw_function,         {parse_func_ptr, nullptr,         precedence::none}},
     {token_type::kw_new,              {parse_new,      nullptr,         precedence::none}}
 };


### PR DESCRIPTION
* Fix a bug when calling a template free function from a template member function would result in the template type not being found. This is fixed by pushing the global namespace as the struct type when compiling a free function.
* It is no longer necessary to spell the type name out when writing a member function. Simply writing `&` or `const&` will do. This could be expanded further to allow for `[]` and `N` to mean a span or array of the given type, or empty to mean a value, but I'll do that when I need to.