### PR TITLE
Template Type Deduction Preparation

### DIFF
--- a/examples/feature_test.az
+++ b/examples/feature_test.az
@@ -359,7 +359,8 @@ print("{} {} {} {}\n", d.x.first, d.x.second, d.y.first, d.y.second);
 
 let vec := @import("lib/vector.az");
 arena v;
-var my_vec := vec.vector!(i64).create(v&);
+let this_type := vec.vector!(i64);
+var my_vec := this_type.create(v&);
 my_vec.push(2);
 my_vec.push(3);
 my_vec.push(4);

--- a/examples/feature_test.az
+++ b/examples/feature_test.az
@@ -116,7 +116,7 @@ fn add3(x: i64, y: i64, z: i64) -> i64
     return add2(x, add2(y, z));
 }
 
-print("{}", add3(1, 2, 3));
+print("adder(1, 2, 3) == {}\n", add3(1, 2, 3));
 
 # Struct definition
 struct vec2

--- a/examples/feature_test.az
+++ b/examples/feature_test.az
@@ -334,7 +334,7 @@ struct pair!(T)
     x: T;
     y: T;
 
-    fn print_struct!(U)(self: pair!(T) const&, u: U) -> null
+    fn print_struct!(U)(self: const&, u: U) -> null
     {
         print("{} {} {}\n", self.x, self.y, u);
     }
@@ -343,7 +343,9 @@ struct pair!(T)
 {
     var f := pair!(i64)(1, 2);
     var g := pair!(f64)(12.3, 45.6);
+print("HERE I AM\n");
     f.print_struct!(u64)(70u);
+print("THERE I AM\n");
     g.print_struct!(u64)(70u);
 }
 

--- a/examples/test.az
+++ b/examples/test.az
@@ -4,4 +4,7 @@ fn adder!(T)(a: i64, b: i64) -> null
     print("{}\n", a + b);
 }
 
-adder!(i64)(1, 2);
+let a := adder;
+print("{}\n", @type_name_of(adder));
+
+a!(i64)(1, 2);

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,7 +1,7 @@
 # functions
-fn adder(a: i64, b: i64) -> i64
+fn adder!(T)(a: i64, b: i64) -> null
 {
-    return a + b;
+    print("{}\n", a + b);
 }
 
-adder(1, 2);
+adder!(i64)(1, 2);

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,5 +1,20 @@
-let vec := @import("lib/vector.az");
-arena v;
-let this_type := vec.vector!(i64);
-print("{}\n", @type_name_of(this_type));
-var my_vec := this_type.create(v&);
+struct pair!(T)
+{
+    x: T;
+    y: T;
+
+    fn foo(self: const&) {
+        print("foo\n");
+    }
+
+    fn print_struct!(U)(self: const&, u: U) -> null
+    {
+        print("{} {} {}\n", self.x, self.y, u);
+    }
+}
+
+var f := pair!(i64)(1, 2);
+print("HERE I AM\n");
+f.print_struct!(u64)(70u);
+f.foo();
+print("THERE I AM\n");

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,3 +1,7 @@
+# functions
+fn adder(a: i64, b: i64) -> i64
+{
+    return a + b;
+}
 
-
-@import("examples/feature_test.az");
+adder(1, 2);

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,10 +1,5 @@
-# functions
-fn adder!(T)(a: i64, b: i64) -> null
-{
-    print("{}\n", a + b);
-}
-
-let a := adder;
-print("{}\n", @type_name_of(adder));
-
-a!(i64)(1, 2);
+let vec := @import("lib/vector.az");
+arena v;
+let this_type := vec.vector!(i64);
+print("{}\n", @type_name_of(this_type));
+var my_vec := this_type.create(v&);

--- a/lib/vector.az
+++ b/lib/vector.az
@@ -9,15 +9,15 @@ struct vector!(T)
         return self._data[0u : self._size];
     }
 
