### PR TITLE
Replace `nullptr` with `null`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -114,6 +114,7 @@
         "resumable": "cpp",
         "stacktrace": "cpp",
         "stdfloat": "cpp",
-        "hash_map": "cpp"
+        "hash_map": "cpp",
+        "string_view": "cpp"
     }
 }

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ An interpreted programming language written in C++. This started out as a stack-
     1. eg: If `l` is an array of 5 `i64`s, then `l[]` is an `i64[]`.
     1. Slicing syntax `l[0 : 2]` for creating subspans.
     1. Arrays can automatically convert to spans when passing to functions.
-    1. Null span: spans can be created from, and compared to, `null`. It has a size of zero.
+    1. Null spans: spans can be created from, and compared to, `null`. It has a size of zero.
 
 * Function Pointers:
     1. Function names resolve to function pointers which can be passed to functions.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ An interpreted programming language written in C++. This started out as a stack-
     1. eg: `i64&` is an `i64` pointer.
     1. If `ptr` is an `i64&`, then `ptr@` is the int that it points to.
     1. Uses `@` instead of the familiar `*` because using `*` in trailing syntax can be ambigious with multiplication. Plus I like it more; it signals that I'm using the value "at" the pointer.
-    1. `nullptr` is a value of a special type to is convertible to any pointer type.
+    1. Null pointers: pointers can be created from, and compared to, `null`. It is an error to derefence one.
 
 * Arrays:
     1. Fixed size arrays with statically known size.
@@ -29,7 +29,7 @@ An interpreted programming language written in C++. This started out as a stack-
     1. eg: If `l` is an array of 5 `i64`s, then `l[]` is an `i64[]`.
     1. Slicing syntax `l[0 : 2]` for creating subspans.
     1. Arrays can automatically convert to spans when passing to functions.
-    1. A "null span" of zero elements can be created from `nullptr`.
+    1. Null span: spans can be created from, and compared to, `null`. It has a size of zero.
 
 * Function Pointers:
     1. Function names resolve to function pointers which can be passed to functions.

--- a/examples/feature_test.az
+++ b/examples/feature_test.az
@@ -283,15 +283,15 @@ let contents := io.read_file("examples/example_data.txt", a&);
 print("'{}'\n", contents);
 print("\nsize={}\n", @len(contents));
 
-# nullptr checks
+# null checks
 {
-    var p : i64& = nullptr;
-    var q : i64& = nullptr;
+    var p : i64& = null;
+    var q : i64& = null;
     print("{}\n", p == q);
 
     var x := 10;
     p = x&;
-    print("comparison of a pointer {} to nullptr: {}\n", p, p == nullptr);
+    print("comparison of a pointer {} to null: {}\n", p, p == null);
 }
 
 # template tests

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,3 +1,2 @@
-let x := [1, 2, 3, 4, 5, 6];
-let y := x[];
-print("{}\n", @len(y));
+let x : i64 = null;
+print("{}\n", x);

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,2 +1,2 @@
-let x : i64 = null;
-print("{}\n", x);
+let x : i64[] = null;
+print("{}\n", @len(x));

--- a/lib/vector.az
+++ b/lib/vector.az
@@ -48,6 +48,6 @@ struct vector!(T)
 
     fn create(arr: arena&) -> vector!(T)
     {
-        return vector!(T)(arr, nullptr, 0u);
+        return vector!(T)(arr, null, 0u);
     }
 }

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -31,9 +31,6 @@ auto print_node(const node_expr& root, int indent) -> void
         [&](const node_literal_null_expr&) {
             std::print("{}Literal (null): null\n", spaces);
         },
-        [&](const node_literal_nullptr_expr&) {
-            std::print("{}Literal (nullptr): nullptr\n", spaces);
-        },
         [&](const node_literal_string_expr& node) {
             std::print("{}Literal (string-literal): {}\n", spaces, node.value);
         },

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -56,11 +56,6 @@ struct node_literal_null_expr
     anzu::token token;
 };
 
