### PR TITLE
Compile Time Booleans (Part 1)

### DIFF
--- a/examples/test.az
+++ b/examples/test.az
@@ -1,11 +1,7 @@
 
 fn is_integer!(T)() -> bool
 {
-    if T == i64 {
-        return true;
-    } else {
-        return false;
-    }
+    return T == i64;
 }
 
 print("{}\n", is_integer!(i64)());

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,12 +1,4 @@
-struct fake_array
-{
-    size: u64;
+let x := bool == i64;
+let y := f64 == f64;
 
-    fn length(self: &) -> u64
-    {
-        return self.size;
-    }
-}
-
-let fa := fake_array(12u);
-print("{}\n", len(fa));
+print("__dump_type", x, y);

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,4 +1,12 @@
-let x := bool == i64;
-let y := f64 == f64;
 
-print("__dump_type", x, y);
+fn is_integer!(T)() -> bool
+{
+    if T == i64 {
+        return true;
+    } else {
+        return false;
+    }
+}
+
+print("{}\n", is_integer!(i64)());
+print("{}\n", is_integer!(u64)());

--- a/src/compilation/type_manager.cpp
+++ b/src/compilation/type_manager.cpp
@@ -28,7 +28,8 @@ auto type_manager::contains(const type_name& type) const -> bool
         [&](const type_bound_method&)         { return true; },
         [&](const type_arena&)                { return true; },
         [&](const type_type& t)               { return contains(*t.type_val); },
-        [&](const type_module&)               { return true; }
+        [&](const type_module&)               { return true; },
+        [&](const type_ct_bool&)              { return true; }
     }, type);
 }
 
@@ -75,19 +76,22 @@ auto type_manager::size_of(const type_name& type) const -> std::size_t
         [](const type_function_ptr&) {
             return sizeof(std::byte*);
         },
-        [](const type_builtin&) {
-            return std::size_t{0}; // not a real type, all info is stored in the type
-        },
         [](const type_bound_method&) {
             return sizeof(std::byte*); // pointer to the object, first arg to the function
         },
         [](const type_arena& arena) {
             return sizeof(std::byte*); // the runtime will store the arena separately
         },
