### PR TITLE
Treat Modules Like Variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,14 @@ An interpreted programming language written in C++. This started out as a stack-
 
 * All the common arithmetic, comparison and logical operators.
 * Builtin functions.
+* Intrinsic func:
+    * These are special functions for accessing compiler internals or to perform operations that require specialised op codes in the runtime to be efficient. They are prefixed with a `@`.
+    * `@size_of(x)` returns the size in bytes of the type of object `x`. `x` can also be itself a type.
+    * `@type_of(x)` return the type of `x`. Can be used anywhere a type is expected.
+    * `@copy(dst, src)` takes two spans of the same type and copies the contents of one into the other. The size of `dst` must be big enough to fit `src`, otherwise it's a runtime error. This exists because it can efficiently memcpy the data rather than looping over the elements.
+    * `@char_to_i64(c)` takes a char and converts its value to an i64. This is always a safe conversion, and will likely be removed for a more general form of casting in the future.
+    * `@import(name)` for importing and using other modules (more info below). This can only be used in the global scope and the module itself is only compiled when the module object is assigned to a variable name in a declaration.
+
 * Memory arenas for allocating dynamic memory:
     ```py
     arena a;
@@ -124,7 +132,7 @@ An interpreted programming language written in C++. This started out as a stack-
 
 * Modules
     ```py
