### PR TITLE
More Runtime Optimisations (~12% speedup)

### DIFF
--- a/examples/aoc2023-1.az
+++ b/examples/aoc2023-1.az
@@ -35,7 +35,6 @@ var total_part2 := 0;
 let delim := "\r\n";
 
 var tokens := str.tokenizer.create(input, delim);
-var x := 0;
 while tokens.valid() {
     var line := tokens.current();
     total_part1 = total_part1 + process_line(line);
@@ -47,7 +46,6 @@ while tokens.valid() {
     total_part2 = total_part2 + part2;
 
     tokens.advance();
-    x = x + 1;
 }
 
 print("{} {}\n", total_part1, total_part2);

--- a/src/anzu.m.cpp
+++ b/src/anzu.m.cpp
@@ -31,6 +31,7 @@ auto main(const int argc, const char* argv[]) -> int
         return 1;
     }
 
+    const auto timer = anzu::scope_timer{};
     const auto file = std::filesystem::canonical(argv[1]);
     const auto root = file.parent_path();
     const auto mode = std::string{argv[2]};

--- a/src/bytecode.cpp
+++ b/src/bytecode.cpp
@@ -144,14 +144,19 @@ auto print_op(std::string_view rom, const std::byte* start, const std::byte* ptr
             const auto type_size = read_at<std::uint64_t>(&ptr);
             std::print("RETURN: type_size={}\n", type_size);
         } break;
