### PR TITLE
Function Template Argument Type Deduction

### DIFF
--- a/examples/test.az
+++ b/examples/test.az
@@ -1,15 +1,11 @@
 
-struct Type!(X)
-{
-    x: X;
+
+fn bar() -> i64 { return 10; }
+
+
+fn foo!(U)(x: fn() -> U) -> null {
+    print("{}\n", x());
 }
 
-fn foo!(U)(x: Type!(U)) -> null {
-    print("{}\n", x);
-}
-
-
-
-
-let s := Type!(u64)(60u);
-foo(s);
+print("{}\n", @type_name_of(@fn_ptr(bar)));
+foo(@fn_ptr(bar));

--- a/examples/test.az
+++ b/examples/test.az
@@ -4,4 +4,4 @@
 
 fn baz!(T)(a: T, b: T) -> null {}
 
-baz(1, 2.0);
+baz(1.0, 2.0);

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,11 +1,9 @@
 
 
-fn bar() -> i64 { return 10; }
 
 
-fn foo!(U)(x: fn() -> U) -> null {
-    print("{}\n", x());
+fn foo!(U)(x: U) -> null {
 }
 
-print("{}\n", @type_name_of(@fn_ptr(bar)));
-foo(@fn_ptr(bar));
+
+foo(5);

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,6 +1,15 @@
 
-fn foo!(U)(x: U) -> null {
+struct Type!(X)
+{
+    x: X;
+}
+
+fn foo!(U)(x: Type!(U)) -> null {
     print("{}\n", x);
 }
 
-foo(5);
+
+
+
+let s := Type!(u64)(60u);
+foo(s);

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,5 +1,6 @@
-struct pair!(T)
-{
-    x: T;
-    y: T;
+
+fn foo!(U)(x: U) {
+    print("{}\n", x);
 }
+
+foo(10);

--- a/examples/test.az
+++ b/examples/test.az
@@ -3,6 +3,7 @@
 
 
 fn foo!(U)(x: U) -> null {
+    print("{}\n", x);
 }
 
 

--- a/examples/test.az
+++ b/examples/test.az
@@ -2,9 +2,6 @@
 
 
 
-fn foo!(U)(x: U) -> null {
-    print("{}\n", x);
-}
+fn baz!(T)(a: T, b: T) -> null {}
 
-
-foo(5);
+baz(1, 2.0);

--- a/examples/test.az
+++ b/examples/test.az
@@ -2,6 +2,16 @@
 
 
 
-fn baz!(T)(a: T, b: T) -> null {}
+struct pair!(T, U)
+{
+    first: T;
+    second: U;
+}
 
-baz(1.0, 2.0);
+fn make_pair!(T, U)(f: T, s: U) -> pair!(T, U)
+{
+    return pair!(T, U)(f, s);
+}
+
+let p := make_pair(1, 2.0);
+print("{}\n", @type_name_of(p));

--- a/examples/test.az
+++ b/examples/test.az
@@ -6,12 +6,9 @@ struct pair!(T, U)
 {
     first: T;
     second: U;
+
+    fn boo!(A)(x: i64) { print("{}\n", x); }
 }
 
-fn make_pair!(T, U)(f: T, s: U) -> pair!(T, U)
-{
-    return pair!(T, U)(f, s);
-}
-
-let p := make_pair(1, 2.0);
-print("{}\n", @type_name_of(p));
+let p := pair!(i64, u64).boo;
+p(10);

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,6 +1,6 @@
 
-fn foo!(U)(x: U) {
+fn foo!(U)(x: U) -> null {
     print("{}\n", x);
 }
 
-foo(10);
+foo(5);

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -291,17 +291,4 @@ auto print_node(const node_stmt& root, int indent) -> void
     }, root);
 }
 
-auto is_lvalue_expr(const node_expr& expr) -> bool
-{
-    return std::holds_alternative<node_name_expr>(expr)
-        || std::holds_alternative<node_field_expr>(expr)
-        || std::holds_alternative<node_deref_expr>(expr)
-        || std::holds_alternative<node_subscript_expr>(expr);
-}
-
-auto is_rvalue_expr(const node_expr& expr) -> bool
-{
-    return !is_lvalue_expr(expr);
-}
-
 }

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -402,9 +402,6 @@ struct node_stmt : std::variant<
 {
 };
 
-auto is_lvalue_expr(const node_expr& expr) -> bool;
-auto is_rvalue_expr(const node_expr& expr) -> bool;
-
 auto print_node(const anzu::node_expr& root, int indent = 0) -> void;
 auto print_node(const anzu::node_stmt& root, int indent = 0) -> void;
 

--- a/src/compilation/type_manager.cpp
+++ b/src/compilation/type_manager.cpp
@@ -99,6 +99,9 @@ auto type_manager::size_of(const type_name& type) const -> std::size_t
         },
         [](const type_ct_bool&) {
             return std::size_t{0}; 
+        },
+        [](const type_placeholder&) {
+            return std::size_t{0}; 
         }
     }, type);
 }

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -355,9 +355,6 @@ void match_placeholders(template_map& map, const token& tok, const type_name& ac
                 match_placeholders(map, tok, *a.return_type, *e.return_type);
             }
         },
