### PR TITLE
Subscript Auto-Dereference

### DIFF
--- a/examples/aoc2023-1.az
+++ b/examples/aoc2023-1.az
@@ -41,7 +41,7 @@ while tokens.valid() {
     total_part1 = total_part1 + process_line(line);
 
     for map in mapping[] {
-        line = str.replace(a&, line, map@[0u], map@[1u]);
+        line = str.replace(a&, line, map[0u], map[1u]);
     }
     let part2 := process_line(line);
     total_part2 = total_part2 + part2;


### PR DESCRIPTION
* If we have a pointer `p` to an object of a type with a field `foo`, then `p.foo` is well-defined and is equivalent to `p@.foo`; ie- field access auto-dereferences through pointers. This now applies to subscripts.
* If you have a pointer `p` to an array or span, then `p[n]` is now equivalent to `p@[n]`.
* Now the only real time you *need* to explicitly dereference is if you need the value itself.