### PR TITLE
Intrinsic Functions

### DIFF
--- a/anzu-lang/syntaxes/anzu.tmLanguage.json
+++ b/anzu-lang/syntaxes/anzu.tmLanguage.json
@@ -17,7 +17,7 @@
 		},
 		{
 			"name": "keyword.other.anzu",
-			"match": "\\b(in|fn|struct|sizeof|typeof|new|delete|default|import|assert)\\b"
+			"match": "\\b(in|fn|struct|new|delete|default|import|assert)\\b"
 		},
 		{
 			"name": "storage.type.anzu",

--- a/examples/feature_test.az
+++ b/examples/feature_test.az
@@ -152,13 +152,13 @@ fn print_vec2(v: vec2) -> null
 {
     var xl := [1, 2, 3, 4];
     xl[2u] = 0;
-    print("Size of array is 4: {}\n", sizeof(xl));
+    print("Size of array is 4: {}\n", @size_of(xl));
 
     let xl2 := [vec2(1, 2), vec2(3, 4)];
     print(
         "xl2 should have size 32 but length 2: size={} length={}\n",
-        sizeof(xl2),
-        sizeof(xl2) / sizeof(xl2[0u])
+        @size_of(xl2),
+        @size_of(xl2) / @size_of(xl2[0u])
     );
 }
 
@@ -195,7 +195,7 @@ struct vec3
     let b := [1, 1, 1, 1, 1];
 
     var idx := 0u;
-    while idx != sizeof(a) / sizeof(a[0u]) {
+    while idx != @size_of(a) / @size_of(a[0u]) {
         print("{}\n", a[idx] == b[idx]);
         idx = idx + 1u;
     }

--- a/examples/feature_test.az
+++ b/examples/feature_test.az
@@ -210,19 +210,19 @@ struct vec3
     }
 }
 
-# typeof operator
+# @type_of function
 let variable := 0;
-fn typeof_example(y: typeof(variable)) -> i64
+fn typ_eof_example(y: @type_of(variable)) -> i64
 {
     return y + y;
 }
-print("{}\n", typeof_example(3)); # no error here!
+print("{}\n", type_of_example(3)); # no error here!
 
-fn typeof_example2(a: u64) -> typeof(a)
+fn type_of_example2(a: u64) -> @type_of(a)
 {
     return a * a;
 }
-print("{}\n", typeof_example2(6u));
+print("{}\n", type_of_example2(6u));
 
 {
     var v1 := vec3(1.0, 1.0, 1.0);

--- a/examples/feature_test.az
+++ b/examples/feature_test.az
@@ -212,7 +212,7 @@ struct vec3
 
 # @type_of function
 let variable := 0;
-fn typ_eof_example(y: @type_of(variable)) -> i64
+fn type_of_example(y: @type_of(variable)) -> i64
 {
     return y + y;
 }

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,3 +1,3 @@
-let x := [1, 2, 3, 4, 5, 6];
-
-print("{}\n", @size_of(x));
+let c := '1';
+let x := @char_to_i64(c);
+print("{}\n", x);

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,11 +1,3 @@
-module str := "lib/str.az";
-module io := "lib/io.az";
+let x := [1, 2, 3, 4, 5, 6];
 
-arena a;
-let input := io.read_file("examples/aoc2023-1-input.txt", a&);
-var tok := str.tokenizer.create(input, "\n");
-
-while tok.valid() {
-    print("1. {}\n", tok.current());
-    tok.advance();
-}
+print("{}\n", @size_of(x));

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,3 +1,18 @@
-let c := '1';
-let x := @char_to_i64(c);
-print("{}\n", x);
+
+fn f() -> bool
+{
+    print("false\n");
+    return false;
+}
+
+fn t() -> bool
+{
+    print("true\n");
+    return true;
+}
+
+if (t() && t()) {
+    print("success\n");
+} else {
+    print("not success\n");
+}

--- a/examples/test.az
+++ b/examples/test.az
@@ -11,7 +11,7 @@ fn t() -> bool
     return true;
 }
 