-struct node_literal_nullptr_expr
-{
-    anzu::token token;
-};
-
 struct node_literal_string_expr
 {
     std::string value;
@@ -209,7 +204,6 @@ struct node_expr : std::variant<
     node_literal_char_expr,
     node_literal_bool_expr,
     node_literal_null_expr,
-    node_literal_nullptr_expr,
     node_literal_string_expr,
     node_unary_op_expr,
     node_binary_op_expr,

--- a/src/compilation/type_manager.cpp
+++ b/src/compilation/type_manager.cpp
@@ -40,7 +40,6 @@ auto type_manager::size_of(const type_name& type) const -> std::size_t
                 case type_fundamental::i64_type:
                 case type_fundamental::u64_type:
                 case type_fundamental::f64_type:
-                case type_fundamental::nullptr_type:
                     return 8;
                 default:
                     panic("unknown fundamental type");

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -246,9 +246,14 @@ void push_copy_typechecked(compiler& com, const node_expr& expr, const type_name
         return;
     }
 
-    // null can convert to a nullptr
+    // null can convert to a null ptr and null span
     if (expected.is<type_ptr>() && actual == null_type()) {
         push_value(code(com), op::push_u64, std::size_t{0}); // push a nullptr
+        return;
+    }
+    if (expected.is<type_span>() && actual == null_type()) {
+        push_value(code(com), op::push_u64, std::size_t{0}); // push a nullptr
+        push_value(code(com), op::push_u64, std::size_t{0}); // push the size
         return;
     }
 

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -69,7 +69,6 @@ auto get_builtin_type(const std::string& name) -> std::optional<type_name>
     if (name == "i64")     return type_name(type_fundamental::i64_type);
     if (name == "u64")     return type_name(type_fundamental::u64_type);
     if (name == "f64")     return type_name(type_fundamental::f64_type);
-    if (name == "nullptr") return type_name(type_fundamental::nullptr_type);
     if (name == "arena")   return type_name(type_arena{});
     return {};
 }
@@ -80,8 +79,8 @@ auto resolve_type(compiler& com, const token& tok, const node_expr_ptr& expr) ->
 {
     const auto type_expr_type = type_of_expr(com, *expr);
     
-    // null and nullptr and also their own types
-    if (type_expr_type == null_type() || type_expr_type == nullptr_type()) {
+    // null is also their own types
+    if (type_expr_type == null_type()) {
         return type_expr_type;
     }
     
@@ -485,7 +484,6 @@ auto push_print_fundamental(compiler& com, const node_expr& node, const token& t
     else if (type == char_type().add_span()) {
         push_value(code(com), op::print_char_span);
     }
-    else if (type == nullptr_type()) { push_value(code(com), op::print_ptr); }
     else if (type.is<type_ptr>()) { push_value(code(com), op::print_ptr); }
     else { tok.error("cannot print value of type {}", type); }
 }
@@ -656,13 +654,6 @@ auto push_expr(compiler& com, compile_type ct, const node_literal_null_expr& nod
     node.token.assert(ct == compile_type::val, "cannot take the address of a null literal");
     push_value(code(com), op::push_null);
     return null_type();
-}
-
-auto push_expr(compiler& com, compile_type ct, const node_literal_nullptr_expr& node) -> type_name
-{
-    node.token.assert(ct == compile_type::val, "cannot take the address of a nullptr literal");
-    push_value(code(com), op::push_nullptr);
-    return nullptr_type();
 }
 
 auto push_expr(compiler& com, compile_type ct, const node_literal_string_expr& node) -> type_name

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -246,6 +246,12 @@ void push_copy_typechecked(compiler& com, const node_expr& expr, const type_name
         return;
     }
 
+    // null can convert to a nullptr
+    if (expected.is<type_ptr>() && actual == null_type()) {
+        push_value(code(com), op::push_u64, std::size_t{0}); // push a nullptr
+        return;
+    }
+
     push_expr(com, compile_type::val, expr);
 
     if (actual == nullptr_type() && expected.is<type_ptr>()) {

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -74,7 +74,6 @@ auto identifier_type(std::string_view token) -> token_type
     if (token == "loop")     return token_type::kw_loop;
     if (token == "new")      return token_type::kw_new;
     if (token == "null")     return token_type::kw_null;
-    if (token == "nullptr")  return token_type::kw_nullptr;
     if (token == "print")    return token_type::kw_print;
     if (token == "return")   return token_type::kw_return;
     if (token == "struct")   return token_type::kw_struct;

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -71,7 +71,6 @@ auto to_string(type_fundamental t) -> std::string
         case type_fundamental::i64_type:     return "i64";
         case type_fundamental::u64_type:     return "u64";
         case type_fundamental::f64_type:     return "f64";
-        case type_fundamental::nullptr_type: return "nullptr";
         default: return "UNKNOWN FUNDAMENTAL";
     }
 }
@@ -186,11 +185,6 @@ auto to_string(const type_placeholder& type) -> std::string
 auto null_type() -> type_name
 {
     return {type_fundamental::null_type};
-}
-
-auto nullptr_type() -> type_name
-{
-    return {type_fundamental::nullptr_type};
 }
 
 auto bool_type() -> type_name

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -31,7 +31,6 @@ enum class type_fundamental : std::uint8_t
     i64_type,
     u64_type,
     f64_type,
-    nullptr_type,
 };
 
 struct type_struct
