### PR TITLE
Ternary and Realloc

### DIFF
--- a/examples/test.az
+++ b/examples/test.az
@@ -1,4 +1,2 @@
 
-for c in "hello world" {
-    print("{}\n", c@);
-}
+let x := true ? "hello" : "world";

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,2 +1,3 @@
 
-let x := true ? "hello" : "world";
+let x := 2 + 2 == 4 ? "hello" : "world";
+print("{}\n", x);

--- a/examples/vector.az
+++ b/examples/vector.az
@@ -51,7 +51,6 @@ fn new_vector!(T)(arr: arena&) -> vector!(T)
 
 arena a;
 var v := new_vector!(i64)(a&);
-v.reserve(25u);
 var idx := 0;
 while idx < 20 {
     v.push(idx);

--- a/examples/vector.az
+++ b/examples/vector.az
@@ -12,9 +12,8 @@ struct vector!(T)
 
     fn reserve(self: &, size: u64) -> null
     {
-        if size > self.capacity() {
-            self._data = new(self._arr, size, self._data) T();
-        }
+        assert(size > self.capacity());
+        self._data = new(self._arr, size, self._data) T();
     }
 
     fn capacity(self: &) -> u64

--- a/examples/vector.az
+++ b/examples/vector.az
@@ -14,17 +14,7 @@ struct vector!(T)
     {
         let cap := self.capacity();
         if cap < size {
-            var new_buf := new(self._arr, size) T();
-            
-            # Copy existing values over
-            {
-                var idx := 0u;
-                while idx < self._size {
-                    new_buf[idx] = self._data[idx];
-                    idx = idx + 1u;
-                }
-            }
-            self._data = new_buf;
+            self._data := new(self._arr, size, self._data) T();
         }
     }
 

--- a/examples/vector.az
+++ b/examples/vector.az
@@ -12,9 +12,8 @@ struct vector!(T)
 
     fn reserve(self: &, size: u64) -> null
     {
-        let cap := self.capacity();
-        if cap < size {
-            self._data := new(self._arr, size, self._data) T();
+        if size > self.capacity() {
+            self._data = new(self._arr, size, self._data) T();
         }
     }
 

--- a/examples/vector.az
+++ b/examples/vector.az
@@ -35,10 +35,7 @@ struct vector!(T)
     {
         let cap := self.capacity();
         if self._size == cap {
-            var new_cap := 8u;
-            if cap > 0u {
-                new_cap = cap * 2u;
-            }
+            let new_cap := cap > 0u ? cap * 2u : 8u;
             self.reserve(new_cap);
         }
         self._data[self._size] = value;

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -145,6 +145,10 @@ auto print_node(const node_expr& root, int indent) -> void
             print_node(*node.arena);
             std::print("{}- Count:\n", spaces);
             print_node(*node.count);
+            if (node.original) {
+                std::print("{}- Original:\n", spaces);
+                print_node(*node.expr);
+            }
             std::print("{}- Expr:\n", spaces);
             print_node(*node.expr);
         }

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -142,15 +142,24 @@ auto print_node(const node_expr& root, int indent) -> void
         [&](const node_new_expr& node) {
             std::print("{}New:\n", spaces);
             std::print("{}- Arena:\n", spaces);
-            print_node(*node.arena);
+            print_node(*node.arena, indent + 1);
             std::print("{}- Count:\n", spaces);
-            print_node(*node.count);
+            print_node(*node.count, indent + 1);
             if (node.original) {
                 std::print("{}- Original:\n", spaces);
-                print_node(*node.expr);
+                print_node(*node.expr, indent + 1);
             }
             std::print("{}- Expr:\n", spaces);
-            print_node(*node.expr);
+            print_node(*node.expr, indent + 1);
+        },
+        [&](const node_ternary_expr& node) {
+            std::print("{}Ternary:\n", spaces);
+            std::print("{}- Condition:\n", spaces);
+            print_node(*node.condition, indent + 1);
+            std::print("{}- TrueCase:\n", spaces);
+            print_node(*node.true_case, indent + 1);
+            std::print("{}- FalseCase:\n", spaces);
+            print_node(*node.false_case, indent + 1);
         }
     }, root);
 }

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -186,6 +186,7 @@ struct node_new_expr
 {
     node_expr_ptr arena;
     node_expr_ptr count;
+    node_expr_ptr original;
     node_expr_ptr expr;
 
     anzu::token   token;

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -192,6 +192,15 @@ struct node_new_expr
     anzu::token   token;
 };
 