-if (t() && t()) {
+if (f() || t()) {
     print("success\n");
 } else {
     print("not success\n");

--- a/lib/str.az
+++ b/lib/str.az
@@ -122,18 +122,11 @@ fn replace(a: arena&, string: char const[], from: char const[], to: char const[]
 
 fn is_digit(c: char) -> bool
 {
-    for x in "0123456789" {
-        if c == x@ { return true; }
-    }
-    return false;
+    let x := @char_to_i64(c);
+    return 47 < x && x < 58;
 }
 
 fn to_i64(c: char) -> i64
 {
-    var value := 0;
-    for x in "0123456789" {
-        if c == x@ { return value; }
-        value = value + 1;
-    }
-    return -1;
+    return @char_to_i64(c) - 48;
 }

--- a/lib/str.az
+++ b/lib/str.az
@@ -91,11 +91,6 @@ fn occurrences(string: char const[], substr: char const[]) -> u64
     return count;
 }
 
-fn copy(dst: char[], src: char const[])
-{
-    util.copy!(char)(dst, src);
-}
-
 fn replace(a: arena&, string: char const[], from: char const[], to: char const[]) -> char const[]
 {
     let new_size := len(from) == len(to) ? len(string)
@@ -107,17 +102,17 @@ fn replace(a: arena&, string: char const[], from: char const[], to: char const[]
     assert tok.valid(); # There is always at least one token (it may be the whole string)
     let curr := tok.current();
     let size := len(curr);
-    copy(new_string[idx : idx + size], tok.current());
+    @copy(new_string[idx : idx + size], tok.current());
     idx = idx + size;
     tok.advance();
 
     while tok.valid() {
-        copy(new_string[idx : idx + len(to)], to);
+        @copy(new_string[idx : idx + len(to)], to);
         idx = idx + len(to);
 
         let curr := tok.current();
         let size := len(curr);
-        copy(new_string[idx : idx + size], tok.current());
+        @copy(new_string[idx : idx + size], tok.current());
         idx = idx + size;
         tok.advance();
     }

--- a/lib/str.az
+++ b/lib/str.az
@@ -120,13 +120,11 @@ fn replace(a: arena&, string: char const[], from: char const[], to: char const[]
     return new_string;
 }
 
-fn is_digit(c: char) -> bool
-{
-    let x := @char_to_i64(c);
-    return 47 < x && x < 58;
-}
-
 fn to_i64(c: char) -> i64
 {
-    return @char_to_i64(c) - 48;
+    let x := @char_to_i64(c);
+    if 47 < x && x < 58 {
+        return x - 48;
+    }
+    return -1;
 }

--- a/lib/utility.az
+++ b/lib/utility.az
@@ -4,16 +4,6 @@ struct pair!(A, B)
     second: B;
 }
 
-fn copy!(T)(dst: T[], src: T const[])
-{
-    assert len(dst) >= len(src);
-    var idx := 0u;
-    while idx < len(src) {
-        dst[idx] = src[idx];
-        idx = idx + 1u;
-    }
-}
-
 fn safe_minus(lhs: u64, rhs: u64) -> u64
 {
     assert lhs >= rhs;

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -122,10 +122,6 @@ auto print_node(const node_expr& root, int indent) -> void
                 print_node(*node.upper_bound, indent + 1);
             }
         },
-        [&](const node_typeof_expr& node) {
-            std::print("{}TypeOf\n", spaces);
-            print_node(*node.expr, indent + 1);
-        },
         [&](const node_function_ptr_type_expr& node) {
             std::print("{}FunctionPtrType:\n", spaces);
             std::print("{}- Params:\n", spaces);

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -98,10 +98,6 @@ auto print_node(const node_expr& root, int indent) -> void
             std::print("{}Deref:\n", spaces);
             print_node(*node.expr, indent + 1);
         },
-        [&](const node_sizeof_expr& node) {
-            std::print("{}SizeOf:\n", spaces);
-            print_node(*node.expr, indent + 1);
-        },
         [&](const node_len_expr& node) {
             std::print("{}Len:\n", spaces);
             print_node(*node.expr, indent + 1);

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -164,6 +164,14 @@ auto print_node(const node_expr& root, int indent) -> void
             print_node(*node.true_case, indent + 1);
             std::print("{}- FalseCase:\n", spaces);
             print_node(*node.false_case, indent + 1);
+        },
+        [&](const node_intrinsic_expr& node) {
+            std::print("{}Intrinsic:\n", spaces);
+            std::print("{}- Name: @{}\n", spaces, node.name);
+            std::print("{}- Args:\n", spaces);
+            for (const auto& arg : node.args) {
+                print_node(*arg, indent + 1);
+            }
         }
     }, root);
 }

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -160,13 +160,6 @@ struct node_span_expr
     anzu::token token;
 };
 
-struct node_typeof_expr
-{
-    node_expr_ptr expr;
-
-    anzu::token token;
-};
-
 struct node_function_ptr_type_expr
 {
     std::vector<node_expr_ptr> params;
@@ -227,7 +220,6 @@ struct node_expr : std::variant<
     node_addrof_expr,
     node_len_expr,
     node_span_expr,
-    node_typeof_expr,
     node_function_ptr_type_expr,
     node_const_expr,
     node_name_expr,

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -136,13 +136,6 @@ struct node_deref_expr
     anzu::token token;
 };
 
-struct node_sizeof_expr
-{
-    node_expr_ptr expr;
-
-    anzu::token token;
-};
-
 struct node_len_expr
 {
     node_expr_ptr expr;
@@ -232,7 +225,6 @@ struct node_expr : std::variant<
     node_array_expr,
     node_repeat_array_expr,
     node_addrof_expr,
-    node_sizeof_expr,
     node_len_expr,
     node_span_expr,
     node_typeof_expr,

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -208,6 +208,14 @@ struct node_ternary_expr
     anzu::token   token;
 };
 