@@ -253,7 +252,6 @@ struct type_name : public std::variant<
 using template_map = std::unordered_map<std::string, type_name>;
 
 auto null_type() -> type_name;
-auto nullptr_type() -> type_name;
 auto bool_type() -> type_name;
 auto char_type() -> type_name;
 auto i32_type() -> type_name;

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -125,13 +125,6 @@ auto parse_null(tokenstream& tokens) -> node_expr_ptr
     return node;
 }
 
-auto parse_nullptr(tokenstream& tokens) -> node_expr_ptr
-{
-    const auto token = tokens.consume_only(token_type::kw_nullptr);
-    auto [node, inner] = new_node<node_literal_nullptr_expr>(token);
-    return node;
-}
-
 auto parse_name(tokenstream& tokens) -> node_expr_ptr
 {
     const auto token = tokens.consume();
@@ -373,7 +366,6 @@ static const auto rules = std::unordered_map<token_type, parse_rule>
     {token_type::kw_true,             {parse_true,          nullptr,         precedence::none}},
     {token_type::kw_false,            {parse_false,         nullptr,         precedence::none}},
     {token_type::kw_null,             {parse_null,          nullptr,         precedence::none}},
-    {token_type::kw_nullptr,          {parse_nullptr,       nullptr,         precedence::none}},
     {token_type::string,              {parse_string,        nullptr,         precedence::none}},
     {token_type::equal_equal,         {nullptr,             parse_binary,    precedence::equality}},
     {token_type::bang_equal,          {nullptr,             parse_binary,    precedence::equality}},
@@ -391,7 +383,6 @@ static const auto rules = std::unordered_map<token_type, parse_rule>
     {token_type::kw_char,             {parse_name,          nullptr,         precedence::none}},
     {token_type::kw_bool,             {parse_name,          nullptr,         precedence::none}},
     {token_type::kw_null,             {parse_name,          nullptr,         precedence::none}},
-    {token_type::kw_nullptr,          {parse_name,          nullptr,         precedence::none}},
     {token_type::kw_arena,            {parse_name,          nullptr,         precedence::none}},
     {token_type::left_bracket,        {parse_array,         parse_subscript, precedence::call}},
     {token_type::dot,                 {nullptr,             parse_dot,       precedence::call}},

--- a/src/token.cpp
+++ b/src/token.cpp
@@ -62,7 +62,6 @@ auto to_string(token_type tt) -> std::string_view
         case token_type::kw_loop:             return "loop";
         case token_type::kw_new:              return "new";
         case token_type::kw_null:             return "null";
-        case token_type::kw_nullptr:          return "nullptr";
         case token_type::kw_print:            return "print";
         case token_type::kw_return:           return "return";
         case token_type::kw_struct:           return "struct";

--- a/src/token.hpp
+++ b/src/token.hpp
@@ -50,7 +50,6 @@ enum class token_type
     kw_loop,
     kw_new,
     kw_null,
-    kw_nullptr,
     kw_print,
     kw_return,
     kw_struct,


### PR DESCRIPTION
* Removes `nullptr` as a keyword, just use `null` instead.
* `push_copy_typechecked` has been updated to allow for the conversions to null pointers and null spans.
* Binary operation compilation has been updated to allow for comparing pointers to `null`. Maybe should allow for comparison against spans for consistency, but spans can't currently be compared (but maybe they should be).