### PR TITLE
Template Deduction for Structs

### DIFF
--- a/examples/test.az
+++ b/examples/test.az
@@ -4,5 +4,5 @@ struct foo!(T)
     y: T;
 }
 
-let s := foo(1, 2.0);
+let s := foo(1, 2);
 @type_name_of(s);

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,9 +1,8 @@
-struct pair
+struct foo!(T)
 {
-    first: i64;
-    second: i64;
-
-    fn boo!(T)(self: &, t: T) { print("{}\n", t); }
+    x: T;
+    y: T;
 }
 
-let pa := pair(1, 2);
+let s := foo(1, 2.0);
+@type_name_of(s);


### PR DESCRIPTION
* It is now possible to instantiate instances of struct templates without explicitly declaring the template types.