### PR TITLE
Improve Performance of Span Functionality

### DIFF
--- a/examples/test.az
+++ b/examples/test.az
@@ -1,8 +1,3 @@
-struct foo!(T)
-{
-    x: T;
-    y: T;
-}
-
-let s := foo(1, 2);
-@type_name_of(s);
+let x := [1, 2, 3, 4, 5, 6];
+let y := x[];
+print("{}\n", len(y));

--- a/src/bytecode.cpp
+++ b/src/bytecode.cpp
@@ -95,8 +95,8 @@ auto print_op(std::string_view rom, const std::byte* start, const std::byte* ptr
             const auto size = read_at<std::uint64_t>(&ptr);
             std::print("NTH_ELEMENT_VAL: size={}\n", size);
         } break;
-        case op::push_span_len: {
-            std::print("PUSH_SPAN_LEN\n");
+        case op::span_ptr_to_len: {
+            std::print("SPAN_PTR_TO_LEN\n");
         } break;
         case op::arena_new: {
             std::print("ARENA_NEW\n");

--- a/src/bytecode.cpp
+++ b/src/bytecode.cpp
@@ -95,6 +95,9 @@ auto print_op(std::string_view rom, const std::byte* start, const std::byte* ptr
             const auto size = read_at<std::uint64_t>(&ptr);
             std::print("NTH_ELEMENT_VAL: size={}\n", size);
         } break;
+        case op::push_span_len: {
+            std::print("PUSH_SPAN_LEN\n");
+        } break;
         case op::arena_new: {
             std::print("ARENA_NEW\n");
         } break;

--- a/src/bytecode.cpp
+++ b/src/bytecode.cpp
@@ -98,6 +98,10 @@ auto print_op(std::string_view rom, const std::byte* start, const std::byte* ptr
         case op::span_ptr_to_len: {
             std::print("SPAN_PTR_TO_LEN\n");
         } break;
+        case op::push_subspan: {
+            const auto size = read_at<std::uint64_t>(&ptr);
+            std::print("PUSH_SUBSPAN: size={}\n", size);
+        } break;
         case op::arena_new: {
             std::print("ARENA_NEW\n");
         } break;

--- a/src/bytecode.hpp
+++ b/src/bytecode.hpp
@@ -43,6 +43,7 @@ enum class op : std::uint8_t
 
     nth_element_ptr,
     nth_element_val,
+    push_span_len,
 
     arena_new,
     arena_delete,

--- a/src/bytecode.hpp
+++ b/src/bytecode.hpp
@@ -43,7 +43,7 @@ enum class op : std::uint8_t
 
     nth_element_ptr,
     nth_element_val,
-    push_span_len,
+    span_ptr_to_len,
 
     arena_new,
     arena_delete,

--- a/src/bytecode.hpp
+++ b/src/bytecode.hpp
@@ -44,6 +44,7 @@ enum class op : std::uint8_t
     nth_element_ptr,
     nth_element_val,
     span_ptr_to_len,
+    push_subspan,
 
     arena_new,
     arena_delete,

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -947,7 +947,7 @@ auto push_expr(compiler& com, compile_type ct, const node_template_expr& node) -
         return fetch_function(com, node.token, name).to_bound_method();
     }
     else if (auto info = type.get_if<type_struct_template>()) {
-        const auto name = type_struct{ .name=info->name, .module=info->module, .templates=templates };
+        const auto name = type_struct{info->name, info->module, templates};
         const auto key = type_struct_template{info->module, info->name};
 
         if (!com.types.contains(name) && com.struct_templates.contains(key)) {
@@ -1015,7 +1015,7 @@ auto push_expr(compiler& com, compile_type ct, const node_len_expr& node) -> typ
     }
     else if (type.is<type_span>()) {
         push_expr(com, compile_type::ptr, *node.expr); // pointer to the span
-        push_value(code(com), op::push_span_len);
+        push_value(code(com), op::span_ptr_to_len);
     }
     else if (type.is<type_arena>()) {
         const auto type = push_expr(com, compile_type::ptr, *node.expr);

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -1015,8 +1015,7 @@ auto push_expr(compiler& com, compile_type ct, const node_len_expr& node) -> typ
     }
     else if (type.is<type_span>()) {
         push_expr(com, compile_type::ptr, *node.expr); // pointer to the span
-        push_value(code(com), op::push_u64, sizeof(std::byte*), op::u64_add); // offset to the size value
-        push_value(code(com), op::load, com.types.size_of(u64_type())); // load the size
+        push_value(code(com), op::push_span_len);
     }
     else if (type.is<type_arena>()) {
         const auto type = push_expr(com, compile_type::ptr, *node.expr);

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -1546,9 +1546,7 @@ void push_stmt(compiler& com, const node_for_stmt& node)
 
     // var size := length of iter;
     push_var_addr(com, node.token, curr_module(com), "$iter"); // push pointer to span
-    push_value(code(com), op::push_u64, sizeof(std::byte*));
-    push_value(code(com), op::u64_add); // offset to the size value
-    push_value(code(com), op::load, com.types.size_of(u64_type()));       
+    push_value(code(com), op::span_ptr_to_len);
     declare_var(com, node.token, "$size", u64_type());
 
     push_loop(com, [&] {

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -120,6 +120,14 @@ auto execute_program(bytecode_context& ctx) -> void
                 const std::byte* ptr = ctx.stack.pop<std::byte*>();
                 ctx.stack.push(ptr + sizeof(std::byte*), sizeof(std::uint64_t));
             } break;
+            case op::push_subspan: {
+                const auto type_size = read_advance<std::uint64_t>(ctx);
+                const auto upper = ctx.stack.pop<std::uint64_t>();
+                const auto lower = ctx.stack.pop<std::uint64_t>();
+                const auto ptr = ctx.stack.pop<std::byte*>();
+                ctx.stack.push(ptr + type_size * lower);
+                ctx.stack.push(upper - lower);
+            } break;
             case op::load: {
                 const auto size = read_advance<std::uint64_t>(ctx);
                 const auto ptr = ctx.stack.pop<std::byte*>();

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -116,7 +116,7 @@ auto execute_program(bytecode_context& ctx) -> void
                 const auto ptr = ctx.stack.pop<std::byte*>();
                 ctx.stack.push(ptr + index * size, size);
             } break;
-            case op::push_span_len: {
+            case op::span_ptr_to_len: {
                 const std::byte* ptr = ctx.stack.pop<std::byte*>();
                 ctx.stack.push(ptr + sizeof(std::byte*), sizeof(std::uint64_t));
             } break;

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -116,6 +116,10 @@ auto execute_program(bytecode_context& ctx) -> void
                 const auto ptr = ctx.stack.pop<std::byte*>();
                 ctx.stack.push(ptr + index * size, size);
             } break;
+            case op::push_span_len: {
+                const std::byte* ptr = ctx.stack.pop<std::byte*>();
+                ctx.stack.push(ptr + sizeof(std::byte*), sizeof(std::uint64_t));
+            } break;
             case op::load: {
                 const auto size = read_advance<std::uint64_t>(ctx);
                 const auto ptr = ctx.stack.pop<std::byte*>();


### PR DESCRIPTION
* Added `op::span_ptr_to_len`, which pops a pointer to a span off the stack and pushes the length.
* Added `op::push_subspan` which pops a pointer to a span and upper and lower indices off the stack, and pushes a new span.
* Both of these improve the performance of `aoc2023-1.az` in debug from 0.95s to 0.75s since it makes a lot of calls into these code paths.
* Improve for loops very slightly by making use of `op::span_ptr_to_len` to get the length.