+struct node_ternary_expr
+{
+    node_expr_ptr condition;
+    node_expr_ptr true_case;
+    node_expr_ptr false_case;
+
+    anzu::token   token;
+};
+
 struct node_expr : std::variant<
     node_literal_i32_expr,
     node_literal_i64_expr,
@@ -217,7 +226,8 @@ struct node_expr : std::variant<
     node_field_expr,
     node_deref_expr,
     node_subscript_expr,
-    node_new_expr>
+    node_new_expr,
+    node_ternary_expr>
 {
 };
 

--- a/src/bytecode.cpp
+++ b/src/bytecode.cpp
@@ -77,19 +77,22 @@ auto print_op(std::string_view rom, const std::byte* start, const std::byte* ptr
             std::print("PUSH_FUNCTION_PTR: id={}\n", id);
         } break;
         case op::arena_new: {
-            std::print("NEW_ARENA\n");
+            std::print("ARENA_NEW\n");
         } break;
         case op::arena_delete: {
-            std::print("DELETE_ARENA\n");
+            std::print("ARENA_DELETE\n");
         } break;
         case op::arena_alloc: {
             const auto size = read_at<std::uint64_t>(&ptr);
-            std::print("ALLOCATE: size={}\n", size);
+            std::print("ARENA_ALLOC: size={}\n", size);
         } break;
         case op::arena_alloc_array: {
             const auto size = read_at<std::uint64_t>(&ptr);
-            const auto count = read_at<std::uint64_t>(&ptr);
-            std::print("ALLOCATE: size={} count={}\n", size, count);
+            std::print("ARENA_ALLOC_ARRAY: size={}\n", size);
+        } break;
+        case op::arena_realloc_array: {
+            const auto size = read_at<std::uint64_t>(&ptr);
+            std::print("ARENA_REALLOC_ARRAY: size={}\n", size);
         } break;
         case op::arena_size: {
             std::print("ARENA_SIZE\n");

--- a/src/bytecode.hpp
+++ b/src/bytecode.hpp
@@ -43,6 +43,7 @@ enum class op : std::uint8_t
     arena_delete,
     arena_alloc,
     arena_alloc_array,
+    arena_realloc_array,
     arena_size,
     
     load,

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -1117,6 +1117,11 @@ auto push_expr(compiler& com, compile_type ct, const node_subscript_expr& node) 
     return t;
 }
 
+auto push_expr(compiler& com, compile_type ct, const node_ternary_expr& node) -> type_name
+{
+    return null_type();
+}
+
 
 void push_stmt(compiler& com, const node_sequence_stmt& node)
 {

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -670,9 +670,6 @@ auto push_expr(compiler& com, compile_type ct, const node_call_expr& node) -> ty
         for (std::size_t i = 0; i != node.args.size(); ++i) {
             push_copy_typechecked(com, *node.args.at(i), expected_params[i], node.token);
         }
-        if (node.args.size() == 0) { // if the class has no data, it needs to be size 1
-            push_value(code(com), op::push_null);
-        }
         return obj_type;
     }
     else if (type.is_function_ptr()) { // function call

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -1130,16 +1130,12 @@ auto push_expr(compiler& com, compile_type ct, const node_ternary_expr& node) ->
     push_value(code(com), op::jump_if_false);
     const auto jump_pos = push_value(code(com), std::uint64_t{0});
     push_expr(com, ct, *node.true_case);
-
-    if (node.false_case) {
-        push_value(code(com), op::jump);
-        const auto else_pos = push_value(code(com), std::uint64_t{0});
-        const auto in_else_pos = code(com).size();
-        push_expr(com, ct, *node.false_case);
-        write_value(code(com), jump_pos, in_else_pos); // Jump into the else block if false
-        write_value(code(com), else_pos, code(com).size()); // Jump past the end if false
-    }
-
+    push_value(code(com), op::jump);
+    const auto else_pos = push_value(code(com), std::uint64_t{0});
+    const auto in_else_pos = code(com).size();
+    push_expr(com, ct, *node.false_case);
+    write_value(code(com), jump_pos, in_else_pos); // Jump into the else block if false
+    write_value(code(com), else_pos, code(com).size()); // Jump past the end if false
     return type;
 }
 

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -228,6 +228,7 @@ auto lexer::get_token() -> token
         case ';': return make_token(token_type::semicolon);
         case ',': return make_token(token_type::comma);
         case '.': return make_token(token_type::dot);