-        //[&](const type_type& a, const type_type& e) { // what would this even be used for?
-        //    match_placeholders(map, tok, *a.type_val, *e.type_val);
-        //},
         [](const auto& a, const auto& e) {}
     }, actual, expected);
 }

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -352,6 +352,9 @@ auto match_placeholders(const type_name& actual, const type_name& expected)
                 match_placeholders(*a.return_type, *e.return_type);
             }
         },
+        //[](const type_type& a, const type_type& e) { // what would this even be used for?
+        //    match_placeholders(*a.type_val, *e.type_val);
+        //},
         [](const auto& a, const auto& e) {}
     }, actual, expected);
 }

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -322,11 +322,9 @@ void match_placeholders(template_map& map, const token& tok, const type_name& ac
 {
     if (auto type = expected.get_if<type_placeholder>()) {
         const auto [it, success] = map.emplace(type->name, actual);
-        if (!success) {
-            tok.assert(it->second == actual,
-                       "ambiguous template deduction, deduced {} as both {} and {}",
-                       type->name, it->second, actual);
-        }
+        tok.assert(success || it->second == actual,
+                   "ambiguous template deduction, deduced {} as both {} and {}",
+                   type->name, it->second, actual);
         return;
     }
 

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -327,8 +327,10 @@ auto deduce_template_params(
 )
     -> std::vector<type_name>
 {
+    node.token.assert_eq(args.size(), sig_params.size(), "invalid number of args to template function");
     auto map = template_map{};
     
+
     auto ret = std::vector<type_name>{};
     for (const auto& name : names) {
         if (!map.contains(name)) {

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -391,7 +391,7 @@ auto deduce_template_params(
     deduced_templates.reserve(names.size());
     for (const auto& name : names) {
         const auto it = name_map.find(name);
-        tok.assert(it != name_map.end(), "unable to deduce type of placeholder {}", name);
+        tok.assert(it != name_map.end(), "unable to deduce type of template {}", name);
         deduced_templates.push_back(it->second);
     }
     return deduced_templates;

--- a/src/compiler.hpp
+++ b/src/compiler.hpp
@@ -67,6 +67,8 @@ struct compiler
     std::vector<module_info> current_module;
     std::vector<struct_info> current_struct;
     std::vector<func_info>   current_function;
+
+    std::vector<std::unordered_set<std::string>> current_placeholders;
 };
 
 auto compile(const anzu_module& ast) -> bytecode_program;

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -178,6 +178,11 @@ auto to_string(const type_ct_bool& type) -> std::string
     return std::format("<comptime_bool: {}>", type.value);
 }
 
+auto to_string(const type_placeholder& type) -> std::string
+{
+    return std::format("<placeholder: {}>", type.name);
+}
+
 auto null_type() -> type_name
 {
     return {type_fundamental::null_type};

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -243,7 +243,8 @@ struct type_name : public std::variant<
     }
 
     auto to_string() const -> std::string {
-        return std::visit([](const auto& obj) { return anzu::to_string(obj); }, *this);
+        const auto inner = std::visit([](const auto& obj) { return anzu::to_string(obj); }, *this);
+        return std::format("{}{}", inner, is_const ? " const" : "");
     }
 };
 

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -171,6 +171,14 @@ struct type_ct_bool
     auto operator==(const type_ct_bool&) const -> bool = default;
 };
 
+struct type_placeholder
+{
+    std::string name;
+
+    auto to_hash() const -> std::size_t { return hash(name); }
+    auto operator==(const type_placeholder&) const -> bool = default;
+};
+
 auto to_string(const type_name& type) -> std::string;
 auto to_string(type_fundamental t) -> std::string;
 auto to_string(const type_array& type) -> std::string;
@@ -188,6 +196,7 @@ auto to_string(const type_function_template& type) -> std::string;
 auto to_string(const type_struct_template& type) -> std::string;
 auto to_string(const type_module& type) -> std::string;
 auto to_string(const type_ct_bool& type) -> std::string;
+auto to_string(const type_placeholder& type) -> std::string;
 
 struct type_name : public std::variant<
     type_fundamental,

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -171,6 +171,7 @@ struct type_ct_bool
     auto operator==(const type_ct_bool&) const -> bool = default;
 };
 
+// Only used during template argument type deduction
 struct type_placeholder
 {
     std::string name;
@@ -214,7 +215,8 @@ struct type_name : public std::variant<
     type_function_template,
     type_struct_template,
     type_module,
-    type_ct_bool>
+    type_ct_bool,
+    type_placeholder>
 {
     using variant::variant;
     


### PR DESCRIPTION
* It is now possible for function templates to be within a call expression. The template arguments will get deduced from the function arguments.
* Implemented by introducing `type_placeholder` to make it possible to have types containing the un-deduced names.
* Deduction only happens for functions for now, but should be easy to implement the same for template structs and bound methods.
* Removed the old `is_lvalue` and `is_value` functions which are unused and also really out of date and incorrect.
* The `current_placeholders` stack on the compiler almost certainly doesn't need to be a stack, because I don't think it's possible to start deducing one function half way through deducing another, but I've done it as a stack anyway just in case.