### PR TITLE
Template Deduction for Bound Methods

### DIFF
--- a/examples/test.az
+++ b/examples/test.az
@@ -11,4 +11,5 @@ struct pair
 }
 
 let p := pair(1, 2);
-p.boo(10);
+let q := p&;
+q.boo(10);

--- a/examples/test.az
+++ b/examples/test.az
@@ -7,8 +7,9 @@ struct pair
     first: i64;
     second: i64;
 
-    fn boo(x: i64) { print("{}\n", x); }
+    fn boo!(T)(x: T) { print("{}\n", x); }
 }
 
-let pa := pair(1, 2);
-let p := pa.boo(10);
+let pa := pair.boo;
+pa(10);
+print("{}\n", @type_name_of(pa));

--- a/examples/test.az
+++ b/examples/test.az
@@ -7,9 +7,8 @@ struct pair
     first: i64;
     second: i64;
 
-    fn boo!(A)(self: const&, x: A) { print("{}\n", x); }
+    fn boo(x: i64) { print("{}\n", x); }
 }
 
-let p := pair(1, 2);
-let q := p&;
-q.boo(10);
+let pa := pair(1, 2);
+let p := pa.boo(10);

--- a/examples/test.az
+++ b/examples/test.az
@@ -2,13 +2,13 @@
 
 
 
-struct pair!(T, U)
+struct pair
 {
-    first: T;
-    second: U;
+    first: i64;
+    second: i64;
 
-    fn boo!(A)(x: i64) { print("{}\n", x); }
+    fn boo!(A)(self: const&, x: A) { print("{}\n", x); }
 }
 
-let p := pair!(i64, u64).boo;
-p(10);
+let p := pair(1, 2);
+p.boo(10);

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -892,10 +892,10 @@ auto push_expr(compiler& com, compile_type ct, const node_call_expr& node) -> ty
     
         // can skip the first param since that's the self parameter so cannot be used to deduce
         // template types anyway
-        auto sig_params = std::vector<node_expr_ptr>{};
-        for (const auto& arg : ast.sig.params | std::views::drop(1)) {
-            sig_params.push_back(arg.type);
-        }
+        const auto sig_params = ast.sig.params
+                              | std::views::drop(1)
+                              | std::views::transform(&node_parameter::type)
+                              | std::ranges::to<std::vector>();
 
         const auto templates = deduce_template_params(com, node.token, ast.templates, sig_params, node.args);
         const auto name = function_name{info->module, info->struct_name, info->name, templates};

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -890,9 +890,8 @@ auto push_expr(compiler& com, compile_type ct, const node_call_expr& node) -> ty
     else if (auto info = type.get_if<type_bound_method_template>()) { // member function call
         const auto& ast = com.function_templates[type_function_template{info->module, info->struct_name, info->name}];
     
-        // can skip the first param since that's the self parameter so cannot be used to deduce
-        // template types anyway
-        const auto sig_params = ast.sig.params
+        // can skip the first param since that's the self parameter
+        const auto sig_params = ast.sig.params 
                               | std::views::drop(1)
                               | std::views::transform(&node_parameter::type)
                               | std::ranges::to<std::vector>();

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -890,7 +890,6 @@ auto push_expr(compiler& com, compile_type ct, const node_call_expr& node) -> ty
     else if (auto info = type.get_if<type_bound_method_template>()) { // member function call
         const auto& ast = com.function_templates[type_function_template{info->module, info->struct_name, info->name}];
     
-
         // can skip the first param since that's the self parameter so cannot be used to deduce
         // template types anyway
         auto sig_params = std::vector<node_expr_ptr>{};

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -160,7 +160,7 @@ auto to_string(const type_function& type) -> std::string
 
 auto to_string(const type_function_template& type) -> std::string
 {
-    return std::format("<function_template: <{}>.{}.{}>", type.module.string(), to_string(type.struct_name), type.name);
+    return std::format("<function_template: <{}>.{}.{}>", type.module.string(), type.struct_name.name, type.name);
 }
 
 auto to_string(const type_struct_template& type) -> std::string


### PR DESCRIPTION
* Another load of code duplication to allow for `type_bound_method_template` to be directly callable and infer template types from the arguments.
* Current implementation skips over the `self` parameter when doing template deduction, meaning it's not possible for `self` to be a template type, which in practice isn't a big deal. The only thing where this may be useful is to allow for C++ "Deducing this" style code where the template type can infer constness. I'll add it if I need it.
* The reason the self param is ignored is because it's just a bit fiddly; it may be cleaner to resolve the signature of a template function earlier on by making use of placeholders, but I'll experiment with that in the future.
* Turns out I have `std::ranges::to` available, so made a bit of use of that.