### PR TITLE
Bugfix: `@type_of` on a Module

### DIFF
--- a/examples/feature_test.az
+++ b/examples/feature_test.az
@@ -367,4 +367,3 @@ print("{}\n", my_vec.size());
 for x in my_vec.to_span() {
     print("{} ", x@);
 }
-print("{}\n", vec.vec_size);

--- a/examples/feature_test.az
+++ b/examples/feature_test.az
@@ -358,7 +358,6 @@ let d := double(util.pair!(i64, f64)(1, 2.0), util.pair!(u64, bool)(3u, false));
 print("{} {} {} {}\n", d.x.first, d.x.second, d.y.first, d.y.second);
 
 let vec := @import("lib/vector.az");
-let vec2 := vec;
 arena v;
 var my_vec := vec.vector!(i64).create(v&);
 my_vec.push(2);
@@ -368,4 +367,4 @@ print("{}\n", my_vec.size());
 for x in my_vec.to_span() {
     print("{} ", x@);
 }
-print("\n");
+print("{}\n", vec.vec_size);

--- a/lib/vector.az
+++ b/lib/vector.az
@@ -51,5 +51,3 @@ struct vector!(T)
         return vector!(T)(arr, nullptr, 0u);
     }
 }
-
-let vec_size := 100;

--- a/lib/vector.az
+++ b/lib/vector.az
@@ -51,3 +51,5 @@ struct vector!(T)
         return vector!(T)(arr, nullptr, 0u);
     }
 }
+
+let vec_size := 100;

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -168,7 +168,9 @@ auto type_of_expr(compiler& com, const node_expr& node) -> type_name
 {
     const auto program_size = code(com).size();
     const auto type = push_expr(com, compile_type::val, node);
-    code(com).resize(program_size);
+    if (com.types.size_of(type) > 0) {
+        code(com).resize(program_size);
+    }
     return type;
 }
 


### PR DESCRIPTION
* `@type_of` works by compiling the given expression and then removing all bytecode instructions added from the program. This was implemented back when the program was a single vector of bytes and hasn't changed, and while it still mostly works, there's some rough edges.
* Calling `@type_of(@import("module_name"))` should return the module type, but if this is the first time this module is imported, the resetting logic removes any of the global variables within the module. Structs and functions are fine since functions are compiled into separate places and structs are purely state for the compiler, but any of the logic that affects `$main` needs to stay around.
* The quick fix for this is to only do the logic resetting if the type of the expression has a non-zero size. If the object is of size 0, there should be no need for resetting the code since the added op codes add nothing to the stack.
* It would be nice to make `@type_of` a true unevaluated context, but that is much more work.