### PR TITLE
Fix Variable Access from Modules

### DIFF
--- a/examples/module.az
+++ b/examples/module.az
@@ -1,2 +1,2 @@
-print("in module\n");
+
 var y := 10;

--- a/examples/test.az
+++ b/examples/test.az
@@ -8,3 +8,5 @@ while tok.valid() {
     print("{}\n", tok.current());
     tok.advance();
 }
+
+print("{}\n", global);

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,5 +1,3 @@
-
-
 module vec := "lib/tokenizer.az";
 
 let input := "my test string has six words";
@@ -8,5 +6,3 @@ while tok.valid() {
     print("{}\n", tok.current());
     tok.advance();
 }
-
-print("{}\n", global);

--- a/lib/tokenizer.az
+++ b/lib/tokenizer.az
@@ -41,5 +41,3 @@ struct tokenizer
         return t;
     }
 }
-
-var global := 10;

--- a/lib/tokenizer.az
+++ b/lib/tokenizer.az
@@ -41,3 +41,5 @@ struct tokenizer
         return t;
     }
 }
+
+var global := 10;

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -1358,7 +1358,13 @@ auto push_stmt(compiler& com, const node_module_declaration_stmt& node) -> void
     com.current_module.back().imports[node.name] = node.filepath;
 
     com.current_module.emplace_back(node.filepath, module_map{});
-    push_stmt(com, *mod.root);
+
+    // We must unwrap the sequence statement like this since we do no want to introduce a new
+    // scope while compiling this, otherwise all the variables will get popped after.
+    node.token.assert(std::holds_alternative<node_sequence_stmt>(*mod.root), "invalid module, top level must be a sequence");
+    for (const auto& node : std::get<node_sequence_stmt>(*mod.root).sequence) {
+        push_stmt(com, *node);
+    }
     com.current_module.pop_back();
     com.modules.emplace(node.filepath);
 }


### PR DESCRIPTION
* When compiling a sequence statement, a new scope is added, so a new scope was getting added when compiling a module, meaning all globals would be cleaned up after importing.
* This fix unwraps the top level sequence statement in a module and compiles each statement separately to avoid this.
* In the future, a cleaner impl would probably involve a module not having a top level sequence statement but instead just have a vector of statements.