-        case op::call: {
+        case op::call_static: {
+            const auto id = read_at<std::uint64_t>(&ptr);
             const auto args_size = read_at<std::uint64_t>(&ptr);
-            std::print("CALL: args_size={}\n", args_size);
+            std::print("CALL_PTR: id={} args_size={}\n", id, args_size);
         } break;
-        case op::builtin_call: {
+        case op::call_ptr: {
+            const auto args_size = read_at<std::uint64_t>(&ptr);
+            std::print("CALL_PTR: args_size={}\n", args_size);
+        } break;
+        case op::call_builtin: {
             const auto id = read_at<std::uint64_t>(&ptr);
             const auto& b = get_builtin(id);
-            std::print("BUILTIN_CALL: {}({}) -> {}\n",
+            std::print("CALL_BUILTIN: {}({}) -> {}\n",
                   b->name, format_comma_separated(b->args), b->return_type);
         } break;
         case op::assert: {

--- a/src/bytecode.cpp
+++ b/src/bytecode.cpp
@@ -87,6 +87,10 @@ auto print_op(std::string_view rom, const std::byte* start, const std::byte* ptr
             const auto id = read_at<std::uint64_t>(&ptr);
             std::print("PUSH_FUNCTION_PTR: id={}\n", id);
         } break;
+        case op::offset_index: {
+            const auto size = read_at<std::uint64_t>(&ptr);
+            std::print("OFFSET_INDEX: size={}\n", size);
+        } break;
         case op::arena_new: {
             std::print("ARENA_NEW\n");
         } break;

--- a/src/bytecode.cpp
+++ b/src/bytecode.cpp
@@ -87,9 +87,13 @@ auto print_op(std::string_view rom, const std::byte* start, const std::byte* ptr
             const auto id = read_at<std::uint64_t>(&ptr);
             std::print("PUSH_FUNCTION_PTR: id={}\n", id);
         } break;
-        case op::offset_index: {
+        case op::nth_element_ptr: {
             const auto size = read_at<std::uint64_t>(&ptr);
-            std::print("OFFSET_INDEX: size={}\n", size);
+            std::print("NTH_ELEMENT_PTR: size={}\n", size);
+        } break;
+        case op::nth_element_val: {
+            const auto size = read_at<std::uint64_t>(&ptr);
+            std::print("NTH_ELEMENT_VAL: size={}\n", size);
         } break;
         case op::arena_new: {
             std::print("ARENA_NEW\n");

--- a/src/bytecode.cpp
+++ b/src/bytecode.cpp
@@ -73,6 +73,16 @@ auto print_op(std::string_view rom, const std::byte* start, const std::byte* ptr
             const auto offset = read_at<std::uint64_t>(&ptr);
             std::print("PUSH_PTR_LOCAL: base_ptr + {}\n", offset);
         } break;
+        case op::push_val_global: {
+            const auto offset = read_at<std::uint64_t>(&ptr);
+            const auto size = read_at<std::uint64_t>(&ptr);
+            std::print("PUSH_VAL_GLOBAL: {}, size={}\n", offset, size);
+        } break;
+        case op::push_val_local: {
+            const auto offset = read_at<std::uint64_t>(&ptr);
+            const auto size = read_at<std::uint64_t>(&ptr);
+            std::print("PUSH_VAL_LOCAL: base_ptr + {}, size={}\n", offset, size);
+        } break;
         case op::push_function_ptr: {
             const auto id = read_at<std::uint64_t>(&ptr);
             std::print("PUSH_FUNCTION_PTR: id={}\n", id);

--- a/src/bytecode.hpp
+++ b/src/bytecode.hpp
@@ -37,6 +37,8 @@ enum class op : std::uint8_t
     push_string_literal,
     push_ptr_global,
     push_ptr_local,
+    push_val_global,
+    push_val_local,
     push_function_ptr,
 
     arena_new,

--- a/src/bytecode.hpp
+++ b/src/bytecode.hpp
@@ -41,7 +41,8 @@ enum class op : std::uint8_t
     push_val_local,
     push_function_ptr,
 
-    offset_index,
+    nth_element_ptr,
+    nth_element_val,
 
     arena_new,
     arena_delete,

--- a/src/bytecode.hpp
+++ b/src/bytecode.hpp
@@ -41,6 +41,8 @@ enum class op : std::uint8_t
     push_val_local,
     push_function_ptr,
 
+    offset_index,
+
     arena_new,
     arena_delete,
     arena_alloc,

--- a/src/bytecode.hpp
+++ b/src/bytecode.hpp
@@ -56,8 +56,9 @@ enum class op : std::uint8_t
     jump,
     jump_if_true,
     jump_if_false,
-    call,
-    builtin_call,
+    call_static,
+    call_ptr,
+    call_builtin,
     ret,
     assert,
 

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -1379,9 +1379,7 @@ auto push_expr(compiler& com, compile_type ct, const node_subscript_expr& node) 
         const auto inner = inner_type(stripped);
         const auto index = push_expr(com, compile_type::val, *node.index);
         node.token.assert_eq(index, u64_type(), "subscript argument must be u64, got {}", index);
-        push_value(code(com), op::push_u64, com.types.size_of(inner));
-        push_value(code(com), op::u64_mul);
-        push_value(code(com), op::u64_add); // modify ptr
+        push_value(code(com), op::offset_index, com.types.size_of(inner));
         if (is_array && stripped.is_const) {
             return inner.add_const(); // propagate const to elements
         }

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -1378,12 +1378,8 @@ auto push_expr(compiler& com, compile_type ct, const node_subscript_expr& node) 
     const auto inner = inner_type(stripped);
     const auto index = push_expr(com, compile_type::val, *node.index);
     node.token.assert_eq(index, u64_type(), "subscript argument must be u64, got {}", index);
-
-    if (ct == compile_type::ptr) {
-        push_value(code(com), op::nth_element_ptr, com.types.size_of(inner));
-    } else {
-        push_value(code(com), op::nth_element_val, com.types.size_of(inner));
-    }
+    const auto opcode = ct == compile_type::val ? op::nth_element_val : op::nth_element_ptr;
+    push_value(code(com), opcode, com.types.size_of(inner));
 
     if (is_array && stripped.is_const) {
         return inner.add_const(); // propagate const to elements

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -1554,8 +1554,7 @@ void push_stmt(compiler& com, const node_for_stmt& node)
         push_var_addr(com, node.token, curr_module(com), "$iter");
         push_value(code(com), op::load, sizeof(std::byte*));  
         load_variable(com, node.token, curr_module(com), "$idx");
-        push_value(code(com), op::push_u64, com.types.size_of(inner));
-        push_value(code(com), op::u64_mul, op::u64_add);
+        push_value(code(com), op::offset_index, com.types.size_of(inner));
         declare_var(com, node.token, node.name, inner.add_ptr());
 
         // idx = idx + 1;

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -104,11 +104,17 @@ auto execute_program(bytecode_context& ctx) -> void
                 std::byte* ptr = &ctx.stack.at(frame.base_ptr + offset);
                 ctx.stack.push(ptr, size);
             } break;
-            case op::offset_index: {
+            case op::nth_element_ptr: {
                 const auto size = read_advance<std::uint64_t>(ctx);
                 const auto index = ctx.stack.pop<std::uint64_t>();
                 const auto ptr = ctx.stack.pop<std::byte*>();
                 ctx.stack.push(ptr + index * size);
+            } break;
+            case op::nth_element_val: {
+                const auto size = read_advance<std::uint64_t>(ctx);
+                const auto index = ctx.stack.pop<std::uint64_t>();
+                const auto ptr = ctx.stack.pop<std::byte*>();
+                ctx.stack.push(ptr + index * size, size);
             } break;
             case op::load: {
                 const auto size = read_advance<std::uint64_t>(ctx);

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -356,7 +356,6 @@ auto execute_program(bytecode_context& ctx) -> void
 template <bool Debug>
 auto run(const bytecode_program& prog) -> void
 {
-    const auto timer = scope_timer{};
     bytecode_context ctx{prog.functions, prog.rom};
     ctx.frames.reserve(1000);
     ctx.frames.emplace_back(call_frame{

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -104,6 +104,12 @@ auto execute_program(bytecode_context& ctx) -> void
                 std::byte* ptr = &ctx.stack.at(frame.base_ptr + offset);
                 ctx.stack.push(ptr, size);
             } break;
+            case op::offset_index: {
+                const auto size = read_advance<std::uint64_t>(ctx);
+                const auto index = ctx.stack.pop<std::uint64_t>();
+                const auto ptr = ctx.stack.pop<std::byte*>();
+                ctx.stack.push(ptr + index * size);
+            } break;
             case op::load: {
                 const auto size = read_advance<std::uint64_t>(ctx);
                 const auto ptr = ctx.stack.pop<std::byte*>();

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -216,7 +216,16 @@ auto execute_program(bytecode_context& ctx) -> void
                 ctx.stack.resize(frame.base_ptr + size);
                 ctx.frames.pop_back();
             } break;
-            case op::call: {
+            case op::call_static: {
+                const auto function_id = read_advance<std::uint64_t>(ctx);
+                const auto args_size = read_advance<std::uint64_t>(ctx);
+                ctx.frames.push_back(call_frame{
+                    .code = ctx.functions[function_id].code.data(),
+                    .ip = ctx.functions[function_id].code.data(),
+                    .base_ptr = ctx.stack.size() - args_size
+                });
+            } break;
+            case op::call_ptr: {
                 const auto args_size = read_advance<std::uint64_t>(ctx);
                 const auto function_id = ctx.stack.pop<std::uint64_t>();
                 ctx.frames.push_back(call_frame{
@@ -225,7 +234,7 @@ auto execute_program(bytecode_context& ctx) -> void
                     .base_ptr = ctx.stack.size() - args_size
                 });
             } break;
-            case op::builtin_call: {
+            case op::call_builtin: {
                 const auto id = read_advance<std::uint64_t>(ctx);
                 get_builtin(id)->ptr(ctx);
             } break;


### PR DESCRIPTION
* The way values are loaded onto the stack is inefficient; currently we always push a pointer via `op::push_ptr_local` and `op::push_ptr_global` and then push a separate `op::load`. Added `op::push_val_local` and `op::push_val_global` to load directly in a single instruction. This brought aoc2023 in debug down from 1.1s to 1.02s.
* Added `op::nth_element_ptr` and `op::nth_element_val` which pops an index and a pointer from the stack, and stores a size statically, and pushes a pointer to / value of the element at the index, speeding up both subscripting and for loops, bringing aoc2023 down under a second.
* Added `op::call_static`; all places except for one where we use `op::call`, we know the function pointer statically, so the combination of `op::push_function_ptr` + `op::call` can be replaced by a single instruction. Only in places where we call functions pointers do we (obviously) pay the cost of the double instruction. This doesn't speed up aoc2023 much because there isn't many function calls, but it's a good optimisation to have. Renamed `op::call` to `op::call_ptr` and `op::builtin_call` to `op::call_builtin` for consistency.