+struct node_intrinsic_expr
+{
+    std::string                name;
+    std::vector<node_expr_ptr> args;
+
+    anzu::token   token;
+};
+
 struct node_expr : std::variant<
     node_literal_i32_expr,
     node_literal_i64_expr,
@@ -235,7 +243,8 @@ struct node_expr : std::variant<
     node_deref_expr,
     node_subscript_expr,
     node_new_expr,
-    node_ternary_expr>
+    node_ternary_expr,
+    node_intrinsic_expr>
 {
 };
 

--- a/src/bytecode.cpp
+++ b/src/bytecode.cpp
@@ -145,6 +145,9 @@ auto print_op(std::string_view rom, const std::byte* start, const std::byte* ptr
             const auto data = &rom[index];
             std::print("ASSERT: msg={}\n", std::string_view{data, size});
         } break;
+        case op::char_to_i64: {
+            std::print("CHAR_TO_I64\n");
+        } break;
         case op::char_eq: { std::print("CHAR_EQ\n"); } break;
         case op::char_ne: { std::print("CHAR_NE\n"); } break;
         case op::i32_add: { std::print("I32_ADD\n"); } break;

--- a/src/bytecode.cpp
+++ b/src/bytecode.cpp
@@ -113,6 +113,10 @@ auto print_op(std::string_view rom, const std::byte* start, const std::byte* ptr
             const auto size = read_at<std::uint64_t>(&ptr);
             std::print("POP: {}\n", size);
         } break;
+        case op::memcpy: {
+            const auto size = read_at<std::uint64_t>(&ptr);
+            std::print("POP: {}\n", size);
+        } break;
         case op::jump: {
             const auto jump = read_at<std::uint64_t>(&ptr);
             std::print("JUMP: jump={}\n", jump);

--- a/src/bytecode.cpp
+++ b/src/bytecode.cpp
@@ -197,8 +197,6 @@ auto print_op(std::string_view rom, const std::byte* start, const std::byte* ptr
         case op::f64_le:  { std::print("F64_LE\n"); } break;
         case op::f64_gt:  { std::print("F64_GT\n"); } break;
         case op::f64_ge:  { std::print("F64_GE\n"); } break;
-        case op::bool_and: { std::print("BOOL_AND\n"); } break;
-        case op::bool_or:  { std::print("BOOL_OR\n"); } break;
         case op::bool_eq:  { std::print("BOOL_EQ\n"); } break;
         case op::bool_ne:  { std::print("BOOL_NE\n"); } break;
         case op::bool_not: { std::print("BOOL_NOT\n"); } break;

--- a/src/bytecode.cpp
+++ b/src/bytecode.cpp
@@ -121,6 +121,10 @@ auto print_op(std::string_view rom, const std::byte* start, const std::byte* ptr
             const auto jump = read_at<std::uint64_t>(&ptr);
             std::print("JUMP: jump={}\n", jump);
         } break;
+        case op::jump_if_true: {
+            const auto jump = read_at<std::uint64_t>(&ptr);
+            std::print("JUMP_IF_TRUE: jump={}\n", jump);
+        } break;
         case op::jump_if_false: {
             const auto jump = read_at<std::uint64_t>(&ptr);
             std::print("JUMP_IF_FALSE: jump={}\n", jump);

--- a/src/bytecode.hpp
+++ b/src/bytecode.hpp
@@ -50,6 +50,7 @@ enum class op : std::uint8_t
     save,
     push,
     pop,
+    memcpy,
     jump,
     jump_if_false,
     call,

--- a/src/bytecode.hpp
+++ b/src/bytecode.hpp
@@ -58,6 +58,8 @@ enum class op : std::uint8_t
     ret,
     assert,
 
+    char_to_i64,
+
     char_eq,
     char_ne,
 

--- a/src/bytecode.hpp
+++ b/src/bytecode.hpp
@@ -111,8 +111,6 @@ enum class op : std::uint8_t
     f64_gt,
     f64_ge,
 
-    bool_or,
-    bool_and,
     bool_eq,
     bool_ne,
     bool_not,

--- a/src/bytecode.hpp
+++ b/src/bytecode.hpp
@@ -52,6 +52,7 @@ enum class op : std::uint8_t
     pop,
     memcpy,
     jump,
+    jump_if_true,
     jump_if_false,
     call,
     builtin_call,

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -802,18 +802,6 @@ auto push_expr(compiler& com, compile_type ct, const node_addrof_expr& node) -> 
     return type.add_ptr();
 }
 
-auto push_expr(compiler& com, compile_type ct, const node_sizeof_expr& node) -> type_name
-{
-    node.token.assert(ct == compile_type::val, "cannot take the address of a sizeof expression");
-    const auto type = type_of_expr(com, *node.expr);
-    if (type.is_type_value()) { // can call sizeof on a type directly
-        push_value(code(com), op::push_u64, com.types.size_of(inner_type(type)));
-    } else {
-        push_value(code(com), op::push_u64, com.types.size_of(type));
-    }
-    return u64_type();
-}
-
 auto push_expr(compiler& com, compile_type ct, const node_len_expr& node) -> type_name
 {
     node.token.assert(ct == compile_type::val, "cannot take the address of a len expression");

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -1221,6 +1221,13 @@ auto push_expr(compiler& com, compile_type ct, const node_intrinsic_expr& node) 
         push_value(code(com), op::memcpy, com.types.size_of(inner_type(lhs)));
         return null_type();
     }
+    if (node.name == "char_to_i64") {
+        node.token.assert_eq(node.args.size(), 1, "@char_to_i64 only accepts one argument");
+        const auto type = push_expr(com, ct, *node.args[0]);
+        node.token.assert_eq(type, char_type(), "@char_to_i64 bad first arg of type '{}'", type);
+        push_value(code(com), op::char_to_i64);
+        return i64_type();
+    }
     node.token.error("no intrisic function named @{} exists", node.name);
 }
 

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -696,9 +696,20 @@ auto push_expr(compiler& com, compile_type ct, const node_binary_op_expr& node) 
                 write_value(code(com), jump_pos2, code(com).size());
                 return type;
             }
