### PR TITLE
Improve Performance by ~35%

### DIFF
--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -259,12 +259,12 @@ auto print_node(const node_stmt& root, int indent) -> void
             }
             std::print("\n");
             std::print("{}- FunctionArguments:\n", spaces);
-            for (const auto& param : node.sig.params) {
+            for (const auto& param : node.params) {
                 std::print("    {}:\n", param.name);
                 print_node(*param.type, indent + 1);
             }
             std::print("{}- ReturnType:\n", spaces);
-            print_node(*node.sig.return_type, indent + 1);
+            print_node(*node.return_type, indent + 1);
             std::print("{}- Body\n", spaces);
             print_node(*node.body, indent + 1);
         },

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -245,12 +245,6 @@ struct node_parameter
     node_expr_ptr type;
 };
 
-struct node_signature
-{
-    std::vector<node_parameter> params;
-    node_expr_ptr               return_type;
-};
-
 struct node_sequence_stmt
 {
     std::vector<node_stmt_ptr> sequence;
@@ -337,10 +331,11 @@ struct node_assignment_stmt
 
 struct node_function_stmt
 {
-    std::string              name;
-    std::vector<std::string> templates;
-    node_signature           sig;
-    node_stmt_ptr            body;
+    std::string                 name;
+    std::vector<std::string>    templates;
+    std::vector<node_parameter> params;
+    node_expr_ptr               return_type;
+    node_stmt_ptr               body;
 
     anzu::token token;
 };

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -45,7 +45,7 @@ auto globals(compiler& com) -> variable_manager& {
 
 auto curr_module(const compiler& com) -> const std::filesystem::path&
 {
-    return com.current_module.back().filepath;
+    return com.current_module.back();
 }
 
 auto curr_struct(const compiler& com) -> const type_struct&
@@ -512,11 +512,11 @@ auto load_module(compiler& com, const token& tok, const std::string& filepath) -
 {
     // Add as an available module to the current module, and check for circular deps
     for (const auto& m : com.current_module | std::views::reverse) {
-        if (m.filepath == filepath) {
+        if (m == filepath) {
             std::print("circular dependencey detected:\n");
             for (const auto& mod : com.current_module | std::views::reverse) {
-                std::print("  - {}\n", mod.filepath.string());
-                if (mod.filepath == m.filepath) tok.error("circular dependency");
+                std::print("  - {}\n", mod.string());
+                if (mod == m) tok.error("circular dependency");
             }
         }
     }

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -1454,7 +1454,7 @@ auto push_expr(compiler& com, compile_type ct, const node_intrinsic_expr& node) 
         node.token.assert(std::holds_alternative<node_literal_string_expr>(*node.args[0]), "@module requires a string literal");
         const auto filepath = std::get<node_literal_string_expr>(*node.args[0]).value;
         load_module(com, node.token, filepath);
-        return type_module{.filepath=filepath};
+        return type_module{filepath};
     }
     if (node.name == "fn_ptr") {
         node.token.assert_eq(node.args.size(), 1, "@fn_ptr only accepts one argument");

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -22,7 +22,7 @@ namespace {
 
 // Returns the current function
 auto current(compiler& com) -> function& {
-    return com.functions[com.current_function.back().id];
+    return com.functions[com.current_function.back()];
 }
 
 // Returns the bytecode that we are currently writing to
@@ -403,10 +403,10 @@ auto compile_function(
     -> void
 {
     const auto id = com.functions.size();
-    com.current_function.emplace_back(id, map);
+    com.current_function.emplace_back(id);
     com.current_struct.emplace_back(name.struct_name);
     com.current_module.emplace_back(name.module);
-    com.functions.emplace_back(name, id, variable_manager{true});
+    com.functions.emplace_back(name, id, variable_manager{true}, map);
     const auto [it, success] = com.functions_by_name.emplace(name, id);
     tok.assert(success, "a function with the name '{}' already exists", name);
     
@@ -1177,7 +1177,7 @@ auto push_expr(compiler& com, compile_type ct, const node_name_expr& node) -> ty
     }
 
     // It might be one of the current functions template aliases
-    const auto& map1 = com.current_function.back().templates;
+    const auto& map1 = current(com).templates;
     if (auto it = map1.find(node.name); it != map1.end()) {
         return type_type{it->second};
     }
@@ -1739,7 +1739,7 @@ auto compile(const anzu_module& ast) -> bytecode_program
     const auto fname = function_name{"__main__", no_struct, "$main"};
     com.functions.emplace_back(fname, 0, variable_manager{false});
 
-    com.current_function.emplace_back(0, template_map{});
+    com.current_function.emplace_back(0);
     com.current_struct.emplace_back(fname.struct_name);
     com.current_module.emplace_back(fname.module);
     variables(com).new_scope();

--- a/src/compiler.hpp
+++ b/src/compiler.hpp
@@ -16,21 +16,16 @@
 
 namespace anzu {
 
-struct signature
-{
-    std::vector<type_name> params;
-    type_name              return_type;
-};
-
 struct function
 {
-    function_name    name;
-    std::size_t      id;
-    variable_manager variables;
-    template_map     templates;
+    function_name          name;
+    std::size_t            id;
+    variable_manager       variables;
+    template_map           templates;
+    std::vector<type_name> params;
+    type_name              return_type;
     
     std::vector<std::byte> code = {};
-    signature              sig  = {};
 };
 
 struct compiler

--- a/src/compiler.hpp
+++ b/src/compiler.hpp
@@ -24,8 +24,7 @@ struct function
     template_map           templates;
     std::vector<type_name> params;
     type_name              return_type;
-    
-    std::vector<std::byte> code = {};
+    std::vector<std::byte> code;
 };
 
 struct compiler

--- a/src/compiler.hpp
+++ b/src/compiler.hpp
@@ -27,15 +27,10 @@ struct function
     function_name    name;
     std::size_t      id;
     variable_manager variables;
+    template_map     templates;
     
     std::vector<std::byte> code = {};
     signature              sig  = {};
-};
-
-struct func_info
-{
-    std::size_t  id;
-    template_map templates;
 };
 
 struct compiler
@@ -54,7 +49,7 @@ struct compiler
 
     std::vector<std::filesystem::path> current_module;
     std::vector<type_struct>           current_struct;
-    std::vector<func_info>             current_function;
+    std::vector<std::size_t>           current_function;
 
     std::vector<std::unordered_set<std::string>> current_placeholders;
 };

--- a/src/compiler.hpp
+++ b/src/compiler.hpp
@@ -32,12 +32,6 @@ struct function
     signature              sig  = {};
 };
 
-struct module_info
-{
-    std::filesystem::path                                  filepath;
-    std::unordered_map<std::string, std::filesystem::path> imports;
-};
-
 struct func_info
 {
     std::size_t  id;
@@ -58,9 +52,9 @@ struct compiler
     std::unordered_map<type_function_template, node_function_stmt> function_templates;
     std::unordered_map<type_struct_template,   node_struct_stmt>   struct_templates;
 
-    std::vector<module_info> current_module;
-    std::vector<type_struct> current_struct;
-    std::vector<func_info>   current_function;
+    std::vector<std::filesystem::path> current_module;
+    std::vector<type_struct>           current_struct;
+    std::vector<func_info>             current_function;
 
     std::vector<std::unordered_set<std::string>> current_placeholders;
 };

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -451,11 +451,11 @@ auto parse_function_def_stmt(tokenstream& tokens) -> node_stmt_ptr
         param.name = parse_identifier(tokens);
         tokens.consume_only(token_type::colon);
         param.type = parse_expression(tokens);
-        stmt.sig.params.push_back(param);
+        stmt.params.push_back(param);
     });
 
     if (tokens.consume_maybe(token_type::arrow)) {
-        stmt.sig.return_type = parse_expression(tokens);
+        stmt.return_type = parse_expression(tokens);
     }
     stmt.body = parse_statement(tokens);
     return node;


### PR DESCRIPTION
* The runtime called `apply_op` in a loop which returned true or false to say whether the program should continue. This resulted in a boolean check on every op code!
* This PR removes that by putting the while loop and switch statement in the same function, and `op::end_program` just returns from the function rather than returning a bool.
* This resulted in the aoc2023 solution (in debug mode) to go from 1.8 seconds to 1.1 seconds!
* Also done a lot of smaller cleanup in the compiler; removing superfluous structs and simplifying.