+    fn capacity(self: &) -> u64
+    {
+        return len(self._data);
+    }
+
     fn reserve(self: &, size: u64) -> null
     {
         assert(size > self.capacity());
         self._data = new(self._arr, size, self._data) T();
-    }
-
-    fn capacity(self: &) -> u64
-    {
-        return len(self._data);
     }
 
     fn size(self: const&) -> u64

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -39,20 +39,12 @@ auto print_node(const node_expr& root, int indent) -> void
         },
         [&](const node_name_expr& node) {
             std::print("{}Name: {}\n", spaces, node.name);
-            std::print("{}- Templates:\n", spaces);
-            for (const auto& arg : node.templates) {
-                print_node(*arg, indent + 1);
-            }
         },
         [&](const node_field_expr& node) {
             std::print("{}Field: \n", spaces);
             std::print("{}- Expr:\n", spaces);
             print_node(*node.expr, indent + 1);
             std::print("{}- Field: {}\n", spaces, node.field_name);
-            std::print("{}- Templates:\n", spaces);
-            for (const auto& arg : node.templates) {
-                print_node(*arg, indent + 1);
-            }
         },
         [&](const node_unary_op_expr& node) {
             std::print("{}UnaryOp: \n", spaces);

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -77,6 +77,15 @@ auto print_node(const node_expr& root, int indent) -> void
                 print_node(*arg, indent + 1);
             }
         },
+        [&](const node_template_expr& node) {
+            std::print("{}Template:\n", spaces);
+            std::print("{}- Expr:\n", spaces);
+            print_node(*node.expr, indent + 1);
+            std::print("{}- Templates:\n", spaces);
+            for (const auto& arg : node.templates) {
+                print_node(*arg, indent + 1);
+            }
+        },
         [&](const node_array_expr& node) {
             std::print("{}Array:\n", spaces);
             std::print("{}- Elements:\n", spaces);

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -44,7 +44,7 @@ auto print_node(const node_expr& root, int indent) -> void
             std::print("{}Field: \n", spaces);
             std::print("{}- Expr:\n", spaces);
             print_node(*node.expr, indent + 1);
-            std::print("{}- Field: {}\n", spaces, node.field_name);
+            std::print("{}- Field: {}\n", spaces, node.name);
         },
         [&](const node_unary_op_expr& node) {
             std::print("{}UnaryOp: \n", spaces);

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -70,7 +70,6 @@ struct node_literal_string_expr
 struct node_name_expr
 {
     std::string                name;
-    std::vector<node_expr_ptr> templates;
 
     anzu::token token;
 };
@@ -79,7 +78,6 @@ struct node_field_expr
 {
     node_expr_ptr              expr;
     std::string                field_name;
-    std::vector<node_expr_ptr> templates;
 
     anzu::token token;
 };

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -69,15 +69,15 @@ struct node_literal_string_expr
 
 struct node_name_expr
 {
-    std::string                name;
+    std::string name;
 
     anzu::token token;
 };
 
 struct node_field_expr
 {
-    node_expr_ptr              expr;
-    std::string                field_name;
+    node_expr_ptr expr;
+    std::string   name;
 
     anzu::token token;
 };

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -107,6 +107,14 @@ struct node_call_expr
     anzu::token token;
 };
 
+struct node_template_expr
+{
+    node_expr_ptr expr;
+    std::vector<node_expr_ptr> templates;
+
+    anzu::token token;
+};
+
 struct node_array_expr
 {
     std::vector<node_expr_ptr> elements;
@@ -215,6 +223,7 @@ struct node_expr : std::variant<
     node_unary_op_expr,
     node_binary_op_expr,
     node_call_expr,
+    node_template_expr,
     node_array_expr,
     node_repeat_array_expr,
     node_addrof_expr,

--- a/src/compilation/type_manager.cpp
+++ b/src/compilation/type_manager.cpp
@@ -30,6 +30,7 @@ auto type_manager::contains(const type_name& type) const -> bool
         [&](const type_type& t)               { return contains(*t.type_val); },
         [&](const type_function&)             { return true; },
         [&](const type_function_template&)    { return true; },
+        [&](const type_struct_template&)      { return true; },
         [&](const type_module&)               { return true; },
         [&](const type_ct_bool&)              { return true; }
     }, type);