-            case tt::bar_bar:             { push(); push_value(code(com), op::bool_or);  return type; }
-            case tt::equal_equal:         { push(); push_value(code(com), op::bool_eq);  return type; }
-            case tt::bang_equal:          { push(); push_value(code(com), op::bool_ne);  return type; }
+            case tt::bar_bar: {
+                push_expr(com, compile_type::val, *node.lhs);
+                push_value(code(com), op::jump_if_true);
+                const auto jump_pos = push_value(code(com), std::size_t{0});
+                push_expr(com, compile_type::val, *node.rhs);
+                push_value(code(com), op::jump);
+                const auto jump_pos2 = push_value(code(com), std::size_t{0});
+                write_value(code(com), jump_pos, code(com).size());
+                push_value(code(com), op::push_bool, true);
+                write_value(code(com), jump_pos2, code(com).size());
+                return type;
+            }
+            case tt::equal_equal: { push(); push_value(code(com), op::bool_eq);  return type; }
+            case tt::bang_equal:  { push(); push_value(code(com), op::bool_ne);  return type; }
         }
     }
 

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -708,8 +708,8 @@ auto push_expr(compiler& com, compile_type ct, const node_binary_op_expr& node) 
                 write_value(code(com), jump_pos2, code(com).size());
                 return type;
             }
-            case tt::equal_equal: { push(); push_value(code(com), op::bool_eq);  return type; }
-            case tt::bang_equal:  { push(); push_value(code(com), op::bool_ne);  return type; }
+            case tt::equal_equal: { push(); push_value(code(com), op::bool_eq); return type; }
+            case tt::bang_equal:  { push(); push_value(code(com), op::bool_ne); return type; }
         }
     }
 

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -1211,6 +1211,10 @@ auto push_expr(compiler& com, compile_type ct, const node_ternary_expr& node) ->
     return type;
 }
 