-    module vec := "lib/vector.az";
+    let vec := @import("lib/vector.az");
     var my_vec := vec.vector!(u64).create(alloc&);
     ```
     * Import other files and access their contents via the defined module object.

--- a/examples/aoc2023-1.az
+++ b/examples/aoc2023-1.az
@@ -1,5 +1,5 @@
-module io := "lib/io.az";
-module str := "lib/str.az";
+let io := @import("lib/io.az");
+let str := @import("lib/str.az");
 
 arena a;
 let input := io.read_file("examples/aoc2023-1-input.txt", a&);

--- a/examples/feature_test.az
+++ b/examples/feature_test.az
@@ -1,5 +1,4 @@
 # tests all language features, here is a comment
-
 # importing a module
 let io := @import("lib/io.az"); # for "read_file"
 

--- a/examples/feature_test.az
+++ b/examples/feature_test.az
@@ -1,7 +1,7 @@
 # tests all language features, here is a comment
 
 # importing a module
-module io := "lib/io.az"; # for "read_file"
+let io := @import("lib/io.az"); # for "read_file"
 
 # declaring immutable variables
 {
@@ -359,6 +359,7 @@ let d := double(util.pair!(i64, f64)(1, 2.0), util.pair!(u64, bool)(3u, false));
 print("{} {} {} {}\n", d.x.first, d.x.second, d.y.first, d.y.second);
 
 let vec := @import("lib/vector.az");
+let vec2 := vec;
 arena v;
 var my_vec := vec.vector!(i64).create(v&);
 my_vec.push(2);

--- a/examples/feature_test.az
+++ b/examples/feature_test.az
@@ -348,7 +348,7 @@ struct pair!(T)
     g.print_struct!(u64)(70u);
 }
 
-module util := "lib/utility.az";
+let util := @import("lib/utility.az");
 
 struct double {
     x: util.pair!(i64, f64);
@@ -358,7 +358,7 @@ struct double {
 let d := double(util.pair!(i64, f64)(1, 2.0), util.pair!(u64, bool)(3u, false));
 print("{} {} {} {}\n", d.x.first, d.x.second, d.y.first, d.y.second);
 
-module vec := "lib/vector.az";
+let vec := @import("lib/vector.az");
 arena v;
 var my_vec := vec.vector!(i64).create(v&);
 my_vec.push(2);

--- a/examples/module.az
+++ b/examples/module.az
@@ -1,2 +1,1 @@
 
-let io := @import("lib/io.az");

--- a/examples/module.az
+++ b/examples/module.az
@@ -1,1 +1,6 @@
 
+fn baz() {
+    print("hello!\n");
+}
+
+var VALUE := 10;

--- a/examples/module.az
+++ b/examples/module.az
@@ -1,2 +1,2 @@
 
-module io := "lib/io.az";
+let io := @import("lib/io.az");

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,18 +1,2 @@
 
-fn f() -> bool
-{
-    print("false\n");
-    return false;
-}
-
-fn t() -> bool
-{
-    print("true\n");
-    return true;
-}
-
-if (f() || t()) {
-    print("success\n");
-} else {
-    print("not success\n");
-}
+let str := @import("lib/str.az");

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,2 +1,3 @@
 
-let str := @import("lib/str.az");
+
+var str := @import("examples/feature_test.az");

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,3 +1,3 @@
 
 
-var str := @import("examples/feature_test.az");
+let x := @import("examples/feature_test.az");

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -244,11 +244,6 @@ auto print_node(const node_stmt& root, int indent) -> void
         [&](const node_arena_declaration_stmt& node) {
             std::print("{}ArenaDeclaration: {}\n", spaces, node.name);
         },
-        [&](const node_module_declaration_stmt& node) {
-            std::print("{}ModuleDeclaration:\n", spaces);
-            std::print("{}- Name: {}\n", spaces, node.name);
-            std::print("{}- File: {}\n", spaces, node.filepath);
-        },
         [&](const node_assignment_stmt& node) {
             std::print("{}Assignment:\n", spaces);
             std::print("{}- Name:\n", spaces);

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -320,13 +320,6 @@ struct node_arena_declaration_stmt
     anzu::token token;
 };
 
-struct node_module_declaration_stmt
-{
-    std::string name;
-    std::string filepath;
-    anzu::token token;
-};
-
 struct node_assignment_stmt
 {
     node_expr_ptr position;
@@ -393,7 +386,6 @@ struct node_stmt : std::variant<
     node_continue_stmt,
     node_declaration_stmt,
     node_arena_declaration_stmt,
-    node_module_declaration_stmt,
     node_assignment_stmt,
     node_function_stmt,
     node_expression_stmt,

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -1475,7 +1475,14 @@ auto push_stmt(compiler& com, const node_declaration_stmt& node) -> void
     type.is_const = node.add_const;
 
     node.token.assert(!type.is_arena(), "cannot create copies of arenas");
-    push_copy_typechecked(com, *node.expr, type, node.token);
+    if (type.is_module_value()) {
+        node.token.assert(type.is_const, "modules can only be declared with 'let'");
+        com.current_module.back().imports[node.name] = std::get<type_module>(type).filepath;
+    }
+    else {
+        push_copy_typechecked(com, *node.expr, type, node.token);
+    }
+
     declare_var(com, node.token, node.name, type);
 }
 

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -502,8 +502,15 @@ auto get_struct(compiler& com, const token& tok, const type_struct& name)
 auto load_module(compiler& com, const token& tok, const std::string& filepath) -> void
 {
     // Add as an available module to the current module, and check for circular deps
-    for (const auto& m : com.current_module) {
-        tok.assert(m.filepath != filepath, "circular dependencey detected");
+    for (const auto& m : com.current_module | std::views::reverse) {
+        if (m.filepath == filepath) {
+            std::print("circular dependencey detected:\n");
+            for (const auto& mod : com.current_module | std::views::reverse) {
+                std::print("  - {}\n", mod.filepath.string());
+                if (mod.filepath == m.filepath) tok.error("circular dependency");
+            }
+        }
+        
     }
 
     // Already compiled, nothing more to do

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -1556,6 +1556,7 @@ void push_stmt(compiler& com, const node_function_stmt& node)
 void push_stmt(compiler& com, const node_expression_stmt& node)
 {
     const auto type = push_expr(com, compile_type::val, *node.expr);
+    node.token.assert(!type.is_module_value(), "meaningless unused module statment");
     push_value(code(com), op::pop, com.types.size_of(type));
 }
 

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -73,7 +73,6 @@ auto identifier_type(std::string_view token) -> token_type
     if (token == "len")      return token_type::kw_len;
     if (token == "let")      return token_type::kw_let;
     if (token == "loop")     return token_type::kw_loop;
-    if (token == "module")   return token_type::kw_module;
     if (token == "new")      return token_type::kw_new;
     if (token == "null")     return token_type::kw_null;
     if (token == "nullptr")  return token_type::kw_nullptr;

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -69,7 +69,6 @@ auto identifier_type(std::string_view token) -> token_type
     if (token == "i32")      return token_type::kw_i32;
     if (token == "i64")      return token_type::kw_i64;
     if (token == "if")       return token_type::kw_if;
-    if (token == "import")   return token_type::kw_import;
     if (token == "in")       return token_type::kw_in;
     if (token == "len")      return token_type::kw_len;
     if (token == "let")      return token_type::kw_let;

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -589,17 +589,6 @@ auto parse_arena_declaration_stmt(tokenstream& tokens) -> node_stmt_ptr
     return node;
 }
 
-auto parse_module_declaration_stmt(tokenstream& tokens) -> node_stmt_ptr
-{
-    auto node = std::make_shared<node_stmt>();
-    auto& stmt = node->emplace<node_module_declaration_stmt>();
-    stmt.token = tokens.consume();
-    stmt.name = parse_identifier(tokens);
-    tokens.consume_only(token_type::colon_equal);
-    stmt.filepath = tokens.consume_only(token_type::string).text;
-    return node;
-}
-
 auto parse_print_stmt(tokenstream& tokens) -> node_stmt_ptr
 {
     auto node = std::make_shared<node_stmt>();
@@ -709,7 +698,6 @@ auto parse_top_level_statement(tokenstream& tokens) -> node_stmt_ptr
     switch (curr.type) {
         case token_type::kw_function: return parse_function_def_stmt(tokens);
         case token_type::kw_struct:   return parse_struct_stmt(tokens);
-        case token_type::kw_module:   return parse_module_declaration_stmt(tokens);
         default:                      return parse_statement(tokens);
     }
 }

--- a/src/token.cpp
+++ b/src/token.cpp
@@ -61,7 +61,6 @@ auto to_string(token_type tt) -> std::string_view
         case token_type::kw_len:              return "len";
         case token_type::kw_let:              return "let";
         case token_type::kw_loop:             return "loop";
-        case token_type::kw_module:           return "module";
         case token_type::kw_new:              return "new";
         case token_type::kw_null:             return "null";
         case token_type::kw_nullptr:          return "nullptr";

--- a/src/token.cpp
+++ b/src/token.cpp
@@ -57,7 +57,6 @@ auto to_string(token_type tt) -> std::string_view
         case token_type::kw_i32:              return "i32";
         case token_type::kw_i64:              return "i64";
         case token_type::kw_if:               return "if";
-        case token_type::kw_import:           return "import";
         case token_type::kw_in:               return "in";
         case token_type::kw_len:              return "len";
         case token_type::kw_let:              return "let";

--- a/src/token.hpp
+++ b/src/token.hpp
@@ -49,7 +49,6 @@ enum class token_type
     kw_len,
     kw_let,
     kw_loop,
-    kw_module,
     kw_new,
     kw_null,
     kw_nullptr,

--- a/src/token.hpp
+++ b/src/token.hpp
@@ -45,7 +45,6 @@ enum class token_type
     kw_i32,
     kw_i64,
     kw_if,
-    kw_import,
     kw_in,
     kw_len,
     kw_let,


### PR DESCRIPTION
* Added a new intrinsic function, `@import`, which acts similar to existing module statements.
* The type of a `@import(...)` call is a `type_module`.
* The module only gets compiled when the module is captured in a declaration statement. It cannot happen as part of the intrinsic function call, because if it gets called in a `type_of_expr` evaluation, the compiled module gets popped off and the compiler will never re-add it. This can either be fixed by changing how `type_of_expr` works or by how module importing works, but I've not come up with a good way in either case yet.
* When a circular dependency is detected, it is now printed.
* Updated the readme to mention intrinsic functions.