@@ -94,6 +95,9 @@ auto type_manager::size_of(const type_name& type) const -> std::size_t
             return std::size_t{0};
         },
         [](const type_function_template&) {
+            return std::size_t{0};
+        },
+        [](const type_struct_template&) {
             return std::size_t{0};
         },
         [](const type_module&) {

--- a/src/compilation/type_manager.cpp
+++ b/src/compilation/type_manager.cpp
@@ -92,6 +92,9 @@ auto type_manager::size_of(const type_name& type) const -> std::size_t
         [](const type_function&) {
             return std::size_t{0};
         },
+        [](const type_function_template&) {
+            return std::size_t{0};
+        },
         [](const type_module&) {
             return std::size_t{0}; 
         },

--- a/src/compilation/type_manager.cpp
+++ b/src/compilation/type_manager.cpp
@@ -29,6 +29,7 @@ auto type_manager::contains(const type_name& type) const -> bool
         [&](const type_arena&)                { return true; },
         [&](const type_type& t)               { return contains(*t.type_val); },
         [&](const type_function&)             { return true; },
+        [&](const type_function_template&)    { return true; },
         [&](const type_module&)               { return true; },
         [&](const type_ct_bool&)              { return true; }
     }, type);

--- a/src/compilation/type_manager.cpp
+++ b/src/compilation/type_manager.cpp
@@ -18,21 +18,12 @@ auto type_manager::add(
 auto type_manager::contains(const type_name& type) const -> bool
 {
     return std::visit(overloaded{
-        [](type_fundamental)                  { return true; },
-        [&](const type_struct&)               { return d_classes.contains(type); },
-        [&](const type_array& t)              { return contains(*t.inner_type); },
-        [&](const type_span& t)               { return contains(*t.inner_type); },
-        [&](const type_ptr& t)                { return contains(*t.inner_type); },
-        [&](const type_function_ptr&)         { return true; },
-        [&](const type_builtin&)              { return true; },
-        [&](const type_bound_method&)         { return true; },
-        [&](const type_arena&)                { return true; },
-        [&](const type_type& t)               { return contains(*t.type_val); },
-        [&](const type_function&)             { return true; },
-        [&](const type_function_template&)    { return true; },
-        [&](const type_struct_template&)      { return true; },
-        [&](const type_module&)               { return true; },
-        [&](const type_ct_bool&)              { return true; }
+        [&](const type_struct&)  { return d_classes.contains(type); },
+        [&](const type_array& t) { return contains(*t.inner_type); },
+        [&](const type_span& t)  { return contains(*t.inner_type); },
+        [&](const type_ptr& t)   { return contains(*t.inner_type); },
+        [&](const type_type& t)  { return contains(*t.type_val); },
+        [&](const auto&)         { return true; }
     }, type);
 }
 
@@ -80,6 +71,9 @@ auto type_manager::size_of(const type_name& type) const -> std::size_t
             return sizeof(std::byte*);
         },
         [](const type_bound_method&) {
+            return sizeof(std::byte*); // pointer to the object, first arg to the function
+        },
+        [](const type_bound_method_template&) {
             return sizeof(std::byte*); // pointer to the object, first arg to the function
         },
         [](const type_arena& arena) {

--- a/src/compilation/type_manager.cpp
+++ b/src/compilation/type_manager.cpp
@@ -28,6 +28,7 @@ auto type_manager::contains(const type_name& type) const -> bool
         [&](const type_bound_method&)         { return true; },
         [&](const type_arena&)                { return true; },
         [&](const type_type& t)               { return contains(*t.type_val); },
+        [&](const type_function&)             { return true; },
         [&](const type_module&)               { return true; },
         [&](const type_ct_bool&)              { return true; }
     }, type);
@@ -87,6 +88,9 @@ auto type_manager::size_of(const type_name& type) const -> std::size_t
         },
         [](const type_type&) {
             return std::size_t{0}; 
+        },
+        [](const type_function&) {
+            return std::size_t{0};
         },
         [](const type_module&) {
             return std::size_t{0}; 

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -1236,9 +1236,8 @@ auto push_expr(compiler& com, compile_type ct, const node_field_expr& node) -> t
     }
     
     const auto stripped = strip_pointers(type);