+        case '?': return make_token(token_type::question);
         case '-': return make_token(
             match(">") ? token_type::arrow : token_type::minus);
         case '+': return make_token(token_type::plus);

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -225,6 +225,9 @@ auto parse_new(tokenstream& tokens) -> node_expr_ptr
     if (tokens.consume_maybe(token_type::comma)) {
         inner.count = parse_expression(tokens);
     }
+    if (tokens.consume_maybe(token_type::comma)) {
+        inner.original = parse_expression(tokens);
+    }
     tokens.consume_only(token_type::right_paren);
     inner.expr = parse_expression(tokens);
     return node;

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -16,6 +16,7 @@ auto parse_expression(tokenstream& tokens) -> node_expr_ptr;
 
 enum class precedence {
   none,
+  ternary,     // ?:
   logical_or,  // or
   logical_and, // and
   equality,    // == !=

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -338,6 +338,17 @@ auto parse_ampersand_pre(tokenstream& tokens) -> node_expr_ptr
     return parse_ampersand(tokens, nullptr);
 }
 
+auto parse_ternary(tokenstream& tokens, const node_expr_ptr& left) -> node_expr_ptr
+{
+    const auto token = tokens.consume_only(token_type::question);
+    auto [node, inner] = new_node<node_ternary_expr>(token);
+    inner.condition = left;
+    inner.true_case = parse_expression(tokens);
+    tokens.consume_only(token_type::colon);
+    inner.false_case = parse_expression(tokens);
+    return node;
+}
+
 auto parse_precedence(tokenstream& tokens, precedence prec) -> node_expr_ptr
 {
     const auto token = tokens.curr();
@@ -396,7 +407,8 @@ static const auto rules = std::unordered_map<token_type, parse_rule>
     {token_type::at,                  {nullptr,             parse_at,        precedence::call}},
     {token_type::ampersand,           {parse_ampersand_pre, parse_ampersand, precedence::call}},
     {token_type::kw_function,         {parse_func_ptr,      nullptr,         precedence::none}},
-    {token_type::kw_new,              {parse_new,           nullptr,         precedence::none}}
+    {token_type::kw_new,              {parse_new,           nullptr,         precedence::none}},
+    {token_type::question,            {nullptr,             parse_ternary,   precedence::ternary}}
 };
 
 auto get_rule(token_type tt) -> const parse_rule*
@@ -408,7 +420,7 @@ auto get_rule(token_type tt) -> const parse_rule*
 
 auto parse_expression(tokenstream& tokens) -> node_expr_ptr
 {
-    return parse_precedence(tokens, precedence::logical_or);
+    return parse_precedence(tokens, precedence::ternary);
 }
 
 auto parse_statement(tokenstream& tokens) -> node_stmt_ptr;

--- a/src/token.cpp
+++ b/src/token.cpp
@@ -80,7 +80,8 @@ auto to_string(token_type tt) -> std::string_view
         case token_type::less:                return "<";        
         case token_type::minus:               return "-";        
         case token_type::percent:             return "%";        
-        case token_type::plus:                return "+";        
+        case token_type::plus:                return "+";
+        case token_type::question:            return "?";      
         case token_type::right_brace:         return "}";        
         case token_type::right_bracket:       return "]";        
         case token_type::right_paren:         return ")";        

--- a/src/token.hpp
+++ b/src/token.hpp
@@ -69,6 +69,7 @@ enum class token_type
     minus,
     percent,
     plus,
+    question,
     right_brace,
     right_bracket,
     right_paren,


### PR DESCRIPTION
* Added the C ternary operator with the same syntax and operator precedence.
* Added another form of the new expression that takes a third argument which must be an existing span. The newly allocated span must be larger than it, and it copies the value of the span over, using the expr to fill in the remaining elements. The `new` expression is a bit of a mess now, a nicer syntax should be created.
* Both make implementing vector simpler, so it will help with maps too.
* I don't quite like the "realloc" use of new; the old array is still perfectly fine in memory given how arenas work, so really it is just an allocate + copy, so maybe a copy operation would be more appropriate to have. On the flip side, it would be easy to add an optimisation to see if the array to realloc was the last allocated object in the arena. If it is, the size could just be increased without needing to copy anything, which would be much faster. You could have an arena dedicated to a single vector, though arguably you would just reserve a big chunk up front for a vector if you knew that was going to be an issue.