### PR TITLE
Bound Method Deduction Cleanup

### DIFF
--- a/examples/test.az
+++ b/examples/test.az
@@ -7,9 +7,9 @@ struct pair
     first: i64;
     second: i64;
 
-    fn boo!(T)(x: T) { print("{}\n", x); }
+    fn boo!(T)(self: &, t: T) { print("{}\n", t); }
 }
 
-let pa := pair.boo;
-pa(10);
-print("{}\n", @type_name_of(pa));
+let pa := pair(1, 2);
+let z := pa.boo; # should not be possible? because its always useless
+z(10); # or maybe it should only fail here, because calling it is the realy problem

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,7 +1,3 @@
-
-
-
-
 struct pair
 {
     first: i64;

--- a/examples/test.az
+++ b/examples/test.az
@@ -11,5 +11,3 @@ struct pair
 }
 
 let pa := pair(1, 2);
-let z := pa.boo; # should not be possible? because its always useless
-z(10); # or maybe it should only fail here, because calling it is the realy problem

--- a/src/compilation/type_manager.cpp
+++ b/src/compilation/type_manager.cpp
@@ -3,18 +3,6 @@
 
 namespace anzu {
 
-auto type_manager::add(
-    const type_name& name,
-    const type_fields& fields,
-    const template_map& templates) -> bool
-{
-    if (d_classes.contains(name)) {
-        return false;
-    }
-    d_classes.emplace(name, type_info{fields, templates});
-    return true;
-}
-
 auto type_manager::add_type(const type_name& name, const template_map& templates) -> bool
 {
     if (d_classes.contains(name)) {

--- a/src/compilation/type_manager.cpp
+++ b/src/compilation/type_manager.cpp
@@ -15,6 +15,24 @@ auto type_manager::add(
     return true;
 }
 
+auto type_manager::add_type(const type_name& name, const template_map& templates) -> bool
+{
+    if (d_classes.contains(name)) {
+        return false;
+    }
+    d_classes.emplace(name, type_info{{}, templates});
+    return true;
+}
+
+auto type_manager::add_field(const type_name& name, const type_field& field) -> bool
+{
+    if (!d_classes.contains(name)) {
+        return false;
+    }
+    d_classes[name].fields.push_back(field);
+    return true;
+}
+
 auto type_manager::contains(const type_name& type) const -> bool
 {
     return std::visit(overloaded{

--- a/src/compilation/type_manager.hpp
+++ b/src/compilation/type_manager.hpp
@@ -25,7 +25,7 @@ class type_manager
     std::unordered_map<type_name, type_info> d_classes;
 
 public:
-    auto add_type(const type_name& name, const template_map& templates) -> bool;
+    auto add_type(const type_name& name, const template_map& templates = {}) -> bool;
     auto add_field(const type_name& name, const type_field& field) -> bool;
     auto contains(const type_name& t) const -> bool;
 

--- a/src/compilation/type_manager.hpp
+++ b/src/compilation/type_manager.hpp
@@ -26,6 +26,8 @@ class type_manager
 
 public:
     auto add(const type_name& name, const type_fields& fields, const template_map& templates = {}) -> bool;
+    auto add_type(const type_name& name, const template_map& templates) -> bool;
+    auto add_field(const type_name& name, const type_field& field) -> bool;
     auto contains(const type_name& t) const -> bool;
 
     auto size_of(const type_name& t) const -> std::size_t;

--- a/src/compilation/type_manager.hpp
+++ b/src/compilation/type_manager.hpp
@@ -22,16 +22,16 @@ struct type_info
 
 class type_manager
 {
-    std::unordered_map<type_name, type_info> d_classes;
+    std::unordered_map<type_struct, type_info> d_classes;
 
 public:
-    auto add_type(const type_name& name, const template_map& templates = {}) -> bool;
-    auto add_field(const type_name& name, const type_field& field) -> bool;
-    auto contains(const type_name& t) const -> bool;
+    auto add_type(const type_struct& name, const template_map& templates = {}) -> bool;
+    auto add_field(const type_struct& name, const type_field& field) -> bool;
+    auto contains(const type_struct& t) const -> bool;
 
     auto size_of(const type_name& t) const -> std::size_t;
-    auto fields_of(const type_name& t) const -> type_fields;
-    auto templates_of(const type_name& t) const -> template_map;
+    auto fields_of(const type_struct& t) const -> type_fields;
+    auto templates_of(const type_struct& t) const -> template_map;
 };
 
 }

--- a/src/compilation/type_manager.hpp
+++ b/src/compilation/type_manager.hpp
@@ -25,7 +25,6 @@ class type_manager
     std::unordered_map<type_name, type_info> d_classes;
 
 public:
-    auto add(const type_name& name, const type_fields& fields, const template_map& templates = {}) -> bool;
     auto add_type(const type_name& name, const template_map& templates) -> bool;
     auto add_field(const type_name& name, const type_field& field) -> bool;
     auto contains(const type_name& t) const -> bool;

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -884,7 +884,7 @@ auto push_expr(compiler& com, compile_type ct, const node_template_expr& node) -
         const auto name = function_name{info->module, info->struct_name, info->name, templates};
         const auto func = fetch_function(com, node.token, name);
         push_expr(com, compile_type::val, *node.expr); // push pointer to the instance to bind to
-        return type_bound_method{ func.param_types, *func.return_type, name.to_string(), func.id };
+        return type_bound_method{ func.param_types, *func.return_type, func.id };
     }
     else if (auto info = type.get_if<type_struct_template>()) {
         const auto name = type_struct{ .name=info->name, .module=info->module, .templates=templates };
@@ -1292,12 +1292,7 @@ auto push_expr(compiler& com, compile_type ct, const node_field_expr& node) -> t
         if (stripped.is_const && !actual.remove_ptr().is_const) {
             node.token.error("cannot bind a const variable to a non-const member function");
         }
-        return type_bound_method{
-            .param_types = info.sig.params,
-            .return_type = info.sig.return_type,
-            .name = info.name.to_string(),
-            .id = info.id
-        };
+        return type_bound_method{ info.sig.params, info.sig.return_type, info.id };
     }
 
     // It might be a member function template

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -1602,12 +1602,12 @@ void push_stmt(compiler& com, const node_struct_stmt& node)
 
     const auto sname = type_struct{ .name=node.name, .module=curr_module(com) };
     com.current_struct.emplace_back(sname, template_map{});
-    auto fields = std::vector<type_field>{};
+    com.types.add_type(sname, template_map{});
     for (const auto& p : node.fields) {
-        fields.emplace_back(p.name, resolve_type(com, node.token, p.type));
+        const auto f = type_field{p.name, resolve_type(com, node.token, p.type)};
+        com.types.add_field(sname, f);
     }
 
-    com.types.add(sname, fields);
     for (const auto& function : node.functions) {
         push_stmt(com, *function);
     }

--- a/src/compiler.hpp
+++ b/src/compiler.hpp
@@ -38,12 +38,6 @@ struct module_info
     std::unordered_map<std::string, std::filesystem::path> imports;
 };
 
-struct struct_info
-{
-    type_struct  name;
-    template_map templates;
-};
-
 struct func_info
 {
     std::size_t  id;
@@ -65,7 +59,7 @@ struct compiler
     std::unordered_map<type_struct_template,   node_struct_stmt>   struct_templates;
 
     std::vector<module_info> current_module;
-    std::vector<struct_info> current_struct;
+    std::vector<type_struct> current_struct;
     std::vector<func_info>   current_function;
 
     std::vector<std::unordered_set<std::string>> current_placeholders;

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -124,9 +124,9 @@ auto to_string(const type_builtin& type) -> std::string
 auto to_string(const type_bound_method& type) -> std::string
 {
     return std::format(
-        "<bound method: '{} {}({}) -> {}'>",
+        "<bound_method: '{}({}) -> {}'>",
         to_string(token_type::kw_function),
-        type.name,
+        type.id,
         format_comma_separated(type.param_types),
         to_string_paren(*type.return_type)
     );

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -91,11 +91,11 @@ struct type_builtin
 
 struct type_bound_method
 {
+    std::size_t            id;
     std::vector<type_name> param_types;
     value_ptr<type_name>   return_type;
-    std::size_t            id;
 
-    auto to_hash() const { return hash(param_types, return_type, id); }
+    auto to_hash() const { return hash(id, param_types, return_type); }
     auto operator==(const type_bound_method&) const -> bool = default;
 };
 
@@ -131,6 +131,7 @@ struct type_function
 
     auto to_pointer() const -> type_name;
     auto to_hash() const { return hash(id, param_types, return_type); }
+    auto to_bound_method() -> type_bound_method { return {id, param_types, return_type}; }
     auto operator==(const type_function&) const -> bool = default;
 };
 

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -219,6 +219,7 @@ struct type_name : public std::variant<
     type_placeholder>
 {
     using variant::variant;
+    type_name(const type_name&) = default;
     
     bool is_const = false;
 

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -85,7 +85,7 @@ struct type_builtin
     std::vector<type_name> args;
     value_ptr<type_name>   return_type;
 
-    auto to_hash() const { return hash(name, id); }
+    auto to_hash() const { return hash(name, id, args, return_type); }
     auto operator==(const type_builtin&) const -> bool = default;
 };
 
@@ -93,10 +93,9 @@ struct type_bound_method
 {
     std::vector<type_name> param_types;
     value_ptr<type_name>   return_type;
-    std::string            name; // for printing only
     std::size_t            id;
 
-    auto to_hash() const { return hash(name, id); }
+    auto to_hash() const { return hash(param_types, return_type, id); }
     auto operator==(const type_bound_method&) const -> bool = default;
 };
 

--- a/src/utility/common.hpp
+++ b/src/utility/common.hpp
@@ -77,14 +77,6 @@ inline auto range(std::size_t max) {
     return std::views::iota(std::size_t{0}, max);
 }
 
-template <typename R1, typename R2>
-auto zip(const R1& r1, const R2& r2)
-{
-    const auto size = static_cast<int>(std::min(r1.size(), r2.size()));
-    return std::views::iota(0, size)
-         | std::views::transform([&](int idx) { return std::tie(r1.at(idx), r2.at(idx)); });
-}
-
 struct scope_timer
 {
     using clock_type = std::chrono::steady_clock;


### PR DESCRIPTION
* Remove a lot of duplication in the code for `node_name_expr` and `node_template expr`.
* We only need to type check the first arg of bound method templates in `node_field_expr` where we do it for bound methods. No need to do it in `node_call_expr` and `node_template_expr`, simplfying it further.
* Remove `zip` and use `std::views::zip`.
* The type manager now only stores struct types. Can probably be removed and stored directly in the compiler at some point.
* Only store struct template values in the type manager; the current_struct stack only stores the name now.