-    const auto struct_name = std::holds_alternative<type_struct>(stripped)
-                           ? std::get<type_struct>(stripped)
-                           : no_struct;
+    node.token.assert(stripped.is_struct(), "expected a struct type, got {}\n", stripped);
+    const auto& struct_name = std::get<type_struct>(stripped);
 
     // It might be a member function
     const auto fname = function_name{struct_name.module, struct_name, node.name};

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -819,6 +819,11 @@ auto push_expr(compiler& com, compile_type ct, const node_call_expr& node) -> ty
     node.token.error("unable to call non-callable type {}", type);
 }
 
+auto push_expr(compiler& com, compile_type ct, const node_template_expr& node) -> type_name
+{
+    return null_type();
+}
+
 auto push_expr(compiler& com, compile_type ct, const node_array_expr& node) -> type_name
 {
     node.token.assert(ct == compile_type::val, "cannot take the address of an array expression");

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -1068,7 +1068,6 @@ auto push_expr(compiler& com, compile_type ct, const node_name_expr& node) -> ty
     const auto fname = function_name{curr_module(com), no_struct, node.name, templates};
     if (auto func = get_function(com, node.token, fname)) {
         node.token.assert(ct == compile_type::val, "cannot take the address of a function ptr");
-        push_value(code(com), op::push_u64, func->id);
         return type_function{ .id = func->id, .param_types = func->sig.params, .return_type = func->sig.return_type };
     }
 
@@ -1133,7 +1132,6 @@ auto push_expr(compiler& com, compile_type ct, const node_field_expr& node) -> t
         const auto fname = function_name{info.filepath, no_struct, node.field_name, templates};
         if (auto func = get_function(com, node.token, fname)) {
             node.token.assert(ct == compile_type::val, "cannot take the address of a function ptr");
-            push_value(code(com), op::push_u64, func->id);
             return type_function{ .id = func->id, .param_types = func->sig.params, .return_type = func->sig.return_type };
         }
 
@@ -1154,7 +1152,6 @@ auto push_expr(compiler& com, compile_type ct, const node_field_expr& node) -> t
         const auto fname = function_name{struct_info.module, struct_info, node.field_name, templates};
         if (auto func = get_function(com, node.token, fname); func.has_value()) {
             node.token.assert(ct == compile_type::val, "cannot take the address of a function ptr");
-            push_value(code(com), op::push_u64, func->id);
             return type_function{ .id = func->id, .param_types = func->sig.params, .return_type = func->sig.return_type };   
         }
 

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -211,8 +211,6 @@ auto const_convertable_to(const token& tok, const type_name& src, const type_nam
     }
 
     return std::visit(overloaded{
-        [&](type_fundamental l, type_fundamental r) { return l == r; },
-        [&](const type_struct& l, const type_struct& r) { return l == r; },
         [&](const type_array& l, const type_array& r) {
             return l.count == r.count && const_convertable_to(tok, *l.inner_type, *r.inner_type);
         },
@@ -222,14 +220,8 @@ auto const_convertable_to(const token& tok, const type_name& src, const type_nam
         [&](const type_span& l, const type_span& r) {
             return const_convertable_to(tok, *l.inner_type, *r.inner_type);
         },
-        [&](const type_function_ptr& l, const type_function_ptr& r) { return l == r; },
-        [&](const type_builtin& l, const type_builtin& r) { return l == r; },
-        [&](const type_bound_method& l, const type_bound_method& r) { return l == r; },
         [&](const type_arena& l, const type_arena& r) { return true; },
-        [&](const type_type& l, const type_type& r) { return l == r; },
-        [&](const type_function& l, const type_function& r) { return l == r; },
-        [&](const type_module& l, const type_module& r) { return l == r; },
-        [&](const type_ct_bool& l, const type_ct_bool& r) { return l == r; },
+        [&] <typename T> (const T& l, const T& r) { return l == r; },
         [&](const auto& l, const auto& r) {
             return false;
         }

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -9,6 +9,11 @@
 
 namespace anzu {
 
+auto type_function::to_pointer() const -> type_name
+{
+    return type_function_ptr{ param_types, return_type };
+}
+
 auto type_name::is_fundamental() const -> bool
 {
     return std::holds_alternative<type_fundamental>(*this);

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -153,6 +153,11 @@ auto to_string(const type_function& type) -> std::string
     return std::format("<function: id {}  {}>", type.id, to_string(function_ptr_type));
 }
 
+auto to_string(const type_function_template& type) -> std::string
+{
+    return std::format("<function_template: TBA>");
+}
+
 auto to_string(const type_module& type) -> std::string
 {
     return std::format("<module: {}>", type.filepath.string());
@@ -238,6 +243,11 @@ auto hash(const type_function& type) -> std::size_t
         val ^= hash(param);
     }
     return val;
+}
+
+auto hash(const type_function_template& type) -> std::size_t
+{
+    return 0; // TODO: Implement
 }
 
 auto hash(const type_module& type) -> std::size_t

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -336,6 +336,11 @@ auto type_name::remove_span() const -> type_name
     return *std::get<type_span>(*this).inner_type;
 }
 
+auto type_name::is_function() const -> bool
+{
+    return std::holds_alternative<type_function>(*this);
+}
+
 auto type_name::is_function_ptr() const -> bool
 {
     return std::holds_alternative<type_function_ptr>(*this);

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -158,6 +158,11 @@ auto to_string(const type_function_template& type) -> std::string
     return std::format("<function_template: TBA>");
 }
 
+auto to_string(const type_struct_template& type) -> std::string
+{
+    return std::format("<struct_template: TBA>");
+}
+
 auto to_string(const type_module& type) -> std::string
 {
     return std::format("<module: {}>", type.filepath.string());
@@ -246,6 +251,11 @@ auto hash(const type_function& type) -> std::size_t
 }
 
 auto hash(const type_function_template& type) -> std::size_t
+{
+    return 0; // TODO: Implement
+}
+
+auto hash(const type_struct_template& type) -> std::size_t
 {
     return 0; // TODO: Implement
 }

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -142,6 +142,12 @@ auto to_string(const type_type& type) -> std::string
     return std::format("<type-expression: {}>", *type.type_val);
 }
 
+auto to_string(const type_function& type) -> std::string
+{
+    const auto function_ptr_type = type_function_ptr{type.param_types, type.return_type};
+    return std::format("<function: id {}  {}>", type.id, to_string(function_ptr_type));
+}
+
 auto to_string(const type_module& type) -> std::string
 {
     return std::format("<module: {}>", type.filepath.string());
@@ -218,6 +224,15 @@ auto hash(const type_arena& type) -> std::size_t
 auto hash(const type_type& type) -> std::size_t
 {
     return hash(*type.type_val) ^ std::hash<std::string_view>{}("type_type");
+}
+
+auto hash(const type_function& type) -> std::size_t
+{
+    auto val = hash(*type.return_type) ^ std::hash<std::size_t>{}(type.id);
+    for (const auto& param : type.param_types) {
+        val ^= hash(param);
+    }
+    return val;
 }
 
 auto hash(const type_module& type) -> std::size_t

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -137,6 +137,11 @@ auto to_string(const type_bound_method& type) -> std::string
     );
 }
 
+auto to_string(const type_bound_method_template& type) -> std::string
+{
+    return std::format("<bound_method_template: TBA>");
+}
+
 auto to_string(const type_arena& type) -> std::string
 {
     return std::string{"<arena>"};
@@ -229,6 +234,11 @@ auto hash(const type_bound_method& type) -> std::size_t
         val ^= hash(param);
     }
     return val;
+}
+
+auto hash(const type_bound_method_template& type) -> std::size_t
+{
+    return 0; // TODO: Implement
 }
 
 auto hash(const type_arena& type) -> std::size_t

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -139,6 +139,7 @@ struct type_name : public std::variant<
     type_builtin,
     type_type,
     type_function,
