### PR TITLE
Module Namespacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,14 @@ An interpreted programming language written in C++. This started out as a stack-
     * C++ and D style templates using D style syntax. The syntax is a bit odd and I would have preferred `foo<i64>` or `foo|i64|`, but those add a lot of complexity to the parser. the `!` token is needed to keep parsing simple.
     * Member functions can also be templated.
 
+* Modules
+    ```py
+    module vec := "lib/vector.az";
+    var my_vec := vec.vector!(u64).create(alloc&);
+    ```
+    * Import other files and access their contents via the defined module object.
+    * Global variables, structs and functions are made available.
+
 
 ## The Pipeline
 The way this langauage is processed and ran is similar to other langages. The lexer, parser, compiler and runtime modules are completely separate, and act as a pipeline by each one outputting a representation that the next one can understand. Below is a diagram showing how everything fits together.

--- a/README.md
+++ b/README.md
@@ -145,8 +145,6 @@ Runtime  -- runtime.hpp   : Functionality to run a program
 ```
 
 # Next Features
-* Modules
 * Complete spans
     - Create spans from other spans.
-* Templated Structs
 * Variants

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ An interpreted programming language written in C++. This started out as a stack-
     1. eg: `i64&` is an `i64` pointer.
     1. If `ptr` is an `i64&`, then `ptr@` is the int that it points to.
     1. Uses `@` instead of the familiar `*` because using `*` in trailing syntax can be ambigious with multiplication. Plus I like it more; it signals that I'm using the value "at" the pointer.
+    1. `nullptr` is a value of a special type to is convertible to any pointer type.
 
 * Arrays:
     1. Fixed size arrays with statically known size.
@@ -28,6 +29,7 @@ An interpreted programming language written in C++. This started out as a stack-
     1. eg: If `l` is an array of 5 `i64`s, then `l[]` is an `i64[]`.
     1. Slicing syntax `l[0 : 2]` for creating subspans.
     1. Arrays can automatically convert to spans when passing to functions.
+    1. A "null span" of zero elements can be created from `nullptr`.
 
 * Function Pointers:
     1. Function names resolve to function pointers which can be passed to functions.
@@ -92,12 +94,15 @@ An interpreted programming language written in C++. This started out as a stack-
         x: f64;
         y: f64;
 
-        fn length2(self: (const vec2)&) -> f64
+        fn length2(self: const&) -> f64
         {
             return (self.x * self.x) + (self.y * self.y);
         }
     }
     ```
+    * The type of the arg for a member function does not need to be explicitly specified.
+    * If the first arg is not a pointer to the type, it is classed as a "static" method and only callable from the type.
+
 * All the common arithmetic, comparison and logical operators.
 * Builtin functions.
 * Memory arenas for allocating dynamic memory:

--- a/examples/feature_test.az
+++ b/examples/feature_test.az
@@ -279,7 +279,7 @@ fn get(a: arena&, count: u64) -> u64[]
 }
 
 arena a;
-let contents := read_file("examples/example_data.txt", a&);
+let contents := io.read_file("examples/example_data.txt", a&);
 
 print("'{}'\n", contents);
 print("\nsize={}\n", contents.size());

--- a/examples/feature_test.az
+++ b/examples/feature_test.az
@@ -347,3 +347,13 @@ struct pair!(T)
     f.print_struct!(u64)(70u);
     g.print_struct!(u64)(70u);
 }
+
+module util := "lib/utility.az";
+
+struct double {
+    x: util.pair!(i64, f64);
+    y: util.pair!(u64, bool);
+}
+
+let d := double(util.pair!(i64, f64)(1, 2.0), util.pair!(u64, bool)(3u, false));
+print("{} {} {} {}\n", d.x.first, d.x.second, d.y.first, d.y.second);