+        [](const type_builtin&) {
+            return std::size_t{0};
+        },
         [](const type_type&) {
             return std::size_t{0}; 
         },
         [](const type_module&) {
+            return std::size_t{0}; 
+        },
+        [](const type_ct_bool&) {
             return std::size_t{0}; 
         }
     }, type);

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -584,7 +584,11 @@ auto push_expr(compiler& com, compile_type ct, const node_binary_op_expr& node) 
 
     // Allow for comparisons of types
     if (lhs.is_type_value() && rhs.is_type_value()) {
-        return type_name{type_ct_bool{inner_type(lhs) == inner_type(rhs)}};
+        switch (node.token.type) {
+            case tt::equal_equal: return type_name{type_ct_bool{inner_type(lhs) == inner_type(rhs)}};
+            case tt::bang_equal:  return type_name{type_ct_bool{inner_type(lhs) != inner_type(rhs)}};
+        }
+        node.token.error("could not find op '{} {} {}'", lhs, node.token.type, rhs);
     }
 
     // Pointers can compare to nullptr

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -1303,9 +1303,18 @@ void push_stmt(compiler& com, const node_for_stmt& node)
 
 void push_stmt(compiler& com, const node_if_stmt& node)
 {
+    const auto type = type_of_expr(com, *node.condition);
+    if (std::holds_alternative<type_ct_bool>(type)) {
+        if (std::get<type_ct_bool>(type).value) {
+            push_stmt(com, *node.body);
+        } else if (node.else_body) {
+            push_stmt(com, *node.else_body);
+        }
+        return;
+    }
+
     const auto cond_type = push_expr(com, compile_type::val, *node.condition);
     node.token.assert_eq(cond_type, bool_type(), "if-stmt invalid condition");
-
     push_value(code(com), op::jump_if_false);
     const auto jump_pos = push_value(code(com), std::uint64_t{0});
     push_stmt(com, *node.body);

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -582,6 +582,7 @@ auto push_expr(compiler& com, compile_type ct, const node_binary_op_expr& node) 
     auto lhs = push_expr(com, compile_type::val, *node.lhs);
     auto rhs = push_expr(com, compile_type::val, *node.rhs);
 
+    // Allow for comparisons of types
     if (lhs.is_type_value() && rhs.is_type_value()) {
         return type_name{type_ct_bool{inner_type(lhs) == inner_type(rhs)}};
     }

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -236,6 +236,7 @@ auto const_convertable_to(const token& tok, const type_name& src, const type_nam
         [&](const type_arena& l, const type_arena& r) { return true; },
         [&](const type_type& l, const type_type& r) { return l == r; },
         [&](const type_module& l, const type_module& r) { return l == r; },
+        [&](const type_ct_bool& l, const type_ct_bool& r) { return l == r; },
         [&](const auto& l, const auto& r) {
             return false;
         }

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -147,6 +147,11 @@ auto to_string(const type_module& type) -> std::string
     return std::format("<module: {}>", type.filepath.string());
 }
 
+auto to_string(const type_ct_bool& type) -> std::string
+{
+    return std::format("<comptime bool: {}>", type.value);
+}
+
 
 auto hash(const type_name& type) -> std::size_t
 {
@@ -218,6 +223,11 @@ auto hash(const type_type& type) -> std::size_t
 auto hash(const type_module& type) -> std::size_t
 {
     return std::hash<std::string>{}(type.filepath.string()) ^ std::hash<std::string_view>{}("type_module");
+}
+
+auto hash(const type_ct_bool& type) -> std::size_t
+{
+    return std::hash<bool>{}(type.value);
 }
 
 auto hash(std::span<const type_name> types) -> std::size_t

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -102,6 +102,12 @@ struct type_module
     auto operator==(const type_module&) const -> bool = default;
 };
 
+struct type_ct_bool
+{
+    bool value;
+    auto operator==(const type_ct_bool&) const -> bool = default;
+};
+
 
 struct type_name : public std::variant<
     type_fundamental,
@@ -109,12 +115,13 @@ struct type_name : public std::variant<
     type_array,
     type_ptr,
     type_span,
-    type_function_ptr,
-    type_builtin,
-    type_bound_method,
     type_arena,
+    type_function_ptr,
+    type_bound_method,
+    type_builtin,
     type_type,
-    type_module>
+    type_module,
+    type_ct_bool>
 {
     using variant::variant;
     
@@ -161,6 +168,7 @@ auto hash(const type_bound_method& type) -> std::size_t;
 auto hash(const type_arena& type) -> std::size_t;
 auto hash(const type_type& type) -> std::size_t;
 auto hash(const type_module& type) -> std::size_t;
+auto hash(const type_ct_bool& type) -> std::size_t;
 auto hash(std::span<const type_name> types) -> std::size_t;
 
 // Used for resolving template types. In the future could also be used for type aliases
@@ -196,6 +204,7 @@ auto to_string(const type_bound_method& type) -> std::string;
 auto to_string(const type_arena& type) -> std::string;
 auto to_string(const type_type& type) -> std::string;
 auto to_string(const type_module& type) -> std::string;
+auto to_string(const type_ct_bool& type) -> std::string;
 
 }
 


### PR DESCRIPTION
* Added the equivalent of `std::true_type` and `std::false_type`.
* Made it possible to compare types in a binary operation with `==` and `!=`, which results in a compile time bool.
* If an if statement condition is a compile time bool, only the true branch is compiled and the condition and other branch are left out of the program.
* Use `push_copy_typechecked` for return values, and allow it to decay a compile time bool into a runtime bool, allowing for compile time bools to be used as the return values from functions returning bool.
* Future changes are needed to allow for compile time bools in all places where regular bools are.
* With this, the true and false literals can be classed as compile time bools, which they currently are not, but the main goal for this was the if statement logic.