+    type_function_template,
     type_module,
     type_ct_bool>
 {

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -110,7 +110,6 @@ struct type_function_template
     std::filesystem::path    module;
     type_struct              struct_name;
     std::string              name;
-    std::vector<std::string> template_names;
     auto operator==(const type_function_template&) const -> bool = default;
 };
 

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -96,6 +96,14 @@ struct type_type
     auto operator==(const type_type&) const -> bool = default;
 };
 
+struct type_function
+{
+    std::size_t            id;
+    std::vector<type_name> param_types;
+    value_ptr<type_name>   return_type;
+    auto operator==(const type_function&) const -> bool = default;
+};
+
 struct type_module
 {
     std::filesystem::path filepath;
@@ -120,6 +128,7 @@ struct type_name : public std::variant<
     type_bound_method,
     type_builtin,
     type_type,
+    type_function,
     type_module,
     type_ct_bool>
 {
@@ -167,6 +176,7 @@ auto hash(const type_builtin& type) -> std::size_t;
 auto hash(const type_bound_method& type) -> std::size_t;
 auto hash(const type_arena& type) -> std::size_t;
 auto hash(const type_type& type) -> std::size_t;
+auto hash(const type_function& type) -> std::size_t;
 auto hash(const type_module& type) -> std::size_t;
 auto hash(const type_ct_bool& type) -> std::size_t;
 auto hash(std::span<const type_name> types) -> std::size_t;

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -153,6 +153,7 @@ struct type_name : public std::variant<
     [[nodiscard]] auto add_span() const -> type_name;
     [[nodiscard]] auto remove_span() const -> type_name;
 
+    [[nodiscard]] auto is_function() const -> bool;
     [[nodiscard]] auto is_function_ptr() const -> bool;
     [[nodiscard]] auto is_builtin() const -> bool;
     [[nodiscard]] auto is_bound_method() const -> bool;

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -113,6 +113,13 @@ struct type_function_template
     auto operator==(const type_function_template&) const -> bool = default;
 };
 
+struct type_struct_template
+{
+    std::filesystem::path module;
+    std::string           name;
+    auto operator==(const type_struct_template&) const -> bool = default;
+};
+
 struct type_module
 {
     std::filesystem::path filepath;
@@ -139,6 +146,7 @@ struct type_name : public std::variant<
     type_type,
     type_function,
     type_function_template,
+    type_struct_template,
     type_module,
     type_ct_bool>
 {
@@ -189,6 +197,7 @@ auto hash(const type_arena& type) -> std::size_t;
 auto hash(const type_type& type) -> std::size_t;
 auto hash(const type_function& type) -> std::size_t;
 auto hash(const type_function_template& type) -> std::size_t;
+auto hash(const type_struct_template& type) -> std::size_t;
 auto hash(const type_module& type) -> std::size_t;
 auto hash(const type_ct_bool& type) -> std::size_t;
 auto hash(std::span<const type_name> types) -> std::size_t;
@@ -227,6 +236,7 @@ auto to_string(const type_arena& type) -> std::string;
 auto to_string(const type_type& type) -> std::string;
 auto to_string(const type_function& type) -> std::string;
 auto to_string(const type_function_template& type) -> std::string;
+auto to_string(const type_struct_template& type) -> std::string;
 auto to_string(const type_module& type) -> std::string;
 auto to_string(const type_ct_bool& type) -> std::string;
 

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -101,6 +101,7 @@ struct type_function
     std::size_t            id;
     std::vector<type_name> param_types;
     value_ptr<type_name>   return_type;
+    auto to_pointer() const -> type_name;
     auto operator==(const type_function&) const -> bool = default;
 };
 

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -84,6 +84,14 @@ struct type_bound_method
     auto operator==(const type_bound_method&) const -> bool = default;
 };
 
+struct type_bound_method_template
+{
+    std::filesystem::path    module;
+    type_struct              struct_name;
+    std::string              name;
+    auto operator==(const type_bound_method_template&) const -> bool = default;
+};
+
 struct type_arena
 {
     auto operator==(const type_arena&) const -> bool = default;
@@ -142,6 +150,7 @@ struct type_name : public std::variant<
     type_arena,
     type_function_ptr,
     type_bound_method,
+    type_bound_method_template,
     type_builtin,
     type_type,
     type_function,
@@ -193,6 +202,7 @@ auto hash(const type_span& type) -> std::size_t;
 auto hash(const type_function_ptr& type) -> std::size_t;
 auto hash(const type_builtin& type) -> std::size_t;
 auto hash(const type_bound_method& type) -> std::size_t;
+auto hash(const type_bound_method_template& type) -> std::size_t;
 auto hash(const type_arena& type) -> std::size_t;
 auto hash(const type_type& type) -> std::size_t;
 auto hash(const type_function& type) -> std::size_t;
@@ -232,6 +242,7 @@ auto to_string(const type_struct& type) -> std::string;
 auto to_string(const type_function_ptr& type) -> std::string;
 auto to_string(const type_builtin& type) -> std::string;
 auto to_string(const type_bound_method& type) -> std::string;
+auto to_string(const type_bound_method_template& type) -> std::string;
 auto to_string(const type_arena& type) -> std::string;
 auto to_string(const type_type& type) -> std::string;
 auto to_string(const type_function& type) -> std::string;

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -105,6 +105,15 @@ struct type_function
     auto operator==(const type_function&) const -> bool = default;
 };
 
+struct type_function_template
+{
+    std::filesystem::path    module;
+    type_struct              struct_name;
+    std::string              name;
+    std::vector<std::string> template_names;
+    auto operator==(const type_function_template&) const -> bool = default;
+};
+
 struct type_module
 {
     std::filesystem::path filepath;
@@ -179,6 +188,7 @@ auto hash(const type_bound_method& type) -> std::size_t;
 auto hash(const type_arena& type) -> std::size_t;
 auto hash(const type_type& type) -> std::size_t;
 auto hash(const type_function& type) -> std::size_t;
+auto hash(const type_function_template& type) -> std::size_t;
 auto hash(const type_module& type) -> std::size_t;
 auto hash(const type_ct_bool& type) -> std::size_t;
 auto hash(std::span<const type_name> types) -> std::size_t;
@@ -215,6 +225,8 @@ auto to_string(const type_builtin& type) -> std::string;
 auto to_string(const type_bound_method& type) -> std::string;
 auto to_string(const type_arena& type) -> std::string;
 auto to_string(const type_type& type) -> std::string;
+auto to_string(const type_function& type) -> std::string;
+auto to_string(const type_function_template& type) -> std::string;
 auto to_string(const type_module& type) -> std::string;
 auto to_string(const type_ct_bool& type) -> std::string;
 

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -303,7 +303,7 @@ auto parse_dot(tokenstream& tokens, const node_expr_ptr& left) -> node_expr_ptr
     const auto token = tokens.consume_only(token_type::dot);
     auto [node, inner] = new_node<node_field_expr>(token);
     inner.expr = left;
-    inner.field_name = parse_identifier(tokens);
+    inner.name = parse_identifier(tokens);
     return node;
 }
 


### PR DESCRIPTION
* In order to have template type deduction, it must be possible to have the expression `foo()` where `foo` is a template, not a concrete function, which is currently not possible.
* Added `type_function`, a size 0 type category which stores all the info for a particular function. This can convert to the `function_ptr` type implicitly. This was mainly added for consistency with the rest of the size 0 types.
* Added `node_template_expr` to the AST. This just contains a template type list. Removed the template lists from `node_name_expr` and `node_field_expr`.
* Added `type_function_template`, a size 0 type category, representing a function template. Applying a template list to it returns a `type_function` object.
* Similarly, added `type_struct_template` and `type_bound_method_template`, the other two things that a template list can be applied to.
* As is usual with a big change like this, the code is a mess, will try and clean up in the next PR.
* With this, template type deduction can be implemented by making it meaningful for a template object to be in a call expression (currently a template_expr must be applied to them first before calling them).