--- a/examples/feature_test.az
+++ b/examples/feature_test.az
@@ -357,3 +357,15 @@ struct double {
 
 let d := double(util.pair!(i64, f64)(1, 2.0), util.pair!(u64, bool)(3u, false));
 print("{} {} {} {}\n", d.x.first, d.x.second, d.y.first, d.y.second);
+
+module vec := "lib/vector.az";
+arena v;
+var my_vec := vec.vector!(i64).create(v&);
+my_vec.push(2);
+my_vec.push(3);
+my_vec.push(4);
+print("{}\n", my_vec.size());
+for x in my_vec.to_span() {
+    print("{} ", x@);
+}
+print("\n");

--- a/examples/module.az
+++ b/examples/module.az
@@ -1,2 +1,6 @@
 
 var y := 10;
+
+fn foo() { print("in foo\n"); }
+
+fn bar!(T)(t: T) { print("in bar {}\n", t); }

--- a/examples/module.az
+++ b/examples/module.az
@@ -1,6 +1,6 @@
 
-var y := 10;
-
-fn foo() { print("in foo\n"); }
-
-fn bar!(T)(t: T) { print("in bar {}\n", t); }
+struct pair
+{
+    x: i64;
+    y: i64;
+}

--- a/examples/module.az
+++ b/examples/module.az
@@ -1,6 +1,2 @@
 
-struct pair
-{
-    x: i64;
-    y: i64;
-}
+module io := "lib/io.az";

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,7 +1,7 @@
 module m := "examples/module.az";
-
+module io := "lib/io.az";
 arena a;
-let contents := m.io.read_file("examples/example_data.txt", a&);
+let contents := io.read_file("examples/example_data.txt", a&);
 
 print("'{}'\n", contents);
 print("\nsize={}\n", contents.size());

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,3 +1,3 @@
 module m := "examples/module.az";
 
-m.bar!(u64)(5u);
+print("{}\n", m.y);

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,22 +1,3 @@
+module m := "examples/module.az";
 
-module vec := "lib/vector.az";
-
-arena a;
-var v1 := vec.vector!(i64).create(a&);
-var v2 := vec.vector!(f64).create(a&);
-
-var x := 0;
-var y := 0.3;
-while x < 10 {
-    v1.push(x);
-    v2.push(y);
-    x = x + 1;
-    y = y + 1.0;
-}
-
-for val in v1.to_span() {
-    print("{}\n", val@);
-}
-for val in v2.to_span() {
-    print("{}\n", val@);
-}
+m.foo();

--- a/examples/test.az
+++ b/examples/test.az
@@ -4,9 +4,10 @@ module vec := "lib/vector.az";
 arena a;
 var v := vec.vector!(i64).create(a&);
 
-let x := 0;
+var x := 0;
 while x < 10 {
     v.push(x);
+    x = x + 1;
 }
 
 for val in v.to_span() {

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,10 +1,7 @@
 module m := "examples/module.az";
-module i := "lib/io.az";
 
-struct double {
-    x: m.pair;
-    y: m.pair;
-}
+arena a;
+let contents := m.io.read_file("examples/example_data.txt", a&);
 
-let d := double(m.pair(1, 2), m.pair(3, 4));
-print("{} {} {} {}\n", d.x.x, d.x.y, d.y.x, d.y.y);
+print("'{}'\n", contents);
+print("\nsize={}\n", contents.size());

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,6 +1,6 @@
-module tk := "lib/tokenizer.az";
+module tk    := "lib/tokenizer.az";
+module vec   := "lib/vector.az";
 module other := "examples/module.az";
-module vec := "lib/vector.az";
 
 let input := "my test string has six words";
 var tok := tk.tokenizer.create(input, ' ');

--- a/examples/test.az
+++ b/examples/test.az
@@ -3,3 +3,12 @@ module vec := "lib/vector.az";
 
 arena a;
 var v := vec.vector!(i64).create(a&);
+
+let x := 0;
+while x < 10 {
+    v.push(x);
+}
+
+for val in v.to_span() {
+    print("{}\n", val@);
+}

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,8 +1,8 @@
-module vec := "lib/tokenizer.az";
-
+module tk := "lib/tokenizer.az";
 let input := "my test string has six words";
-var tok := tokenizer.create(input, ' ');
+var tok := tk.tokenizer.create(input, ' ');
 while tok.valid() {
     print("{}\n", tok.current());
     tok.advance();
 }
+print("__dump_type", tok);

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,3 +1,4 @@
 module m := "examples/module.az";
 
+let y := 100;
 print("{}\n", m.y);

--- a/examples/test.az
+++ b/examples/test.az
@@ -2,14 +2,21 @@
 module vec := "lib/vector.az";
 
 arena a;
-var v := vec.vector!(i64).create(a&);
+var v1 := vec.vector!(i64).create(a&);
+var v2 := vec.vector!(f64).create(a&);
 
 var x := 0;
+var y := 0.3;
 while x < 10 {
-    v.push(x);
+    v1.push(x);
+    v2.push(y);
     x = x + 1;
+    y = y + 1.0;
 }
 
-for val in v.to_span() {
+for val in v1.to_span() {
+    print("{}\n", val@);
+}
+for val in v2.to_span() {
     print("{}\n", val@);
 }

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,4 +1,7 @@
 module tk := "lib/tokenizer.az";
+module other := "examples/module.az";
+module vec := "lib/vector.az";
+
 let input := "my test string has six words";
 var tok := tk.tokenizer.create(input, ' ');
 while tok.valid() {
@@ -6,3 +9,9 @@ while tok.valid() {
     tok.advance();
 }
 print("__dump_type", tok);
+
+print("{}\n", y);
+foo();
+
+arena a;
+var v := vec.vector!(i64).create(a&);

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,17 +1,5 @@
-module tk    := "lib/tokenizer.az";
-module vec   := "lib/vector.az";
-module other := "examples/module.az";
 
-let input := "my test string has six words";
-var tok := tk.tokenizer.create(input, ' ');
-while tok.valid() {
-    print("{}\n", tok.current());
-    tok.advance();
-}
-print("__dump_type", tok);
-
-print("{}\n", y);
-foo();
+module vec := "lib/vector.az";
 
 arena a;
 var v := vec.vector!(i64).create(a&);

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,4 +1,10 @@
 module m := "examples/module.az";
+module i := "lib/io.az";
 
-let y := 100;
-print("{}\n", m.y);
+struct double {
+    x: m.pair;
+    y: m.pair;
+}
+
+let d := double(m.pair(1, 2), m.pair(3, 4));
+print("{} {} {} {}\n", d.x.x, d.x.y, d.y.x, d.y.y);

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,3 +1,3 @@
 module m := "examples/module.az";
 
-m.foo();
+m.bar!(u64)(5u);

--- a/lib/io.az
+++ b/lib/io.az
@@ -5,3 +5,9 @@ fn read_file(filename: char const[], a: arena&) -> char const[]
     fclose(f);
     return contents;
 }
+
+struct pair
+{
+    a: i64;
+    b: i64;
+}

--- a/lib/io.az
+++ b/lib/io.az
@@ -5,9 +5,3 @@ fn read_file(filename: char const[], a: arena&) -> char const[]
     fclose(f);
     return contents;
 }
-
-struct pair
-{
-    a: i64;
-    b: i64;
-}

--- a/lib/utility.az
+++ b/lib/utility.az
@@ -1,0 +1,5 @@
+struct pair!(A, B)
+{
+    first: A;
+    second: B;
+}

--- a/lib/vector.az
+++ b/lib/vector.az
@@ -41,6 +41,11 @@ struct vector!(T)
         self._size = self._size + 1u;
     }
 
+    fn test!(U)(self: &, u: U) -> null
+    {
+        print("{}\n", u);
+    }
+
     fn create(arr: arena&) -> vector!(T)
     {
         return vector!(T)(arr, nullptr, 0u);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,6 +16,7 @@ add_executable(
     functions.cpp
     bytecode.cpp
     runtime.cpp
+    names.cpp
 
     compilation/type_manager.cpp
     compilation/variable_manager.cpp

--- a/src/compilation/type_manager.hpp
+++ b/src/compilation/type_manager.hpp
@@ -22,7 +22,7 @@ struct type_info
 
 class type_manager
 {
-    std::unordered_map<type_name, type_info, type_hash> d_classes;
+    std::unordered_map<type_name, type_info> d_classes;
 
 public:
     auto add(const type_name& name, const type_fields& fields, const template_map& templates = {}) -> bool;

--- a/src/compilation/variable_manager.cpp
+++ b/src/compilation/variable_manager.cpp
@@ -30,23 +30,23 @@ void variable_manager::new_loop_scope()
 }
 
 auto variable_manager::declare(
-    const std::string& name, const type_name& type, std::size_t size
+    const std::filesystem::path& module, const std::string& name, const type_name& type, std::size_t size
 ) -> bool
 {
     auto& scope = d_scopes.back();
     for (const auto& var : scope.variables) {
         if (var.name == name) return false;
     }
-    scope.variables.emplace_back(name, type, scope.next, size);
+    scope.variables.emplace_back(module, name, type, scope.next, size);
     scope.next += size;
     return true;
 }
 
-auto variable_manager::find(const std::string& name) const -> std::optional<variable>
+auto variable_manager::find(const std::filesystem::path& module, const std::string& name) const -> std::optional<variable>
 {
     for (const auto& scope : d_scopes | std::views::reverse) {
         for (const auto& var : scope.variables) { // no need to reverse here, var names are unique per scope
-            if (var.name == name) return var;
+            if (var.name == name && var.module == module) return var;
         }
     }
     return std::nullopt;

--- a/src/compilation/variable_manager.cpp
+++ b/src/compilation/variable_manager.cpp
@@ -35,7 +35,7 @@ auto variable_manager::declare(
 {
     auto& scope = d_scopes.back();
     for (const auto& var : scope.variables) {
-        if (var.name == name) return false;
+        if (var.name == name && var.module == module) return false;
     }
     scope.variables.emplace_back(module, name, type, scope.next, size);
     scope.next += size;

--- a/src/compilation/variable_manager.hpp
+++ b/src/compilation/variable_manager.hpp
@@ -9,6 +9,7 @@
 #include <span>
 #include <variant>
 #include <ranges>
+#include <filesystem>
 
 namespace anzu {
 
@@ -17,10 +18,11 @@ class compiler;
 
 struct variable
 {
-    std::string name;
-    type_name   type;
-    std::size_t location;
-    std::size_t size;
+    std::filesystem::path module;
+    std::string           name;
+    type_name             type;
+    std::size_t           location;
+    std::size_t           size;
 };
 
 struct simple_scope
@@ -50,8 +52,8 @@ class variable_manager
 
 public:
     variable_manager(bool local = true) : d_local{local} {}
-    auto declare(const std::string& name, const type_name& type, std::size_t size) -> bool;
-    auto find(const std::string& name) const -> std::optional<variable>;
+    auto declare(const std::filesystem::path& module, const std::string& name, const type_name& type, std::size_t size) -> bool;
+    auto find(const std::filesystem::path& module, const std::string& name) const -> std::optional<variable>;
     auto scopes() const -> std::span<const scope> { return d_scopes; }
 
     auto in_loop() const -> bool;

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -1060,8 +1060,7 @@ auto push_expr(compiler& com, compile_type ct, const node_field_expr& node) -> t
                            ? std::get<type_struct>(stripped)
                            : no_struct;
 
-
-    // Check if it is a function that needs compiling
+    // It might be a member function
     const auto fname = function_name{struct_name.module, struct_name, node.field_name, templates};
     if (auto info = get_function(com, node.token, fname); info.has_value()) {
         node.token.assert(ct == compile_type::val, "cannot take the address of a bound method");

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -915,7 +915,7 @@ auto push_expr(compiler& com, compile_type ct, const node_name_expr& node) -> ty
     const auto struct_type = type_struct{
         .name=node.name, .module=curr_module(com), .templates=templates
     };
-    const auto key = template_struct_name{node.name, curr_module(com)};
+    const auto key = template_struct_name{curr_module(com), node.name};
     if (com.struct_templates.contains(key) && !com.types.contains(struct_type)) {
         const auto& ast = com.struct_templates.at(key);
 
@@ -1006,7 +1006,7 @@ auto push_expr(compiler& com, compile_type ct, const node_field_expr& node) -> t
         const auto struct_type = type_struct{
             .name=node.field_name, .module=info.filepath, .templates=templates
         };
-        const auto key = template_struct_name{node.field_name, info.filepath};
+        const auto key = template_struct_name{info.filepath, node.field_name};
 
         if (com.struct_templates.contains(key) && !com.types.contains(struct_type)) {
             com.current_module.emplace_back(info.filepath);
@@ -1365,7 +1365,7 @@ void push_stmt(compiler& com, const node_if_stmt& node)
 void push_stmt(compiler& com, const node_struct_stmt& node)
 {
     if (!node.templates.empty()) {
-        const auto key = template_struct_name{node.name, curr_module(com)};
+        const auto key = template_struct_name{curr_module(com), node.name};
         const auto [it, success] = com.struct_templates.emplace(key, node);
         node.token.assert(success, "struct template named '<{}>.{}' already defined", curr_module(com).string(), node.name);
         return;

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -301,13 +301,14 @@ auto build_template_map(
 auto compile_function(
     compiler& com,
     const token& tok,
-    const std::string& full_name,
+    const function_name& name,
     const node_signature& node_sig,
     const node_stmt_ptr& body,
     const template_map& map = {}
 )
     -> void
 {
+    const auto full_name = name.to_string();
     const auto id = com.functions.size();
     com.current_function.emplace_back(id, map);
     com.functions.emplace_back(full_name, id, variable_manager{true});
@@ -912,7 +913,7 @@ auto push_expr(compiler& com, compile_type ct, const node_name_expr& node) -> ty
         const auto& ast = com.function_templates.at(fkey);
         const auto map = build_template_map(com, node.token, ast.templates, node.templates);
         com.current_struct.emplace_back(no_struct, template_map{});
-        compile_function(com, node.token, fname.to_string(), ast.sig, ast.body, map);
+        compile_function(com, node.token, fname, ast.sig, ast.body, map);
         com.current_struct.pop_back();
     }
 
@@ -1068,7 +1069,7 @@ auto push_expr(compiler& com, compile_type ct, const node_field_expr& node) -> t
             const auto& ast = com.function_templates.at(fkey);
             const auto map = build_template_map(com, node.token, ast.templates, node.templates);
             com.current_struct.emplace_back(no_struct, template_map{});
-            compile_function(com, node.token, fname.to_string(), ast.sig, ast.body, map);
+            compile_function(com, node.token, fname, ast.sig, ast.body, map);
             com.current_struct.pop_back();
         }
         if (auto func = get_function(com, fname)) {
@@ -1110,7 +1111,7 @@ auto push_expr(compiler& com, compile_type ct, const node_field_expr& node) -> t
             com.current_struct.emplace_back(struct_info, com.types.templates_of(inner_type(type)));
             com.current_module.emplace_back(struct_info.module);
             const auto map = build_template_map(com, node.token, ast.templates, node.templates);
-            compile_function(com, node.token, fname.to_string(), ast.sig, ast.body, map);
+            compile_function(com, node.token, fname, ast.sig, ast.body, map);
             com.current_module.pop_back();
             com.current_struct.pop_back();
         }
@@ -1145,7 +1146,7 @@ auto push_expr(compiler& com, compile_type ct, const node_field_expr& node) -> t
         com.current_struct.emplace_back(struct_name, com.types.templates_of(stripped));
         com.current_module.emplace_back(struct_name.module);
         const auto map = build_template_map(com, node.token, ast.templates, node.templates);
-        compile_function(com, node.token, fname.to_string(), ast.sig, ast.body, map);
+        compile_function(com, node.token, fname, ast.sig, ast.body, map);
         com.current_module.pop_back();
         com.current_struct.pop_back();
     }
@@ -1508,12 +1509,12 @@ void push_stmt(compiler& com, const node_function_stmt& node)
         return;
     }
 
-    const auto key = function_name{
+    const auto fname = function_name{
         .module = curr_module(com),
         .struct_name = struct_name,
         .name = node.name
     };
-    compile_function(com, node.token, key.to_string(), node.sig, node.body);
+    compile_function(com, node.token, fname, node.sig, node.body);
 }
 
 void push_stmt(compiler& com, const node_expression_stmt& node)

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -922,9 +922,9 @@ auto push_expr(compiler& com, compile_type ct, const node_name_expr& node) -> ty
     const auto full_name = fn_name(com, node.token, curr_module(com), no_struct, node.name, node.templates);
     
     const auto fkey = template_function_type{
-        .name = node.name,
         .module = curr_module(com),
-        .struct_name = no_struct
+        .struct_name = no_struct,
+        .name = node.name
     };
     if (com.function_templates.contains(fkey) && !get_function(com, full_name)) {
         const auto& ast = com.function_templates.at(fkey);
@@ -959,9 +959,9 @@ auto push_expr(compiler& com, compile_type ct, const node_name_expr& node) -> ty
             const auto func_name = fn_name(com, node.token, curr_module(com), std::get<type_struct>(struct_type), stmt.name);
 
             const auto fkey = template_function_type{
-                .name=stmt.name,
                 .module=curr_module(com),
-                .struct_name=struct_type
+                .struct_name=std::get<type_struct>(struct_type),
+                .name=stmt.name
             };
             // Template functions only get compiled at the call site, so we just stash the ast
             const auto [it, success] = com.function_templates.emplace(fkey, stmt);
@@ -1056,9 +1056,9 @@ auto push_expr(compiler& com, compile_type ct, const node_field_expr& node) -> t
                 const auto func_name = fn_name(com, node.token, info.filepath, std::get<type_struct>(struct_type), stmt.name);
 
                 const auto fkey = template_function_type{
-                    .name=stmt.name,
                     .module=info.filepath,
-                    .struct_name=struct_type
+                    .struct_name=std::get<type_struct>(struct_type),
+                    .name=stmt.name
                 };
 
                 // Template functions only get compiled at the call site, so we just stash the ast
@@ -1078,9 +1078,9 @@ auto push_expr(compiler& com, compile_type ct, const node_field_expr& node) -> t
         // Firstly, might be a template
         const auto fn = fn_name(com, node.token, info.filepath, no_struct, node.field_name, node.templates);
         const auto fkey = template_function_type{
-            .name = node.field_name,
             .module = info.filepath,
-            .struct_name = no_struct
+            .struct_name = no_struct,
+            .name = node.field_name
         };
         if (com.function_templates.contains(fkey) && !get_function(com, fn)) {
             const auto& ast = com.function_templates.at(fkey);
@@ -1114,9 +1114,9 @@ auto push_expr(compiler& com, compile_type ct, const node_field_expr& node) -> t
         // Check if it is a function that needs compiling
         const auto full_name = fn_name(com, node.token, struct_info.module, struct_info, node.field_name, node.templates);
         const auto fkey = template_function_type{
-            .name=node.field_name,
             .module= struct_info.module,
-            .struct_name = inner
+            .struct_name = struct_info,
+            .name=node.field_name
         };
         if (com.function_templates.contains(fkey) && !get_function(com, full_name)) {
             const auto ast = com.function_templates.at(fkey);
@@ -1144,9 +1144,9 @@ auto push_expr(compiler& com, compile_type ct, const node_field_expr& node) -> t
     // Check if it is a function that needs compiling
     const auto full_name = fn_name(com, node.token, struct_name.module, struct_name, node.field_name, node.templates);
     const auto fkey = template_function_type{
-        .name=node.field_name,
         .module=struct_name.module,
-        .struct_name = stripped
+        .struct_name = struct_name,
+        .name=node.field_name
     };
     if (com.function_templates.contains(fkey) && !get_function(com, full_name)) {
         const auto ast = com.function_templates.at(fkey);
@@ -1510,9 +1510,9 @@ void push_stmt(compiler& com, const node_function_stmt& node)
     // Template functions only get compiled at the call site, so we just stash the ast
     if (!node.templates.empty()) {
         const auto key = template_function_type{
-            .name = node.name,
             .module = curr_module(com),
-            .struct_name = struct_name
+            .struct_name = std::get<type_struct>(struct_name),
+            .name = node.name
         };
         const auto [it, success] = com.function_templates.emplace(key, node);
         node.token.assert(success, "function template named '{}' already defined", function_name);

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -86,7 +86,7 @@ auto resolve_type(compiler& com, const token& tok, const node_expr_ptr& expr) ->
 
 auto get_function(compiler& com, const function_name& name) -> std::optional<function>
 {
-    if (const auto it = com.functions_by_name.find(name.to_string()); it != com.functions_by_name.end()) {
+    if (const auto it = com.functions_by_name.find(name); it != com.functions_by_name.end()) {
         return com.functions[it->second];
     }
     return std::nullopt;
@@ -312,7 +312,7 @@ auto compile_function(
     const auto id = com.functions.size();
     com.current_function.emplace_back(id, map);
     com.functions.emplace_back(full_name, id, variable_manager{true});
-    const auto [it, success] = com.functions_by_name.emplace(full_name, id);
+    const auto [it, success] = com.functions_by_name.emplace(name, id);
     tok.assert(success, "a function with the name '{}' already exists", full_name);
     
     variables(com).new_scope();
@@ -1402,9 +1402,10 @@ void push_stmt(compiler& com, const node_struct_stmt& node)
     }
 
     const auto struct_name = type_struct{ .name=node.name, .module=curr_module(com) };
+    const auto fname = function_name{curr_module(com), no_struct, node.name};
     const auto message = std::format("type '{}' already defined", node.name);
     node.token.assert(!com.types.contains(struct_name), "{}", message);
-    node.token.assert(!com.functions_by_name.contains(node.name), "{}", message);
+    node.token.assert(!com.functions_by_name.contains(fname), "{}", message);
 
     com.current_struct.emplace_back(struct_name, template_map{});
     auto fields = std::vector<type_field>{};

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -919,7 +919,6 @@ auto push_expr(compiler& com, compile_type ct, const node_name_expr& node) -> ty
     }
 
     // Next, check if it is a function that needs compiling (does val/ptr matter?)
-    const auto full_name_no_templates = fn_name(com, node.token, curr_module(com), no_struct, node.name);
     const auto full_name = fn_name(com, node.token, curr_module(com), no_struct, node.name, node.templates);
     
     const auto fkey = template_function_type{

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -1043,9 +1043,7 @@ auto push_expr(compiler& com, compile_type ct, const node_field_expr& node) -> t
     
     // If the expression is a type, allow for accessing the functions (only makes sense on structs)
     if (type.is_type_value() && std::holds_alternative<type_struct>(inner_type(type))) {
-        
-        const auto& inner = inner_type(type);
-        const auto& struct_info = std::get<type_struct>(inner);
+        const auto struct_info = std::get<type_struct>(inner_type(type));
          
         const auto fname = function_name{struct_info.module, struct_info, node.field_name, templates};
         if (auto func = get_function(com, node.token, fname); func.has_value()) {

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -277,23 +277,6 @@ auto build_template_map(
     compiler& com,
     const token& tok,
     const std::vector<std::string>& names,
-    const std::vector<node_expr_ptr>& types
-)
-    -> template_map
-{
-    tok.assert_eq(types.size(), names.size(), "bad number of template args");
-    auto map = template_map{};
-    for (const auto& [actual, expected] : zip(types, names)) {
-        const auto [it, success] = map.emplace(expected, resolve_type(com, tok, actual));
-        if (!success) { tok.error("duplicate template name {}", expected); }
-    }
-    return map;
-}
-
-auto build_template_map2(
-    compiler& com,
-    const token& tok,
-    const std::vector<std::string>& names,
     const std::vector<type_name>& types
 )
     -> template_map
@@ -429,7 +412,7 @@ auto get_function(compiler& com, const token& tok, const function_name& name)
     // If the function doesn't exist, it may still be a template, if it is then compile it
     if (com.function_templates.contains(name.as_template())) {
         const auto& ast = com.function_templates.at(name.as_template());
-        const auto map = build_template_map2(com, tok, ast.templates, name.templates);
+        const auto map = build_template_map(com, tok, ast.templates, name.templates);
 
         com.current_struct.emplace_back(name.struct_name, com.types.templates_of(name.struct_name));
         com.current_module.emplace_back(name.module);
@@ -449,7 +432,7 @@ auto get_struct(compiler& com, const token& tok, const type_struct& name)
     if (com.struct_templates.contains(key) && !com.types.contains(name)) {
         const auto& ast = com.struct_templates.at(key);
 
-        auto map = build_template_map2(com, tok, ast.templates, name.templates);
+        auto map = build_template_map(com, tok, ast.templates, name.templates);
         com.current_struct.emplace_back(name, map);
         com.current_module.emplace_back(name.module);
         auto fields = std::vector<type_field>{};

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -1015,8 +1015,8 @@ auto push_expr(compiler& com, compile_type ct, const node_name_expr& node) -> ty
         return type_function_ptr{ .param_types = func->sig.params, .return_type = func->sig.return_type };
     }
 
-    // The name might be a builtin
-    if (auto func = get_builtin(full_name)) {
+    // The name might be a builtin (no module, struct or templates, so just the name);
+    if (auto func = get_builtin(node.name)) {
         node.token.assert(ct == compile_type::val, "cannot take the address of a builtin");
         node.token.assert(node.templates.empty(), "builtins cannot be templated");
         return type_builtin{
@@ -1414,7 +1414,6 @@ void push_stmt(compiler& com, const node_struct_stmt& node)
     }
 
     const auto struct_name = make_type(com, node.name);
-    std::print("created {}\n", struct_name);
     const auto message = std::format("type '{}' already defined", node.name);
     node.token.assert(!com.types.contains(struct_name), "{}", message);
     node.token.assert(!com.functions_by_name.contains(node.name), "{}", message);

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -363,7 +363,6 @@ auto compile_function(
 )
     -> void
 {
-    std::print("compiling {}\n", full_name);
     const auto id = com.functions.size();
     com.current_function.emplace_back(id, map);
     com.functions.emplace_back(full_name, id, variable_manager{true});
@@ -1120,7 +1119,6 @@ auto push_expr(compiler& com, compile_type ct, const node_field_expr& node) -> t
     }
     
     const auto stripped = strip_pointers(type);
-    std::print("stripped = {}\n", stripped);
     const auto struct_name = std::holds_alternative<type_struct>(stripped)
                            ? std::get<type_struct>(stripped)
                            : no_struct;

--- a/src/compiler.hpp
+++ b/src/compiler.hpp
@@ -24,7 +24,7 @@ struct signature
 
 struct function
 {
-    std::string      name;
+    function_name    name;
     std::size_t      id;
     variable_manager variables;
     

--- a/src/compiler.hpp
+++ b/src/compiler.hpp
@@ -62,9 +62,9 @@ using template_struct_type_hash = decltype([](const template_struct_type& x) {
 
 struct template_function_type
 {
-    std::string name;
     std::filesystem::path module;
-    type_name struct_name;
+    type_struct           struct_name;
+    std::string           name;
     auto operator==(const template_function_type&) const -> bool = default;
 };
 using template_function_type_hash = decltype([](const template_function_type& x) {

--- a/src/compiler.hpp
+++ b/src/compiler.hpp
@@ -2,6 +2,7 @@
 #include "ast.hpp"
 #include "parser.hpp"
 #include "bytecode.hpp"
+#include "names.hpp"
 
 #include "compilation/type_manager.hpp"
 #include "compilation/variable_manager.hpp"
@@ -31,10 +32,10 @@ struct function
     signature              sig  = {};
 };
 
-struct func_info
+struct module_info
 {
-    std::size_t  id;
-    template_map templates;
+    std::filesystem::path                                  filepath;
+    std::unordered_map<std::string, std::filesystem::path> imports;
 };
 
 struct struct_info
@@ -43,38 +44,10 @@ struct struct_info
     template_map templates;
 };
 
-using module_map = std::unordered_map<std::string, std::filesystem::path>;
-struct module_info
+struct func_info
 {
-    std::filesystem::path filepath;
-    module_map            imports;
-};
-
-struct template_struct_type
-{
-    std::string name;
-    std::filesystem::path module;
-    auto operator==(const template_struct_type&) const -> bool = default;
-};
-using template_struct_type_hash = decltype([](const template_struct_type& x) {
-    return std::hash<std::string>{}(x.name) ^ std::hash<std::string>{}(x.module.string());
-});
-
-struct template_function_type
-{
-    std::filesystem::path module;
-    type_struct           struct_name;
-    std::string           name;
-    auto operator==(const template_function_type&) const -> bool = default;
-};
-using template_function_type_hash = decltype([](const template_function_type& x) {
-    return std::hash<std::string>{}(x.name) ^ std::hash<std::string>{}(x.module.string())
-        ^ anzu::hash(x.struct_name);
-});
-
-struct function_key
-{
-    type_struct struct_type;
+    std::size_t  id;
+    template_map templates;
 };
 
 struct compiler
@@ -88,12 +61,12 @@ struct compiler
 
     std::unordered_map<std::string, std::size_t> functions_by_name;
     
-    std::unordered_map<template_function_type, node_function_stmt, template_function_type_hash> function_templates;
-    std::unordered_map<template_struct_type, node_struct_stmt, template_struct_type_hash> struct_templates;
+    std::unordered_map<template_function_name, node_function_stmt> function_templates;
+    std::unordered_map<template_struct_name, node_struct_stmt>     struct_templates;
 
+    std::vector<module_info> current_module;
     std::vector<struct_info> current_struct;
     std::vector<func_info>   current_function;
-    std::vector<module_info> current_module;
 };
 
 auto compile(const anzu_module& ast) -> bytecode_program;

--- a/src/compiler.hpp
+++ b/src/compiler.hpp
@@ -50,7 +50,6 @@ struct module_info
     module_map            imports;
 };
 
-// Represents a struct template
 struct template_struct_type
 {
     std::string name;
@@ -59,6 +58,18 @@ struct template_struct_type
 };
 using template_struct_type_hash = decltype([](const template_struct_type& x) {
     return std::hash<std::string>{}(x.name) ^ std::hash<std::string>{}(x.module.string());
+});
+
+struct template_function_type
+{
+    std::string name;
+    std::filesystem::path module;
+    type_name struct_name;
+    auto operator==(const template_function_type&) const -> bool = default;
+};
+using template_function_type_hash = decltype([](const template_function_type& x) {
+    return std::hash<std::string>{}(x.name) ^ std::hash<std::string>{}(x.module.string())
+        ^ anzu::hash(x.struct_name);
 });
 
 struct compiler
@@ -72,7 +83,7 @@ struct compiler
 
     std::unordered_map<std::string, std::size_t> functions_by_name;
     
-    std::unordered_map<std::string, node_function_stmt> function_templates;
+    std::unordered_map<template_function_type, node_function_stmt, template_function_type_hash> function_templates;
     std::unordered_map<template_struct_type, node_struct_stmt, template_struct_type_hash> struct_templates;
 
     std::vector<struct_info> current_struct;

--- a/src/compiler.hpp
+++ b/src/compiler.hpp
@@ -59,7 +59,7 @@ struct compiler
 
     std::unordered_set<std::filesystem::path> modules;
 
-    std::unordered_map<std::string, std::size_t> functions_by_name;
+    std::unordered_map<function_name, std::size_t> functions_by_name;
     
     std::unordered_map<template_function_name, node_function_stmt> function_templates;
     std::unordered_map<template_struct_name, node_struct_stmt>     struct_templates;

--- a/src/compiler.hpp
+++ b/src/compiler.hpp
@@ -72,6 +72,11 @@ using template_function_type_hash = decltype([](const template_function_type& x)
         ^ anzu::hash(x.struct_name);
 });
 
+struct function_key
+{
+    type_struct struct_type;
+};
+
 struct compiler
 {
     std::vector<function> functions;

--- a/src/compiler.hpp
+++ b/src/compiler.hpp
@@ -50,6 +50,17 @@ struct module_info
     module_map            imports;
 };
 
+// Represents a struct template
+struct template_struct_type
+{
+    std::string name;
+    std::filesystem::path module;
+    auto operator==(const template_struct_type&) const -> bool = default;
+};
+using template_struct_type_hash = decltype([](const template_struct_type& x) {
+    return std::hash<std::string>{}(x.name) ^ std::hash<std::string>{}(x.module.string());
+});
+
 struct compiler
 {
     std::vector<function> functions;
@@ -62,7 +73,7 @@ struct compiler
     std::unordered_map<std::string, std::size_t> functions_by_name;
     
     std::unordered_map<std::string, node_function_stmt> function_templates;
-    std::unordered_map<std::string, node_struct_stmt>   struct_templates;
+    std::unordered_map<template_struct_type, node_struct_stmt, template_struct_type_hash> struct_templates;
 
     std::vector<struct_info> current_struct;
     std::vector<func_info>   current_function;

--- a/src/compiler.hpp
+++ b/src/compiler.hpp
@@ -39,7 +39,7 @@ struct func_info
 
 struct struct_info
 {
-    type_name    name;
+    type_struct  name;
     template_map templates;
 };
 

--- a/src/names.cpp
+++ b/src/names.cpp
@@ -1,0 +1,46 @@
+#include "names.hpp"
+
+namespace anzu {
+ 
+auto struct_name::as_template() const -> template_struct_name
+{
+    return template_struct_name{module, name};
+}
+
+auto template_function_name::to_string() const -> std::string
+{
+    auto ret = std::format("<{}>", module.string());
+    if (struct_name != type_struct{""}) {
+        ret += std::format(".{}", struct_name.name);
+        if (!struct_name.templates.empty()) {
+            ret += std::format("!({})", format_comma_separated(struct_name.templates));
+        }
+    }
+    ret += std::format(".{}", name);
+    return ret;
+}
+
+auto function_name::as_template() const -> template_function_name
+{
+    return template_function_name{module, struct_name, name};
+}
+
+auto function_name::to_string() const -> std::string
+{
+    auto ret = std::format("<{}>", module.string());
+    if (struct_name != type_struct{""}) {
+        ret += std::format(".{}", struct_name.name);
+        if (!struct_name.templates.empty()) {
+            ret += std::format("!({})", format_comma_separated(struct_name.templates));
+        }
+    }
+    ret += std::format(".{}", name);
+    if (!templates.empty()) {
+        const auto template_args_string = format_comma_separated(templates);
+        ret += std::format("!({})", template_args_string);
+    }
+
+    return ret;
+}
+
+}

--- a/src/names.cpp
+++ b/src/names.cpp
@@ -1,11 +1,6 @@
 #include "names.hpp"
 
 namespace anzu {
- 
-auto struct_name::as_template() const -> template_struct_name
-{
-    return template_struct_name{module, name};
-}
 
 auto template_function_name::to_string() const -> std::string
 {

--- a/src/names.hpp
+++ b/src/names.hpp
@@ -15,16 +15,6 @@ struct template_struct_name
     auto operator==(const template_struct_name&) const -> bool = default;
 };
 
-struct struct_name
-{
-    std::filesystem::path  module;
-    std::string            name;
-    std::vector<type_name> templates;
-
-    auto as_template() const -> template_struct_name;
-    auto operator==(const struct_name&) const -> bool = default;
-};
-
 struct template_function_name
 {
     std::filesystem::path module;

--- a/src/names.hpp
+++ b/src/names.hpp
@@ -41,6 +41,12 @@ struct function_name
     std::string            name;
     std::vector<type_name> templates;
     auto operator==(const function_name&) const -> bool = default;
+    
+    auto as_template() const -> template_function_name
+    {
+        return template_function_name{module, struct_name, name};
+    }
+
     auto to_string() const -> std::string
     {
         auto ret = std::format("<{}>", module.string());

--- a/src/names.hpp
+++ b/src/names.hpp
@@ -62,6 +62,22 @@ struct function_name
 
 }
 
+template <>
+struct std::formatter<anzu::template_function_name> : std::formatter<std::string>
+{
+    auto format(const anzu::template_function_name& type, auto& ctx) const {
+        return std::formatter<std::string>::format(type.to_string(), ctx);
+    }
+};
+
+template <>
+struct std::formatter<anzu::function_name> : std::formatter<std::string>
+{
+    auto format(const anzu::function_name& type, auto& ctx) const {
+        return std::formatter<std::string>::format(type.to_string(), ctx);
+    }
+};
+
 template<>
 struct std::hash<anzu::template_struct_name>
 {

--- a/src/names.hpp
+++ b/src/names.hpp
@@ -9,9 +9,20 @@ namespace anzu {
 
 struct template_struct_name
 {
-    std::string name;
     std::filesystem::path module;
+    std::string           name;
+
     auto operator==(const template_struct_name&) const -> bool = default;
+};
+
+struct struct_name
+{
+    std::filesystem::path  module;
+    std::string            name;
+    std::vector<type_name> templates;
+
+    auto as_template() const -> template_struct_name;
+    auto operator==(const struct_name&) const -> bool = default;
 };
 
 struct template_function_name
@@ -19,19 +30,9 @@ struct template_function_name
     std::filesystem::path module;
     type_struct           struct_name;
     std::string           name;
+
+    auto to_string() const -> std::string;
     auto operator==(const template_function_name&) const -> bool = default;
-    auto to_string() const -> std::string
-    {
-        auto ret = std::format("<{}>", module.string());
-        if (struct_name != type_struct{""}) {
-            ret += std::format(".{}", struct_name.name);
-            if (!struct_name.templates.empty()) {
-                ret += std::format("!({})", format_comma_separated(struct_name.templates));
-            }
-        }
-        ret += std::format(".{}", name);
-        return ret;
-    }
 };
 
 struct function_name
@@ -40,30 +41,10 @@ struct function_name
     type_struct            struct_name;
     std::string            name;
     std::vector<type_name> templates;
+
+    auto as_template() const -> template_function_name;
+    auto to_string() const -> std::string;
     auto operator==(const function_name&) const -> bool = default;
-    
-    auto as_template() const -> template_function_name
-    {
-        return template_function_name{module, struct_name, name};
-    }
-
-    auto to_string() const -> std::string
-    {
-        auto ret = std::format("<{}>", module.string());
-        if (struct_name != type_struct{""}) {
-            ret += std::format(".{}", struct_name.name);
-            if (!struct_name.templates.empty()) {
-                ret += std::format("!({})", format_comma_separated(struct_name.templates));
-            }
-        }
-        ret += std::format(".{}", name);
-        if (!templates.empty()) {
-            const auto template_args_string = format_comma_separated(templates);
-            ret += std::format("!({})", template_args_string);
-        }
-
-        return ret;
-    }
 };
 
 }

--- a/src/names.hpp
+++ b/src/names.hpp
@@ -1,0 +1,93 @@
+#include <string>
+#include <filesystem>
+#include <utility>
+#include <format>
+
+#include "object.hpp"
+
+namespace anzu {
+
+struct template_struct_name
+{
+    std::string name;
+    std::filesystem::path module;
+    auto operator==(const template_struct_name&) const -> bool = default;
+};
+
+struct template_function_name
+{
+    std::filesystem::path module;
+    type_struct           struct_name;
+    std::string           name;
+    auto operator==(const template_function_name&) const -> bool = default;
+    auto to_string() const -> std::string
+    {
+        auto ret = std::format("<{}>", module.string());
+        if (struct_name != type_struct{""}) {
+            ret += std::format(".{}", struct_name.name);
+            if (!struct_name.templates.empty()) {
+                ret += std::format("!({})", format_comma_separated(struct_name.templates));
+            }
+        }
+        ret += std::format(".{}", name);
+        return ret;
+    }
+};
+
+struct function_name
+{
+    std::filesystem::path  module;
+    type_struct            struct_name;
+    std::string            name;
+    std::vector<type_name> templates;
+    auto operator==(const function_name&) const -> bool = default;
+    auto to_string() const -> std::string
+    {
+        auto ret = std::format("<{}>", module.string());
+        if (struct_name != type_struct{""}) {
+            ret += std::format(".{}", struct_name.name);
+            if (!struct_name.templates.empty()) {
+                ret += std::format("!({})", format_comma_separated(struct_name.templates));
+            }
+        }
+        ret += std::format(".{}", name);
+        if (!templates.empty()) {
+            const auto template_args_string = format_comma_separated(templates);
+            ret += std::format("!({})", template_args_string);
+        }
+
+        return ret;
+    }
+};
+
+}
+
+template<>
+struct std::hash<anzu::template_struct_name>
+{
+    auto operator()(const anzu::template_struct_name& name) const -> std::size_t
+    {
+        return std::hash<std::string>{}(name.name) ^ std::hash<std::string>{}(name.module.string());
+    }
+};
+
+template<>
+struct std::hash<anzu::template_function_name>
+{
+    auto operator()(const anzu::template_function_name& name) const -> std::size_t
+    {
+        return std::hash<std::string>{}(name.name) ^ std::hash<std::string>{}(name.module.string())
+                                                   ^ anzu::hash(name.struct_name);
+    }
+};
+
+template<>
+struct std::hash<anzu::function_name>
+{
+    // TODO: hash the template args
+    auto operator()(const anzu::function_name& name) const -> std::size_t
+    {
+        return std::hash<std::string>{}(name.name) ^ std::hash<std::string>{}(name.module.string())
+                                                   ^ anzu::hash(name.struct_name);
+    }
+};

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -126,7 +126,7 @@ auto to_string(const type_bound_method& type) -> std::string
     return std::format(
         "<bound method: '{} {}({}) -> {}'>",
         to_string(token_type::kw_function),
-        type.function_name,
+        type.name,
         format_comma_separated(type.param_types),
         to_string_paren(*type.return_type)
     );
@@ -203,7 +203,7 @@ auto hash(const type_builtin& type) -> std::size_t
 
 auto hash(const type_bound_method& type) -> std::size_t
 {
-    auto val = hash(*type.return_type) ^ std::hash<std::size_t>{}(type.function_id);
+    auto val = hash(*type.return_type) ^ std::hash<std::size_t>{}(type.id);
     for (const auto& param : type.param_types) {
         val ^= hash(param);
     }

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -78,7 +78,7 @@ auto to_string(type_fundamental t) -> std::string
 
 auto to_string(const type_struct& type) -> std::string
 {
-    return type.name;
+    return std::format("<{}>.{}", type.module.string(), type.name);
 }
 
 auto to_string(const type_array& type) -> std::string

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -78,7 +78,11 @@ auto to_string(type_fundamental t) -> std::string
 
 auto to_string(const type_struct& type) -> std::string
 {
-    return std::format("<{}>.{}", type.module.string(), type.name);
+    if (!type.templates.empty()) {
+        return std::format("<{}>.{}!({})", type.module.string(), type.name, format_comma_separated(type.templates));
+    } else {
+        return std::format("<{}>.{}", type.module.string(), type.name);
+    }
 }
 
 auto to_string(const type_array& type) -> std::string

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -34,8 +34,9 @@ enum class type_fundamental : std::uint8_t
 
 struct type_struct
 {
-    std::string           name;
-    std::filesystem::path module;
+    std::string            name;
+    std::filesystem::path  module;
+    std::vector<type_name> templates;
     auto operator==(const type_struct&) const -> bool = default;
 };
 

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -79,8 +79,8 @@ struct type_bound_method
 {
     std::vector<type_name> param_types;
     value_ptr<type_name>   return_type;
-    std::string            function_name; // for printing only
-    std::size_t            function_id;
+    std::string            name; // for printing only
+    std::size_t            id;
     auto operator==(const type_bound_method&) const -> bool = default;
 };
 

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -34,7 +34,8 @@ enum class type_fundamental : std::uint8_t
 
 struct type_struct
 {
-    std::string name;
+    std::string           name;
+    std::filesystem::path module;
     auto operator==(const type_struct&) const -> bool = default;
 };
 

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -170,7 +170,6 @@ auto hash(const type_arena& type) -> std::size_t;
 auto hash(const type_type& type) -> std::size_t;
 auto hash(const type_module& type) -> std::size_t;
 auto hash(std::span<const type_name> types) -> std::size_t;
-using type_hash = decltype([](const type_name& t) { return anzu::hash(t); });
 
 // Used for resolving template types. In the future could also be used for type aliases
 using template_map = std::unordered_map<std::string, type_name>;
@@ -223,5 +222,14 @@ struct std::formatter<anzu::type_name> : std::formatter<std::string>
 {
     auto format(const anzu::type_name& type, auto& ctx) const {
         return std::formatter<std::string>::format(anzu::to_string(type), ctx);
+    }
+};
+
+template<>
+struct std::hash<anzu::type_name>
+{
+    auto operator()(const anzu::type_name& name) const -> std::size_t
+    {
+        return anzu::hash(name);
     }
 };


### PR DESCRIPTION
* Objects from other modules can now only be accessed as fields on the delcared module object, essentially namespacing the objects in them.
* Only global variables, (template) structs and (template) functions are exposed publicly from modules.
* You cannot access other modules though modules, so no transitivity at all.
* Major refactor of the compiler which is now much more maintainable.
    * Factored out code for fetching functions and structs by name, and all template instantiation happens in there, so templates don't need to be reasoned about in the rest of the compiler.
    * There are now proper "name" structs to act as keys for the template maps and struct maps, rather than stringifying everything, which was hard to maintain.
    * `type_struct` is now used more heavily in places, and also contains the module and templates for the struct.