### PR TITLE
Hash Map Setup

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -116,5 +116,6 @@
         "stdfloat": "cpp",
         "hash_map": "cpp",
         "string_view": "cpp"
-    }
+    },
+    "C_Cpp.errorSquiggles": "disabled"
 }

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Runtime  -- runtime.hpp   : Functionality to run a program
 ```
 
 # Next Features
+* Hash Maps
 * Generators
-* Template Type Deductions
 * Pattern Matching
 * Variants

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ An interpreted programming language written in C++. This started out as a stack-
     * `@type_of(x)` returns the type of `x`. Can be used anywhere a type is expected.
     * `@type_name_of(x)` returns a string representation of the type of `x`.
     * `@copy(dst, src)` takes two spans of the same type and copies the contents of one into the other. The size of `dst` must be big enough to fit `src`, otherwise it's a runtime error. This exists because it can efficiently memcpy the data rather than looping over the elements.
+    * `@compare(lhs, rhs)` takes two pointers of the same type and compares them bytewise via memcmp. 
     * `@char_to_i64(c)` takes a char and converts its value to an i64. This is always a safe conversion, and will likely be removed for a more general form of casting in the future.
     * `@import(name)` for importing and using other modules (more info below). This can only be used in the global scope.
     * `@fn_ptr(func)` takes the name of a function an explicitly converts it to a function pointer.

--- a/README.md
+++ b/README.md
@@ -105,14 +105,15 @@ An interpreted programming language written in C++. This started out as a stack-
 
 * All the common arithmetic, comparison and logical operators.
 * Builtin functions.
-* Intrinsic func:
+* Intrinsic functions.
     * These are special functions for accessing compiler internals or to perform operations that require specialised op codes in the runtime to be efficient. They are prefixed with a `@`.
     * `@size_of(x)` returns the size in bytes of the type of object `x`. `x` can also be itself a type.
     * `@type_of(x)` returns the type of `x`. Can be used anywhere a type is expected.
     * `@type_name_of(x)` returns a string representation of the type of `x`.
     * `@copy(dst, src)` takes two spans of the same type and copies the contents of one into the other. The size of `dst` must be big enough to fit `src`, otherwise it's a runtime error. This exists because it can efficiently memcpy the data rather than looping over the elements.
     * `@char_to_i64(c)` takes a char and converts its value to an i64. This is always a safe conversion, and will likely be removed for a more general form of casting in the future.
-    * `@import(name)` for importing and using other modules (more info below). This can only be used in the global scope and the module itself is only compiled when the module object is assigned to a variable name in a declaration.
+    * `@import(name)` for importing and using other modules (more info below). This can only be used in the global scope.
+    * `@fn_ptr(func)` takes the name of a function an explicitly converts it to a function pointer.
 
 * Memory arenas for allocating dynamic memory:
     ```py

--- a/README.md
+++ b/README.md
@@ -106,15 +106,16 @@ An interpreted programming language written in C++. This started out as a stack-
 * All the common arithmetic, comparison and logical operators.
 * Builtin functions.
 * Intrinsic functions.
-    * These are special functions for accessing compiler internals or to perform operations that require specialised op codes in the runtime to be efficient. They are prefixed with a `@`.
+    * These are special functions for accessing compiler internals or to perform operations that require specialised op codes in the runtime to be efficient. They are prefixed with a `@`. They can also accept types as arguments.
+    * `@len(obj)` behaves differently depending on the object. If it's an array or span, returns the number of elements. If it's an arena, is returns the number of bytes allocated. If it's a struct that has a `.len() -> u64` member function, it calls that. Otherwise it's a compiler error.
     * `@size_of(x)` returns the size in bytes of the type of object `x`. `x` can also be itself a type.
     * `@type_of(x)` returns the type of `x`. Can be used anywhere a type is expected.
     * `@type_name_of(x)` returns a string representation of the type of `x`.
     * `@copy(dst, src)` takes two spans of the same type and copies the contents of one into the other. The size of `dst` must be big enough to fit `src`, otherwise it's a runtime error. This exists because it can efficiently memcpy the data rather than looping over the elements.
     * `@compare(lhs, rhs)` takes two pointers of the same type and compares them bytewise via memcmp. 
-    * `@char_to_i64(c)` takes a char and converts its value to an i64. This is always a safe conversion, and will likely be removed for a more general form of casting in the future.
     * `@import(name)` for importing and using other modules (more info below). This can only be used in the global scope.
     * `@fn_ptr(func)` takes the name of a function an explicitly converts it to a function pointer.
