### PR TITLE
Static Methods

### DIFF
--- a/examples/tokenizer.az
+++ b/examples/tokenizer.az
@@ -47,8 +47,7 @@ struct tokenizer
 let input := "my test string has six words";
 
 var tok := tokenizer.create(input, ' ');
-let x := tokenizer.current;
 while tok.valid() {
-    print("{}\n", x(tok&));
+    print("{}\n", tok.current());
     tok.advance();
 }

--- a/examples/tokenizer.az
+++ b/examples/tokenizer.az
@@ -34,19 +34,21 @@ struct tokenizer
     {
         return self._string[self._start : self._curr];
     }
+
+    fn create(input: char const[], delim: char) -> tokenizer
+    {
+        var t := tokenizer(input, delim, 0u, 0u);
+        t.advance(); # prime the tokenizer at the first word
+        return t;
+    }
 }
 
-fn new_tokenizer(input: char const[], delim: char) -> tokenizer
-{
-    var t := tokenizer(input, delim, 0u, 0u);
-    t.advance(); # prime the tokenizer at the first word
-    return t;
-}
 
 let input := "my test string has six words";
 
-var tok := new_tokenizer(input, ' ');
+var tok := tokenizer.create(input, ' ');
+let x := tokenizer.current;
 while tok.valid() {
-    print("{}\n", tok.current());
+    print("{}\n", x(tok&));
     tok.advance();
 }

--- a/examples/vector.az
+++ b/examples/vector.az
@@ -41,16 +41,17 @@ struct vector!(T)
         self._data[self._size] = value;
         self._size = self._size + 1u;
     }
+
+    fn create(arr: arena&) -> vector!(T)
+    {
+        return vector!(T)(arr, nullptr, 0u);
+    }
 }
 
-fn new_vector!(T)(arr: arena&) -> vector!(T)
-{
-    return vector!(T)(arr, nullptr, 0u);
-}
 
 
 arena a;
-var v := new_vector!(i64)(a&);
+var v := vector!(i64).create(a&);
 var idx := 0;
 while idx < 20 {
     v.push(idx);

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -1009,14 +1009,11 @@ auto push_expr(compiler& com, compile_type ct, const node_field_expr& node) -> t
             com.current_struct.pop_back();
         }
 
-        if (auto info = get_function(com, full_name); info.has_value()) {
-            node.token.assert(ct == compile_type::val, "cannot take the address of a function ptr");
-            push_value(code(com), op::push_u64, info->id);
-            return type_function_ptr{ .param_types = info->sig.params, .return_type = info->sig.return_type };   
-        }
-        else {
-            node.token.error("can only access member functions from structs");
-        }
+        node.token.assert(ct == compile_type::val, "cannot take the address of a function ptr");
+        auto info = get_function(com, full_name);
+        node.token.assert(info.has_value(), "can only access member functions from structs");
+        push_value(code(com), op::push_u64, info->id);
+        return type_function_ptr{ .param_types = info->sig.params, .return_type = info->sig.return_type };   
     }
     
     const auto stripped = strip_pointers(type);


### PR DESCRIPTION
* It is now possible to access member functions on structs directly through the struct itself. For example, given a object `vec` of type `vector!(u64)`, you can either call `vec.size()` or equivalently `vector!(u64).size(vec&)`.
* This allows for member functions that don't have a self parameter. Trying to call one of the these on a instance of a class is an error.
* To implement this, the check on the first argument to the function is now done in `node_field_expr` when constructing the bound method object, rather than in `compile_function`.
* The example functions `new_vector` and `new_tokenizer` are now spelled `vector.create` and `tokenizer.create`.
* With this, there's a bit more duplication in the handling of compiling templates, and it may be possible to generalise the current implementation further for name and field expressions.
* Static methods can also be templates.