+auto push_expr(compiler& com, compile_type ct, const node_intrinsic_expr& name) -> type_name
+{
+    return null_type();
+}
 
 void push_stmt(compiler& com, const node_sequence_stmt& node)
 {

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -684,7 +684,18 @@ auto push_expr(compiler& com, compile_type ct, const node_binary_op_expr& node) 
     }
     else if (type == bool_type()) {
         switch (node.token.type) {
-            case tt::ampersand_ampersand: { push(); push_value(code(com), op::bool_and); return type; }
+            case tt::ampersand_ampersand: {
+                push_expr(com, compile_type::val, *node.lhs);
+                push_value(code(com), op::jump_if_false);
+                const auto jump_pos = push_value(code(com), std::size_t{0});
+                push_expr(com, compile_type::val, *node.rhs);
+                push_value(code(com), op::jump);
+                const auto jump_pos2 = push_value(code(com), std::size_t{0});
+                write_value(code(com), jump_pos, code(com).size());
+                push_value(code(com), op::push_bool, false);
+                write_value(code(com), jump_pos2, code(com).size());
+                return type;
+            }
             case tt::bar_bar:             { push(); push_value(code(com), op::bool_or);  return type; }
             case tt::equal_equal:         { push(); push_value(code(com), op::bool_eq);  return type; }
             case tt::bang_equal:          { push(); push_value(code(com), op::bool_ne);  return type; }

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -582,8 +582,13 @@ auto push_expr(compiler& com, compile_type ct, const node_binary_op_expr& node) 
 {
     node.token.assert(ct == compile_type::val, "cannot take the address of a binary op");
     using tt = token_type;
-    auto lhs = push_expr(com, compile_type::val, *node.lhs);
-    auto rhs = push_expr(com, compile_type::val, *node.rhs);
+    auto lhs = type_of_expr(com, *node.lhs);
+    auto rhs = type_of_expr(com, *node.rhs);
+
+    const auto push = [&] {
+        push_expr(com, compile_type::val, *node.lhs);
+        push_expr(com, compile_type::val, *node.rhs);
+    };
 
     // Allow for comparisons of types
     if (lhs.is_type_value() && rhs.is_type_value()) {
@@ -597,8 +602,8 @@ auto push_expr(compiler& com, compile_type ct, const node_binary_op_expr& node) 
     // Pointers can compare to nullptr
     if ((lhs.is_ptr() && rhs == nullptr_type()) || (rhs.is_ptr() && lhs == nullptr_type())) {
         switch (node.token.type) {
-            case tt::equal_equal: { push_value(code(com), op::u64_eq); return bool_type(); }
-            case tt::bang_equal:  { push_value(code(com), op::u64_ne); return bool_type(); }
+            case tt::equal_equal: { push(); push_value(code(com), op::u64_eq); return bool_type(); }
+            case tt::bang_equal:  { push(); push_value(code(com), op::u64_ne); return bool_type(); }
         }
         node.token.error("could not find op '{} {} {}'", lhs, node.token.type, rhs);
     }
@@ -608,81 +613,81 @@ auto push_expr(compiler& com, compile_type ct, const node_binary_op_expr& node) 
 
     if (type.is_ptr()) {
         switch (node.token.type) {
-            case tt::equal_equal: { push_value(code(com), op::u64_eq); return bool_type(); }
-            case tt::bang_equal:  { push_value(code(com), op::u64_ne); return bool_type(); }
+            case tt::equal_equal: { push(); push_value(code(com), op::u64_eq); return bool_type(); }
+            case tt::bang_equal:  { push(); push_value(code(com), op::u64_ne); return bool_type(); }
         }
     }
     else if (type == char_type()) {
         switch (node.token.type) {
-            case tt::equal_equal: { push_value(code(com), op::char_eq); return bool_type(); }
-            case tt::bang_equal:  { push_value(code(com), op::char_ne); return bool_type(); }
+            case tt::equal_equal: { push(); push_value(code(com), op::char_eq); return bool_type(); }
+            case tt::bang_equal:  { push(); push_value(code(com), op::char_ne); return bool_type(); }
         }
     }
     else if (type == i32_type()) {
         switch (node.token.type) {
-            case tt::plus:          { push_value(code(com), op::i32_add); return type;       }
-            case tt::minus:         { push_value(code(com), op::i32_sub); return type;       }
-            case tt::star:          { push_value(code(com), op::i32_mul); return type;       }
-            case tt::slash:         { push_value(code(com), op::i32_div); return type;       }
-            case tt::percent:       { push_value(code(com), op::i32_mod); return type;       }
-            case tt::equal_equal:   { push_value(code(com), op::i32_eq); return bool_type(); }
-            case tt::bang_equal:    { push_value(code(com), op::i32_ne); return bool_type(); }
-            case tt::less:          { push_value(code(com), op::i32_lt); return bool_type(); }
-            case tt::less_equal:    { push_value(code(com), op::i32_le); return bool_type(); }
-            case tt::greater:       { push_value(code(com), op::i32_gt); return bool_type(); }
-            case tt::greater_equal: { push_value(code(com), op::i32_ge); return bool_type(); }
+            case tt::plus:          { push(); push_value(code(com), op::i32_add); return type;       }
+            case tt::minus:         { push(); push_value(code(com), op::i32_sub); return type;       }
+            case tt::star:          { push(); push_value(code(com), op::i32_mul); return type;       }
+            case tt::slash:         { push(); push_value(code(com), op::i32_div); return type;       }
+            case tt::percent:       { push(); push_value(code(com), op::i32_mod); return type;       }
+            case tt::equal_equal:   { push(); push_value(code(com), op::i32_eq); return bool_type(); }
+            case tt::bang_equal:    { push(); push_value(code(com), op::i32_ne); return bool_type(); }
+            case tt::less:          { push(); push_value(code(com), op::i32_lt); return bool_type(); }
+            case tt::less_equal:    { push(); push_value(code(com), op::i32_le); return bool_type(); }
+            case tt::greater:       { push(); push_value(code(com), op::i32_gt); return bool_type(); }
+            case tt::greater_equal: { push(); push_value(code(com), op::i32_ge); return bool_type(); }
         }
     }
     else if (type == i64_type()) {
         switch (node.token.type) {
-            case tt::plus:          { push_value(code(com), op::i64_add); return type;       }
-            case tt::minus:         { push_value(code(com), op::i64_sub); return type;       }
-            case tt::star:          { push_value(code(com), op::i64_mul); return type;       }
-            case tt::slash:         { push_value(code(com), op::i64_div); return type;       }
-            case tt::percent:       { push_value(code(com), op::i64_mod); return type;       }
-            case tt::equal_equal:   { push_value(code(com), op::i64_eq); return bool_type(); }
-            case tt::bang_equal:    { push_value(code(com), op::i64_ne); return bool_type(); }
-            case tt::less:          { push_value(code(com), op::i64_lt); return bool_type(); }
-            case tt::less_equal:    { push_value(code(com), op::i64_le); return bool_type(); }
-            case tt::greater:       { push_value(code(com), op::i64_gt); return bool_type(); }
-            case tt::greater_equal: { push_value(code(com), op::i64_ge); return bool_type(); }
+            case tt::plus:          { push(); push_value(code(com), op::i64_add); return type;       }
+            case tt::minus:         { push(); push_value(code(com), op::i64_sub); return type;       }
+            case tt::star:          { push(); push_value(code(com), op::i64_mul); return type;       }
+            case tt::slash:         { push(); push_value(code(com), op::i64_div); return type;       }
+            case tt::percent:       { push(); push_value(code(com), op::i64_mod); return type;       }
+            case tt::equal_equal:   { push(); push_value(code(com), op::i64_eq); return bool_type(); }
+            case tt::bang_equal:    { push(); push_value(code(com), op::i64_ne); return bool_type(); }
+            case tt::less:          { push(); push_value(code(com), op::i64_lt); return bool_type(); }
+            case tt::less_equal:    { push(); push_value(code(com), op::i64_le); return bool_type(); }
+            case tt::greater:       { push(); push_value(code(com), op::i64_gt); return bool_type(); }
+            case tt::greater_equal: { push(); push_value(code(com), op::i64_ge); return bool_type(); }
         }
     }
     else if (type == u64_type()) {
         switch (node.token.type) {
-            case tt::plus:          { push_value(code(com), op::u64_add); return type;       }
-            case tt::minus:         { push_value(code(com), op::u64_sub); return type;       }
-            case tt::star:          { push_value(code(com), op::u64_mul); return type;       }
-            case tt::slash:         { push_value(code(com), op::u64_div); return type;       }
-            case tt::percent:       { push_value(code(com), op::u64_mod); return type;       }
-            case tt::equal_equal:   { push_value(code(com), op::u64_eq); return bool_type(); }
-            case tt::bang_equal:    { push_value(code(com), op::u64_ne); return bool_type(); }
-            case tt::less:          { push_value(code(com), op::u64_lt); return bool_type(); }
-            case tt::less_equal:    { push_value(code(com), op::u64_le); return bool_type(); }
-            case tt::greater:       { push_value(code(com), op::u64_gt); return bool_type(); }
-            case tt::greater_equal: { push_value(code(com), op::u64_ge); return bool_type(); }
+            case tt::plus:          { push(); push_value(code(com), op::u64_add); return type;       }
+            case tt::minus:         { push(); push_value(code(com), op::u64_sub); return type;       }
+            case tt::star:          { push(); push_value(code(com), op::u64_mul); return type;       }
+            case tt::slash:         { push(); push_value(code(com), op::u64_div); return type;       }
+            case tt::percent:       { push(); push_value(code(com), op::u64_mod); return type;       }
+            case tt::equal_equal:   { push(); push_value(code(com), op::u64_eq); return bool_type(); }
+            case tt::bang_equal:    { push(); push_value(code(com), op::u64_ne); return bool_type(); }
+            case tt::less:          { push(); push_value(code(com), op::u64_lt); return bool_type(); }
+            case tt::less_equal:    { push(); push_value(code(com), op::u64_le); return bool_type(); }
+            case tt::greater:       { push(); push_value(code(com), op::u64_gt); return bool_type(); }
+            case tt::greater_equal: { push(); push_value(code(com), op::u64_ge); return bool_type(); }
         }
     }
     else if (type == f64_type()) {
         switch (node.token.type) {
-            case tt::plus:          { push_value(code(com), op::f64_add); return type;       }
-            case tt::minus:         { push_value(code(com), op::f64_sub); return type;       }
-            case tt::star:          { push_value(code(com), op::f64_mul); return type;       }
-            case tt::slash:         { push_value(code(com), op::f64_div); return type;       }
-            case tt::equal_equal:   { push_value(code(com), op::f64_eq); return bool_type(); }
-            case tt::bang_equal:    { push_value(code(com), op::f64_ne); return bool_type(); }
-            case tt::less:          { push_value(code(com), op::f64_lt); return bool_type(); }
-            case tt::less_equal:    { push_value(code(com), op::f64_le); return bool_type(); }
-            case tt::greater:       { push_value(code(com), op::f64_gt); return bool_type(); }
-            case tt::greater_equal: { push_value(code(com), op::f64_ge); return bool_type(); }
+            case tt::plus:          { push(); push_value(code(com), op::f64_add); return type;       }
+            case tt::minus:         { push(); push_value(code(com), op::f64_sub); return type;       }
+            case tt::star:          { push(); push_value(code(com), op::f64_mul); return type;       }
+            case tt::slash:         { push(); push_value(code(com), op::f64_div); return type;       }
+            case tt::equal_equal:   { push(); push_value(code(com), op::f64_eq); return bool_type(); }
+            case tt::bang_equal:    { push(); push_value(code(com), op::f64_ne); return bool_type(); }
+            case tt::less:          { push(); push_value(code(com), op::f64_lt); return bool_type(); }
+            case tt::less_equal:    { push(); push_value(code(com), op::f64_le); return bool_type(); }
+            case tt::greater:       { push(); push_value(code(com), op::f64_gt); return bool_type(); }
+            case tt::greater_equal: { push(); push_value(code(com), op::f64_ge); return bool_type(); }
         }
     }
     else if (type == bool_type()) {
         switch (node.token.type) {
-            case tt::ampersand_ampersand: { push_value(code(com), op::bool_and); return type; }
-            case tt::bar_bar:             { push_value(code(com), op::bool_or);  return type; }
-            case tt::equal_equal:         { push_value(code(com), op::bool_eq);  return type; }
-            case tt::bang_equal:          { push_value(code(com), op::bool_ne);  return type; }
+            case tt::ampersand_ampersand: { push(); push_value(code(com), op::bool_and); return type; }
+            case tt::bar_bar:             { push(); push_value(code(com), op::bool_or);  return type; }
+            case tt::equal_equal:         { push(); push_value(code(com), op::bool_eq);  return type; }
+            case tt::bang_equal:          { push(); push_value(code(com), op::bool_ne);  return type; }
         }
     }
 

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -82,7 +82,6 @@ auto identifier_type(std::string_view token) -> token_type
     if (token == "return")   return token_type::kw_return;
     if (token == "struct")   return token_type::kw_struct;
     if (token == "true")     return token_type::kw_true;
-    if (token == "typeof")   return token_type::kw_typeof;
     if (token == "u64")      return token_type::kw_u64;
     if (token == "var")      return token_type::kw_var;
     if (token == "while")    return token_type::kw_while;

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -80,7 +80,6 @@ auto identifier_type(std::string_view token) -> token_type
     if (token == "nullptr")  return token_type::kw_nullptr;
     if (token == "print")    return token_type::kw_print;
     if (token == "return")   return token_type::kw_return;
-    if (token == "sizeof")   return token_type::kw_sizeof;
     if (token == "struct")   return token_type::kw_struct;
     if (token == "true")     return token_type::kw_true;
     if (token == "typeof")   return token_type::kw_typeof;

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -172,16 +172,6 @@ auto parse_typeof(tokenstream& tokens) -> node_expr_ptr
     return node;
 }
 
-auto parse_sizeof(tokenstream& tokens) -> node_expr_ptr
-{
-    const auto token = tokens.consume_only(token_type::kw_sizeof);
-    tokens.consume_only(token_type::left_paren);
-    auto [node, inner] = new_node<node_sizeof_expr>(token);
-    inner.expr = parse_expression(tokens);
-    tokens.consume_only(token_type::right_paren);
-    return node;
-}
-
 auto parse_len(tokenstream& tokens) -> node_expr_ptr
 {
     const auto token = tokens.consume_only(token_type::kw_len);
@@ -423,7 +413,6 @@ static const auto rules = std::unordered_map<token_type, parse_rule>
     {token_type::kw_nullptr,          {parse_name,          nullptr,         precedence::none}},
     {token_type::kw_arena,            {parse_name,          nullptr,         precedence::none}},
     {token_type::kw_typeof,           {parse_typeof,        nullptr,         precedence::none}},
-    {token_type::kw_sizeof,           {parse_sizeof,        nullptr,         precedence::none}},
     {token_type::kw_len,              {parse_len,           nullptr,         precedence::none}},
     {token_type::left_bracket,        {parse_array,         parse_subscript, precedence::call}},
     {token_type::dot,                 {nullptr,             parse_dot,       precedence::call}},

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -162,16 +162,6 @@ auto parse_unary(tokenstream& tokens) -> node_expr_ptr
     return node;
 }
 
-auto parse_typeof(tokenstream& tokens) -> node_expr_ptr
-{
-    const auto token = tokens.consume_only(token_type::kw_typeof);
-    tokens.consume_only(token_type::left_paren);
-    auto [node, inner] = new_node<node_typeof_expr>(token);
-    inner.expr = parse_expression(tokens);
-    tokens.consume_only(token_type::right_paren);
-    return node;
-}
-
 auto parse_len(tokenstream& tokens) -> node_expr_ptr
 {
     const auto token = tokens.consume_only(token_type::kw_len);
@@ -412,7 +402,6 @@ static const auto rules = std::unordered_map<token_type, parse_rule>
     {token_type::kw_null,             {parse_name,          nullptr,         precedence::none}},
     {token_type::kw_nullptr,          {parse_name,          nullptr,         precedence::none}},
     {token_type::kw_arena,            {parse_name,          nullptr,         precedence::none}},
-    {token_type::kw_typeof,           {parse_typeof,        nullptr,         precedence::none}},
     {token_type::kw_len,              {parse_len,           nullptr,         precedence::none}},
     {token_type::left_bracket,        {parse_array,         parse_subscript, precedence::call}},
     {token_type::dot,                 {nullptr,             parse_dot,       precedence::call}},

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -105,6 +105,18 @@ auto apply_op(bytecode_context& ctx) -> bool
             const auto size = read_advance<std::uint64_t>(ctx);
             ctx.stack.resize(ctx.stack.size() - size);
         } break;
+        case op::memcpy: {
+            const auto type_size = read_advance<std::uint64_t>(ctx);
+            const auto src_count = ctx.stack.pop<std::uint64_t>(); 
+            const auto src_data = ctx.stack.pop<std::byte*>();
+            const auto dst_count = ctx.stack.pop<std::uint64_t>(); 
+            const auto dst_data = ctx.stack.pop<std::byte*>();
+            if (dst_count < src_count) {
+                runtime_error("dst span too small to hold src span");
+            }
+            std::memcpy(dst_data, src_data, src_count * type_size);
+            ctx.stack.push(std::byte{0}); // returns null;
+        } break;
         case op::arena_new: {
             const auto arena = new memory_arena;
             arena->next = 0;

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -220,6 +220,11 @@ auto apply_op(bytecode_context& ctx) -> bool
             }
         } break;
 
+        case op::char_to_i64: {
+            const auto value = ctx.stack.pop<char>();
+            ctx.stack.push(std::int64_t{value});
+        } break;
+
         case op::char_eq: { binary_op<char, std::equal_to>(ctx); } break;
         case op::char_ne: { binary_op<char, std::not_equal_to>(ctx); } break;
 

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -279,8 +279,6 @@ auto apply_op(bytecode_context& ctx) -> bool
         case op::f64_gt:  { binary_op<double, std::greater>(ctx); } break;
         case op::f64_ge:  { binary_op<double, std::greater_equal>(ctx); } break;
 
-        case op::bool_and: { binary_op<bool, std::logical_and>(ctx); } break;
-        case op::bool_or:  { binary_op<bool, std::logical_or>(ctx); } break;
         case op::bool_eq:  { binary_op<bool, std::equal_to>(ctx); } break;
         case op::bool_ne:  { binary_op<bool, std::not_equal_to>(ctx); } break;
         case op::bool_not: { unary_op<bool, std::logical_not>(ctx); } break;

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -185,6 +185,10 @@ auto apply_op(bytecode_context& ctx) -> bool
             const auto jump = read_advance<std::uint64_t>(ctx);
             frame.ip = &frame.code[jump];
         } break;
+        case op::jump_if_true: {
+            const auto jump = read_advance<std::uint64_t>(ctx);
+            if (ctx.stack.pop<bool>()) frame.ip = &frame.code[jump];
+        } break;
         case op::jump_if_false: {
             const auto jump = read_advance<std::uint64_t>(ctx);
             if (!ctx.stack.pop<bool>()) frame.ip = &frame.code[jump];

--- a/src/token.cpp
+++ b/src/token.cpp
@@ -70,7 +70,6 @@ auto to_string(token_type tt) -> std::string_view
         case token_type::kw_return:           return "return";
         case token_type::kw_struct:           return "struct";
         case token_type::kw_true:             return "true";
-        case token_type::kw_typeof:           return "typeof";
         case token_type::kw_u64:              return "u64";
         case token_type::kw_var:              return "var";
         case token_type::kw_while:            return "while";

--- a/src/token.cpp
+++ b/src/token.cpp
@@ -68,7 +68,6 @@ auto to_string(token_type tt) -> std::string_view
         case token_type::kw_nullptr:          return "nullptr";
         case token_type::kw_print:            return "print";
         case token_type::kw_return:           return "return";
-        case token_type::kw_sizeof:           return "sizeof";
         case token_type::kw_struct:           return "struct";
         case token_type::kw_true:             return "true";
         case token_type::kw_typeof:           return "typeof";

--- a/src/token.hpp
+++ b/src/token.hpp
@@ -58,7 +58,6 @@ enum class token_type
     kw_return,
     kw_struct,
     kw_true,
-    kw_typeof,
     kw_u64,
     kw_var,
     kw_while,

--- a/src/token.hpp
+++ b/src/token.hpp
@@ -56,7 +56,6 @@ enum class token_type
     kw_nullptr,
     kw_print,
     kw_return,
-    kw_sizeof,
     kw_struct,
     kw_true,
     kw_typeof,


### PR DESCRIPTION
* Added a new set of functions prefixed with a `@`. This has nothing to do with the suffix `@` for dereference and may change in the future. The goal of this is to make it easier to add functions that access compiler internals without needing to add a new AST node every time.
* Added `@size_of` which replaces `sizeof`, which is no longer a keyword.
* Added `@type_of` which replaces `typeof`, which is no longer a keyword.
* Added `@copy` which replaces `utils.copy!`, for a more efficient way of copying the contents of one span into another. This uses a new op code, `op::memcpy` to perform it in a single copy.
* Added `@char_to_i64` which converts a char to an i64. This uses a new op code, `op::char_to_i64`. I'll make this more generic as some point to include all other safe fundamental type casts.
* Made logical operators `&&` and `||` short circuit. Removed `op::bool_and` and `op::bool_or` since they are no longer used.
* With these optimisations, the solution to Advent of Code 2023 Day 1 now runs in 1.8 seconds, down from 2.5 seconds (with a debug build interpreter). 0.1 seconds with release build.