+    * `@is_fundamental(type)` returns `true` if the given type of one of the builtin types.
 
 * Memory arenas for allocating dynamic memory:
     ```py

--- a/examples/feature_test.az
+++ b/examples/feature_test.az
@@ -343,9 +343,9 @@ struct pair!(T)
 {
     var f := pair!(i64)(1, 2);
     var g := pair!(f64)(12.3, 45.6);
-print("HERE I AM\n");
+    print("HERE I AM\n");
     f.print_struct!(u64)(70u);
-print("THERE I AM\n");
+    print("THERE I AM\n");
     g.print_struct!(u64)(70u);
 }
 

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,2 +1,2 @@
-let x := -1 as u64;
+let x := 12.8 as u64;
 print("{}\n", x);

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,3 +1,4 @@
 let util := @import("lib/utility.az");
-let x := -1234;
+let x := null;
+
 print("{}\n", util.hash(x&));

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,2 +1,2 @@
-let x := false as u64;
+let x := null as i64;
 print("{}\n", x);

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,4 +1,11 @@
-let util := @import("lib/utility.az");
-let x := null;
+struct foo
+{
+    x: i64;
+    y: f64;
+}
 
-print("{}\n", util.hash(x&));
+let f := foo(10, 1.0);
+var g := foo(10, 2.0);
+g.y = 1.0;
+
+print("{}\n", @compare(f&, g&));

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,11 +1,1 @@
-struct foo
-{
-    x: i64;
-    y: f64;
-}
-
-let f := foo(10, 1.0);
-var g := foo(10, 2.0);
-g.y = 1.0;
-
-print("{}\n", @compare(f&, g&));
+let x := 10 as u64;

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,2 +1,2 @@
-let x := 12.8 as u64;
+let x := false as u64;
 print("{}\n", x);

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,1 +1,2 @@
-let x := 10 as u64;
+let x := -1 as u64;
+print("{}\n", x);

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,2 +1,4 @@
-let x := null as i64;
-print("{}\n", x);
+let util := @import("lib/utility.az");
+let x := 14u;
+let hash := util.hash(x&);
+print("{}\n", hash);

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,2 +1,3 @@
-let x : i64[] = null;
-print("{}\n", @len(x));
+let util := @import("lib/utility.az");
+let x := -1234;
+print("{}\n", util.hash(x&));

--- a/lib/map.az
+++ b/lib/map.az
@@ -20,12 +20,15 @@ struct map!(Key, Value)
     fn has(self: const&, key: Key const&) -> bool
     {
         let hash := util.hash(key);
-        return hash < self._size && self._data[hash].key
+        return hash < self._size && @compare(key, self._data[hash].key&);
     }
 
     fn get(self: &, key: Key&) -> Value&
     {
         let hash := util.hash(key);
+        assert(self.has(key));
+        
+        return self._data[hash].value&;
     }
 
     fn create(arr: arena&) -> map!(Key, Value)

--- a/lib/map.az
+++ b/lib/map.az
@@ -27,7 +27,7 @@ struct map!(Key, Value)
     {
         let hash := util.hash(key);
         assert(self.has(key));
-        
+
         return self._data[hash].value&;
     }
 

--- a/lib/map.az
+++ b/lib/map.az
@@ -1,0 +1,11 @@
+struct map!(Key, Value)
+{
+    _arr: arena&;
+    _data: T[];
+    _size: u64;
+
+    fn create(arr: arena&) -> map!(Key, Value)
+    {
+        return map!(Key, Value)(arr, null, 0u);
+    }
+}

--- a/lib/map.az
+++ b/lib/map.az
@@ -1,8 +1,32 @@
+let util := @import("lib/utility.az");
+
+struct map_element!(Key, Value)
+{
+    key: Key;
+    value: Value;
+}
+
 struct map!(Key, Value)
 {
     _arr: arena&;
-    _data: T[];
+    _data: map_element!(Key, Value)[];
     _size: u64;
+
+    fn insert(self: &, key: Key&, value: Value&)
+    {
+
+    }
+
+    fn has(self: const&, key: Key const&) -> bool
+    {
+        let hash := util.hash(key);
+        return hash < self._size && self._data[hash].key
+    }
+
+    fn get(self: &, key: Key&) -> Value&
+    {
+        let hash := util.hash(key);
+    }
 
     fn create(arr: arena&) -> map!(Key, Value)
     {

--- a/lib/str.az
+++ b/lib/str.az
@@ -92,7 +92,7 @@ fn occurrences(string: char const[], substr: char const[]) -> u64
 fn replace(a: arena&, string: char const[], from: char const[], to: char const[]) -> char const[]
 {
     let new_size := @len(from) == @len(to) ? @len(string)
-                                         : @len(string) + occurrences(string, from) * (@len(to) - @len(from));
+                                           : @len(string) + occurrences(string, from) * (@len(to) - @len(from));
 
     var new_string := new(a, new_size) ' ';
     var idx := 0u;

--- a/lib/utility.az
+++ b/lib/utility.az
@@ -12,11 +12,6 @@ fn safe_minus(lhs: u64, rhs: u64) -> u64
 
 fn hash!(T)(value: T&) -> u64
 {
-    if T == u64       { return value@; }
-    else if T == i64  { return value@ as u64; }
-    else if T == f64  { return value@ as u64; }
-    else if T == char { return value@ as u64; }
-    else if T == bool { return value ? 1u : 0u; }
-    else if T == null { return 0u; }
-    else              { return value.hash(); }
+    if @is_fundamental(T) { return value@ as u64; }
+    else                  { return value.hash(); }
 }

--- a/lib/utility.az
+++ b/lib/utility.az
@@ -12,25 +12,11 @@ fn safe_minus(lhs: u64, rhs: u64) -> u64
 
 fn hash!(T)(value: T&) -> u64
 {
-    if T == u64 {
-        return value@;
-    }
-    else if T == i64 {
-        return @i64_to_u64(value@);
-    }
-    else if T == f64 {
-        return @f64_to_u64(value@);
-    }
-    else if T == char {
-        return @i64_to_u64(@char_to_i64(value@));
-    }
-    else if T == bool {
-        return value ? 1u : 0u;
-    }
-    else if T == null {
-        return 0u;
-    }
-    else {
-        return value.hash();
-    }
+    if T == u64       { return value@; }
+    else if T == i64  { return @i64_to_u64(value@); }
+    else if T == f64  { return @f64_to_u64(value@); }
+    else if T == char { return @i64_to_u64(@char_to_i64(value@)); }
+    else if T == bool { return value ? 1u : 0u; }
+    else if T == null { return 0u; }
+    else              { return value.hash(); }
 }

--- a/lib/utility.az
+++ b/lib/utility.az
@@ -13,7 +13,7 @@ fn safe_minus(lhs: u64, rhs: u64) -> u64
 fn hash!(T)(value: T&) -> u64
 {
     if T == u64 {
-        return value;
+        return value@;
     }
     else if T == i64 {
         return @i64_to_u64(value@);

--- a/lib/utility.az
+++ b/lib/utility.az
@@ -9,3 +9,28 @@ fn safe_minus(lhs: u64, rhs: u64) -> u64
     assert lhs >= rhs;
     return lhs - rhs;
 }
+
+fn hash!(T)(value: T&) -> u64
+{
+    if T == u64 {
+        return value;
+    }
+    else if T == i64 {
+        return @i64_to_u64(value@);
+    }
+    else if T == f64 {
+        return @f64_to_u64(value@);
+    }
+    else if T == char {
+        return @i64_to_u64(@char_to_i64(value@));
+    }
+    else if T == bool {
+        return value ? 1u : 0u;
+    }
+    else if T == null {
+        return 0u;
+    }
+    else {
+        return value.hash();
+    }
+}

--- a/lib/utility.az
+++ b/lib/utility.az
@@ -13,9 +13,9 @@ fn safe_minus(lhs: u64, rhs: u64) -> u64
 fn hash!(T)(value: T&) -> u64
 {
     if T == u64       { return value@; }
-    else if T == i64  { return @i64_to_u64(value@); }
-    else if T == f64  { return @f64_to_u64(value@); }
-    else if T == char { return @i64_to_u64(@char_to_i64(value@)); }
+    else if T == i64  { return value@ as u64; }
+    else if T == f64  { return value@ as u64; }
+    else if T == char { return value@ as u64; }
     else if T == bool { return value ? 1u : 0u; }
     else if T == null { return 0u; }
     else              { return value.hash(); }

--- a/lib/vector.az
+++ b/lib/vector.az
@@ -41,11 +41,6 @@ struct vector!(T)
         self._size = self._size + 1u;
     }
 
-    fn test!(U)(self: &, u: U) -> null
-    {
-        print("{}\n", u);
-    }
-
     fn create(arr: arena&) -> vector!(T)
     {
         return vector!(T)(arr, null, 0u);

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -158,6 +158,13 @@ auto print_node(const node_expr& root, int indent) -> void
             for (const auto& arg : node.args) {
                 print_node(*arg, indent + 1);
             }
+        },
+        [&](const node_as_expr& node) {
+            std::print("{}As:\n", spaces);
+            std::print("{}- Expr:\n", spaces);
+            print_node(*node.expr, indent + 1);
+            std::print("{}- Type:\n", spaces);
+            print_node(*node.type, indent + 1);
         }
     }, root);
 }

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -196,6 +196,14 @@ struct node_intrinsic_expr
     anzu::token   token;
 };
 
+struct node_as_expr
+{
+    node_expr_ptr expr;
+    node_expr_ptr type;
+
+    anzu::token   token;
+};
+
 struct node_expr : std::variant<
     node_literal_i32_expr,
     node_literal_i64_expr,
@@ -221,7 +229,8 @@ struct node_expr : std::variant<
     node_subscript_expr,
     node_new_expr,
     node_ternary_expr,
-    node_intrinsic_expr>
+    node_intrinsic_expr,
+    node_as_expr>
 {
 };
 

--- a/src/bytecode.cpp
+++ b/src/bytecode.cpp
@@ -180,9 +180,9 @@ auto print_op(std::string_view rom, const std::byte* start, const std::byte* ptr
             const auto data = &rom[index];
             std::print("ASSERT: msg={}\n", std::string_view{data, size});
         } break;
-        case op::char_to_i64: {
-            std::print("CHAR_TO_I64\n");
-        } break;
+        case op::char_to_i64: { std::print("CHAR_TO_I64\n"); } break;
+        case op::i64_to_u64: { std::print("I64_TO_U64\n"); } break;
+        case op::f64_to_u64: { std::print("F64_TO_U64\n"); } break;
         case op::char_eq: { std::print("CHAR_EQ\n"); } break;
         case op::char_ne: { std::print("CHAR_NE\n"); } break;
         case op::i32_add: { std::print("I32_ADD\n"); } break;

--- a/src/bytecode.cpp
+++ b/src/bytecode.cpp
@@ -185,8 +185,12 @@ auto print_op(std::string_view rom, const std::byte* start, const std::byte* ptr
             std::print("ASSERT: msg={}\n", std::string_view{data, size});
         } break;
         case op::char_to_i64: { std::print("CHAR_TO_I64\n"); } break;
+
+        case op::bool_to_u64: { std::print("BOOL_TO_U64\n"); } break;
+        case op::char_to_u64: { std::print("CHAR_TO_U64\n"); } break;
         case op::i64_to_u64: { std::print("I64_TO_U64\n"); } break;
         case op::f64_to_u64: { std::print("F64_TO_U64\n"); } break;
+        
         case op::char_eq: { std::print("CHAR_EQ\n"); } break;
         case op::char_ne: { std::print("CHAR_NE\n"); } break;
         case op::i32_add: { std::print("I32_ADD\n"); } break;

--- a/src/bytecode.cpp
+++ b/src/bytecode.cpp
@@ -141,7 +141,11 @@ auto print_op(std::string_view rom, const std::byte* start, const std::byte* ptr
         } break;
         case op::memcpy: {
             const auto size = read_at<std::uint64_t>(&ptr);
-            std::print("POP: {}\n", size);
+            std::print("MEMCPY: {}\n", size);
+        } break;
+        case op::memcmp: {
+            const auto size = read_at<std::uint64_t>(&ptr);
+            std::print("MEMCMP: {}\n", size);
         } break;
         case op::jump: {
             const auto jump = read_at<std::uint64_t>(&ptr);

--- a/src/bytecode.cpp
+++ b/src/bytecode.cpp
@@ -184,10 +184,18 @@ auto print_op(std::string_view rom, const std::byte* start, const std::byte* ptr
             const auto data = &rom[index];
             std::print("ASSERT: msg={}\n", std::string_view{data, size});
         } break;
+        
+        case op::null_to_i64: { std::print("NULL_TO_I64\n"); } break;
+        case op::bool_to_i64: { std::print("BOOL_TO_I64\n"); } break;
         case op::char_to_i64: { std::print("CHAR_TO_I64\n"); } break;
+        case op::i32_to_i64: { std::print("I32_TO_I64\n"); } break;
+        case op::u64_to_i64: { std::print("U64_TO_I64\n"); } break;
+        case op::f64_to_i64: { std::print("F64_TO_I64\n"); } break;
 
+        case op::null_to_u64: { std::print("NULL_TO_U64\n"); } break;
         case op::bool_to_u64: { std::print("BOOL_TO_U64\n"); } break;
         case op::char_to_u64: { std::print("CHAR_TO_U64\n"); } break;
+        case op::i32_to_u64: { std::print("I32_TO_U64\n"); } break;
         case op::i64_to_u64: { std::print("I64_TO_U64\n"); } break;
         case op::f64_to_u64: { std::print("F64_TO_U64\n"); } break;
         

--- a/src/bytecode.hpp
+++ b/src/bytecode.hpp
@@ -69,6 +69,9 @@ enum class op : std::uint8_t
     assert,
 
     char_to_i64,
+
+    bool_to_u64,
+    char_to_u64,
     i64_to_u64,
     f64_to_u64,
 

--- a/src/bytecode.hpp
+++ b/src/bytecode.hpp
@@ -58,6 +58,7 @@ enum class op : std::uint8_t
     push,
     pop,
     memcpy,
+    memcmp,
     jump,
     jump_if_true,
     jump_if_false,

--- a/src/bytecode.hpp
+++ b/src/bytecode.hpp
@@ -68,6 +68,8 @@ enum class op : std::uint8_t
     assert,
 
     char_to_i64,
+    i64_to_u64,
+    f64_to_u64,
 
     char_eq,
     char_ne,

--- a/src/bytecode.hpp
+++ b/src/bytecode.hpp
@@ -68,20 +68,18 @@ enum class op : std::uint8_t
     ret,
     assert,
 
-    null_to_i64, // TODO
-    bool_to_i64, // TODO
+    null_to_i64,
+    bool_to_i64,
     char_to_i64,
-    i32_to_i64,  // TODO
-    //i64_to_i64,  // NOOP
-    u64_to_i64, // NOOP
-    f64_to_i64, // NOOP
+    i32_to_i64,
+    u64_to_i64,
+    f64_to_i64,
 
-    null_to_u64, // TODO
+    null_to_u64,
     bool_to_u64,
     char_to_u64,
-    i32_to_u64,  // TODO
+    i32_to_u64,
     i64_to_u64,
-    //u64_to_u64, // NOOP
     f64_to_u64,
 
     char_eq,

--- a/src/bytecode.hpp
+++ b/src/bytecode.hpp
@@ -68,11 +68,20 @@ enum class op : std::uint8_t
     ret,
     assert,
 
+    null_to_i64, // TODO
+    bool_to_i64, // TODO
     char_to_i64,
+    i32_to_i64,  // TODO
+    //i64_to_i64,  // NOOP
+    u64_to_i64, // NOOP
+    f64_to_i64, // NOOP
 
+    null_to_u64, // TODO
     bool_to_u64,
     char_to_u64,
+    i32_to_u64,  // TODO
     i64_to_u64,
+    //u64_to_u64, // NOOP
     f64_to_u64,
 
     char_eq,

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -715,6 +715,17 @@ auto push_expr(compiler& com, compile_type ct, const node_binary_op_expr& node) 
         node.token.error("could not find op '{} {} {}'", lhs, node.token.type, rhs);
     }
 
+    // Types can compare to null, since null is also its own type, allows for T == null
+    if ((lhs.is<type_type>() && rhs == null_type()) || (rhs.is<type_type>() && lhs == null_type())) {
+        const auto lhs_inner = lhs.is<type_type>() ? inner_type(lhs) : null_type();
+        const auto rhs_inner = rhs.is<type_type>() ? inner_type(rhs) : null_type();
+        switch (node.token.type) {
+            case tt::equal_equal: return type_name{type_ct_bool{lhs_inner == rhs_inner}};
+            case tt::bang_equal:  return type_name{type_ct_bool{lhs_inner != rhs_inner}};
+        }
+        node.token.error("could not find op '{} {} {}'", lhs, node.token.type, rhs);
+    }
+
     // Pointers can compare to null
     if ((lhs.is<type_ptr>() && rhs == null_type()) || (rhs.is<type_ptr>() && lhs == null_type())) {
         push_ptr(*node.lhs);

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -1518,11 +1518,18 @@ auto push_expr(compiler& com, compile_type ct, const node_as_expr& node) -> type
     const auto dst_wrapped = push_expr(com, ct, *node.type);
     node.token.assert(dst_wrapped.is<type_type>(), "expected a type, got {}", dst_wrapped);
     const auto dst_type = inner_type(dst_wrapped);
+
     using tf = type_fundamental;
     std::visit(overloaded{
         [&](tf src, tf dst) {
             if (src == tf::i64_type && dst == tf::u64_type) {
                 push_value(code(com), op::i64_to_u64);
+            }
+            else if (src == tf::f64_type && dst == tf::u64_type) {
+                push_value(code(com), op::f64_to_u64);
+            }
+            else if (src == tf::char_type && dst == tf::i64_type) {
+                push_value(code(com), op::char_to_i64);
             }
             else {
                 node.token.error("cannot convert expression of type '{}' to '{}'", src_type, dst_type);

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -1422,6 +1422,20 @@ auto push_expr(compiler& com, compile_type ct, const node_intrinsic_expr& node) 
         push_value(code(com), op::char_to_i64);
         return i64_type();
     }
+    if (node.name == "i64_to_u64") {
+        node.token.assert_eq(node.args.size(), 1, "@i64_to_u64 only accepts one argument");
+        const auto type = push_expr(com, ct, *node.args[0]);
+        node.token.assert_eq(type, char_type(), "@i64_to_u64 bad first arg of type '{}'", type);
+        push_value(code(com), op::i64_to_u64);
+        return u64_type();
+    }
+    if (node.name == "f64_to_u64") {
+        node.token.assert_eq(node.args.size(), 1, "@f64_to_u64 only accepts one argument");
+        const auto type = push_expr(com, ct, *node.args[0]);
+        node.token.assert_eq(type, char_type(), "@f64_to_u64 bad first arg of type '{}'", type);
+        push_value(code(com), op::f64_to_u64);
+        return u64_type();
+    }
     if (node.name == "import") {
         node.token.assert(com.current_function.size() == 1, "can only import modules at the top level");
         node.token.assert_eq(node.args.size(), 1, "@module only accepts one argument");

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -1505,15 +1505,38 @@ auto push_expr(compiler& com, compile_type ct, const node_as_expr& node) -> type
                 // noop
             }
 
+            // to i64
+            else if (src == tf::null_type && dst == tf::i64_type) {
+                push_value(code(com), op::null_to_i64);
+            }
+            else if (src == tf::bool_type && dst == tf::i64_type) {
+                push_value(code(com), op::bool_to_i64);
+            }
             else if (src == tf::char_type && dst == tf::i64_type) {
                 push_value(code(com), op::char_to_i64);
             }
+            else if (src == tf::i32_type && dst == tf::i64_type) {
+                push_value(code(com), op::i32_to_i64);
+            }
+            else if (src == tf::u64_type && dst == tf::i64_type) {
+                push_value(code(com), op::u64_to_i64);
+            }
+            else if (src == tf::f64_type && dst == tf::i64_type) {
+                push_value(code(com), op::f64_to_i64);
+            }
 
+            // to u64
+            else if (src == tf::null_type && dst == tf::u64_type) {
+                push_value(code(com), op::null_to_u64);
+            }
             else if (src == tf::bool_type && dst == tf::u64_type) {
                 push_value(code(com), op::bool_to_u64);
             }
             else if (src == tf::char_type && dst == tf::u64_type) {
                 push_value(code(com), op::char_to_u64);
+            }
+            else if (src == tf::i32_type && dst == tf::u64_type) {
+                push_value(code(com), op::i32_to_u64);
             }
             else if (src == tf::i64_type && dst == tf::u64_type) {
                 push_value(code(com), op::i64_to_u64);
@@ -1521,6 +1544,7 @@ auto push_expr(compiler& com, compile_type ct, const node_as_expr& node) -> type
             else if (src == tf::f64_type && dst == tf::u64_type) {
                 push_value(code(com), op::f64_to_u64);
             }
+
             else {
                 node.token.error("cannot convert expression of type '{}' to '{}'", src_type, dst_type);
             }

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -1425,14 +1425,14 @@ auto push_expr(compiler& com, compile_type ct, const node_intrinsic_expr& node) 
     if (node.name == "i64_to_u64") {
         node.token.assert_eq(node.args.size(), 1, "@i64_to_u64 only accepts one argument");
         const auto type = push_expr(com, ct, *node.args[0]);
-        node.token.assert_eq(type, char_type(), "@i64_to_u64 bad first arg of type '{}'", type);
+        node.token.assert_eq(type, i64_type(), "@i64_to_u64 bad first arg of type '{}'", type);
         push_value(code(com), op::i64_to_u64);
         return u64_type();
     }
     if (node.name == "f64_to_u64") {
         node.token.assert_eq(node.args.size(), 1, "@f64_to_u64 only accepts one argument");
         const auto type = push_expr(com, ct, *node.args[0]);
-        node.token.assert_eq(type, char_type(), "@f64_to_u64 bad first arg of type '{}'", type);
+        node.token.assert_eq(type, f64_type(), "@f64_to_u64 bad first arg of type '{}'", type);
         push_value(code(com), op::f64_to_u64);
         return u64_type();
     }

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -1511,6 +1511,11 @@ auto push_expr(compiler& com, compile_type ct, const node_intrinsic_expr& node) 
     node.token.error("no intrisic function named @{} exists", node.name);
 }
 
+auto push_expr(compiler& com, compile_type ct, const node_as_expr& node) -> type_name
+{
+    return null_type();
+}
+
 void push_stmt(compiler& com, const node_sequence_stmt& node)
 {
     variables(com).new_scope();

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -1505,44 +1505,28 @@ auto push_expr(compiler& com, compile_type ct, const node_as_expr& node) -> type
                 // noop
             }
 
-            // to i64
-            else if (src == tf::null_type && dst == tf::i64_type) {
-                push_value(code(com), op::null_to_i64);
-            }
-            else if (src == tf::bool_type && dst == tf::i64_type) {
-                push_value(code(com), op::bool_to_i64);
-            }
-            else if (src == tf::char_type && dst == tf::i64_type) {
-                push_value(code(com), op::char_to_i64);
-            }
-            else if (src == tf::i32_type && dst == tf::i64_type) {
-                push_value(code(com), op::i32_to_i64);
-            }
-            else if (src == tf::u64_type && dst == tf::i64_type) {
-                push_value(code(com), op::u64_to_i64);
-            }
-            else if (src == tf::f64_type && dst == tf::i64_type) {
-                push_value(code(com), op::f64_to_i64);
+            else if (dst == tf::i64_type) {
+                switch (src) {
+                    case tf::null_type: { push_value(code(com), op::null_to_i64); } break;
+                    case tf::bool_type: { push_value(code(com), op::bool_to_i64); } break;
+                    case tf::char_type: { push_value(code(com), op::char_to_i64); } break;
+                    case tf::i32_type:  { push_value(code(com), op::i32_to_i64);  } break;
+                    case tf::i64_type:  { /* noop */ } break;
+                    case tf::u64_type:  { push_value(code(com), op::u64_to_i64);  } break;
+                    case tf::f64_type:  { push_value(code(com), op::f64_to_i64);  } break;
+                }
             }
 
-            // to u64
-            else if (src == tf::null_type && dst == tf::u64_type) {
-                push_value(code(com), op::null_to_u64);
-            }
-            else if (src == tf::bool_type && dst == tf::u64_type) {
-                push_value(code(com), op::bool_to_u64);
-            }
-            else if (src == tf::char_type && dst == tf::u64_type) {
-                push_value(code(com), op::char_to_u64);
-            }
-            else if (src == tf::i32_type && dst == tf::u64_type) {
-                push_value(code(com), op::i32_to_u64);
-            }
-            else if (src == tf::i64_type && dst == tf::u64_type) {
-                push_value(code(com), op::i64_to_u64);
-            }
-            else if (src == tf::f64_type && dst == tf::u64_type) {
-                push_value(code(com), op::f64_to_u64);
+            else if (dst == tf::u64_type) {
+                switch (src) {
+                    case tf::null_type: { push_value(code(com), op::null_to_u64); } break;
+                    case tf::bool_type: { push_value(code(com), op::bool_to_u64); } break;
+                    case tf::char_type: { push_value(code(com), op::char_to_u64); } break;
+                    case tf::i32_type:  { push_value(code(com), op::i32_to_u64);  } break;
+                    case tf::i64_type:  { push_value(code(com), op::i64_to_u64);  } break;
+                    case tf::u64_type:  { /* noop */ } break;
+                    case tf::f64_type:  { push_value(code(com), op::f64_to_u64);  } break;
+                }
             }
 
             else {

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -1426,6 +1426,18 @@ auto push_expr(compiler& com, compile_type ct, const node_intrinsic_expr& node) 
         push_value(code(com), op::memcpy, com.types.size_of(inner_type(lhs)));
         return null_type();
     }
+    if (node.name == "compare") {
+        node.token.assert_eq(node.args.size(), 2, "@compare requires two arguments");
+        const auto lhs = push_expr(com, ct, *node.args[0]);
+        node.token.assert(lhs.is<type_ptr>(), "@compare bad first arg of type '{}'", lhs);
+        const auto rhs = push_expr(com, ct, *node.args[1]);
+        node.token.assert(rhs.is<type_ptr>(), "@compare bad second arg of type '{}'", rhs);
+        node.token.assert_eq(rhs.remove_ptr().remove_const(),
+                             lhs.remove_ptr().remove_const(),
+                             "@copy args must be of the same type");
+        push_value(code(com), op::memcmp, com.types.size_of(lhs.remove_ptr()));
+        return bool_type();
+    }
     if (node.name == "char_to_i64") {
         node.token.assert_eq(node.args.size(), 1, "@char_to_i64 only accepts one argument");
         const auto type = push_expr(com, ct, *node.args[0]);

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -54,6 +54,7 @@ auto lexer::match(std::string_view expected) -> bool
 
 auto identifier_type(std::string_view token) -> token_type
 {
+    if (token == "as")       return token_type::kw_as;
     if (token == "arena")    return token_type::kw_arena;
     if (token == "assert")   return token_type::kw_assert;
     if (token == "bool")     return token_type::kw_bool;

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -18,9 +18,10 @@ auto parse_identifier(tokenstream& tokens) -> std::string;
 
 enum class precedence {
   none,
+  as,          // as
   ternary,     // ?:
   logical_or,  // or
-  logical_and, // andE
+  logical_and, // and
   equality,    // == !=
   comparison,  // < > <= >=
   term,        // + -
@@ -336,6 +337,15 @@ auto parse_ternary(tokenstream& tokens, const node_expr_ptr& left) -> node_expr_
     return node;
 }
 
+auto parse_as(tokenstream& tokens, const node_expr_ptr& left) -> node_expr_ptr
+{
+    const auto token = tokens.consume_only(token_type::kw_as);
+    auto [node, inner] = new_node<node_as_expr>(token);
+    inner.expr = left;
+    inner.type = parse_expression(tokens);
+    return node;
+}
+
 auto parse_precedence(tokenstream& tokens, precedence prec) -> node_expr_ptr
 {
     const auto token = tokens.curr();
@@ -391,7 +401,8 @@ static const auto rules = std::unordered_map<token_type, parse_rule>
     {token_type::ampersand,           {parse_ampersand_pre, parse_ampersand, precedence::call}},
     {token_type::kw_function,         {parse_func_ptr,      nullptr,         precedence::none}},
     {token_type::kw_new,              {parse_new,           nullptr,         precedence::none}},
-    {token_type::question,            {nullptr,             parse_ternary,   precedence::ternary}}
+    {token_type::question,            {nullptr,             parse_ternary,   precedence::ternary}},
+    {token_type::kw_as,               {nullptr,             parse_as,        precedence::as}}
 };
 
 auto get_rule(token_type tt) -> const parse_rule*

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -414,7 +414,7 @@ auto get_rule(token_type tt) -> const parse_rule*
 
 auto parse_expression(tokenstream& tokens) -> node_expr_ptr
 {
-    return parse_precedence(tokens, precedence::ternary);
+    return parse_precedence(tokens, precedence::as);
 }
 
 auto parse_identifier(tokenstream& tokens) -> std::string

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -158,6 +158,13 @@ auto execute_program(bytecode_context& ctx) -> void
                 std::memcpy(dst_data, src_data, src_count * type_size);
                 ctx.stack.push(std::byte{0}); // returns null;
             } break;
+            case op::memcmp: {
+                const auto type_size = read_advance<std::uint64_t>(ctx); 
+                const auto rhs_data = ctx.stack.pop<std::byte*>();
+                const auto lhs_data = ctx.stack.pop<std::byte*>();
+                const bool equal = std::memcmp(lhs_data, rhs_data, type_size) == 0;
+                ctx.stack.push(equal); // returns null;
+            } break;
             case op::arena_new: {
                 const auto arena = new memory_arena;
                 arena->next = 0;

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -275,6 +275,14 @@ auto execute_program(bytecode_context& ctx) -> void
                 const auto value = ctx.stack.pop<char>();
                 ctx.stack.push(std::int64_t{value});
             } break;
+            case op::i64_to_u64: {
+                const auto value = ctx.stack.pop<std::int64_t>();
+                ctx.stack.push(static_cast<std::uint64_t>(value));
+            } break;
+            case op::f64_to_u64: {
+                const auto value = ctx.stack.pop<double>();
+                ctx.stack.push(static_cast<std::uint64_t>(value));
+            } break;
 
             case op::char_eq: { binary_op<char, std::equal_to>(ctx); } break;
             case op::char_ne: { binary_op<char, std::not_equal_to>(ctx); } break;

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -278,17 +278,45 @@ auto execute_program(bytecode_context& ctx) -> void
                 }
             } break;
 
+            case op::null_to_i64: {
+                const auto value = ctx.stack.pop<std::byte>();
+                ctx.stack.push(std::int64_t{0});
+            } break;
+            case op::bool_to_i64: {
+                const auto value = ctx.stack.pop<bool>();
+                ctx.stack.push(static_cast<std::int64_t>(value));
+            } break;
             case op::char_to_i64: {
                 const auto value = ctx.stack.pop<char>();
-                ctx.stack.push(std::int64_t{value});
+                ctx.stack.push(static_cast<std::int64_t>(value));
+            } break;
+            case op::i32_to_i64: {
+                const auto value = ctx.stack.pop<std::int32_t>();
+                ctx.stack.push(static_cast<std::int64_t>(value));
+            } break;
+            case op::u64_to_i64: {
+                const auto value = ctx.stack.pop<std::uint64_t>();
+                ctx.stack.push(static_cast<std::int64_t>(value));
+            } break;
+            case op::f64_to_i64: {
+                const auto value = ctx.stack.pop<double>();
+                ctx.stack.push(static_cast<std::int64_t>(value));
             } break;
 
+            case op::null_to_u64: {
+                const auto value = ctx.stack.pop<std::byte>();
+                ctx.stack.push(std::uint64_t{0});
+            } break;
             case op::bool_to_u64: {
                 const auto value = ctx.stack.pop<bool>();
                 ctx.stack.push(static_cast<std::uint64_t>(value));
             } break;
             case op::char_to_u64: {
                 const auto value = ctx.stack.pop<char>();
+                ctx.stack.push(static_cast<std::uint64_t>(value));
+            } break;
+            case op::i32_to_u64: {
+                const auto value = ctx.stack.pop<std::int32_t>();
                 ctx.stack.push(static_cast<std::uint64_t>(value));
             } break;
             case op::i64_to_u64: {

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -282,6 +282,15 @@ auto execute_program(bytecode_context& ctx) -> void
                 const auto value = ctx.stack.pop<char>();
                 ctx.stack.push(std::int64_t{value});
             } break;
+
+            case op::bool_to_u64: {
+                const auto value = ctx.stack.pop<bool>();
+                ctx.stack.push(static_cast<std::uint64_t>(value));
+            } break;
+            case op::char_to_u64: {
+                const auto value = ctx.stack.pop<char>();
+                ctx.stack.push(static_cast<std::uint64_t>(value));
+            } break;
             case op::i64_to_u64: {
                 const auto value = ctx.stack.pop<std::int64_t>();
                 ctx.stack.push(static_cast<std::uint64_t>(value));

--- a/src/token.cpp
+++ b/src/token.cpp
@@ -42,6 +42,7 @@ auto to_string(token_type tt) -> std::string_view
         case token_type::identifier:          return "identifier";
         case token_type::int32:               return "int32";
         case token_type::int64:               return "int64";
+        case token_type::kw_as:               return "as";
         case token_type::kw_arena:            return "arena";
         case token_type::kw_assert:           return "assert";
         case token_type::kw_bool:             return "bool";

--- a/src/token.hpp
+++ b/src/token.hpp
@@ -30,6 +30,7 @@ enum class token_type
     identifier,
     int32,
     int64,
+    kw_as,
     kw_arena,
     kw_assert,
     kw_bool,


### PR DESCRIPTION
* A bunch of tools and improvements needed in order to implement a hash map. More are needed but this is a start.
* Added `<expr> as <type>` syntax, inspired by rust. Currently only `as i64` and `as u64` for fundamental types is implemented.
* Removed `@char_to_i64`.
* Added `@compare(lhs, rhs)` intrinsic which is a safe wrapper for `memcmp`.
* Added `@is_fundamental(type)` intrinsic which returns true if and only if the given type is a fundamental type. This along with the `as` statement makes implementing the standard hash function simpler.
* Implemented the compile time check `T == null` which was previously broken because `null` is itself its own type, so `T == null` would drop into the value comparison for null rather than type comparison. Maybe `null_type` should be included, but I don't like that.
* Started implementing a hash map, but not complete yet.