### PR TITLE
Single Type Type

### DIFF
--- a/examples/test.az
+++ b/examples/test.az
@@ -1,3 +1,6 @@
-print("{}\n", @type_name_of(5));
-print("{}\n", @type_name_of(i64));
-print("{}\n", @type_of(i64) == type);
+
+if 2 == 2 {
+    print("A\n");
+} else {
+    print("B\n");
+}

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,8 +1,3 @@
-let io := @import("lib/io.az");
-
-fn foo(m: module)
-{
-    m.bar();
-}
-
-foo(io);
+print("{}\n", @type_name_of(5));
+print("{}\n", @type_name_of(i64));
+print("{}\n", @type_of(i64) == type);

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -84,15 +84,16 @@ auto get_builtin_type(const std::string& name) -> std::optional<type_name>
 // Otherwise program is ill-formed.
 auto resolve_type(compiler& com, const token& tok, const node_expr_ptr& expr) -> type_name
 {
-    const auto type_expr_type = type_of_expr(com, *expr).type;
+    const auto [type, value] = type_of_expr(com, *expr);
     
     // null is also their own types
-    if (type_expr_type == null_type()) {
-        return type_expr_type;
+    if (type == null_type()) {
+        return type;
     }
     
-    tok.assert(type_expr_type.is<type_type>(), "expected type expression, got {}", type_expr_type);
-    return *type_expr_type.as<type_type>().type_val;
+    tok.assert(type.is<type_type>(), "expected type expression, got {}", type);
+    tok.assert(value.is<value_ptr<type_name>>(), "type needs to be known at compile time");
+    return *value.as<value_ptr<type_name>>();
 }
 
 auto resolve_types(compiler& com, const token& tok, const std::vector<node_expr_ptr>& exprs)
@@ -724,17 +725,21 @@ auto push_expr(compiler& com, compile_type ct, const node_binary_op_expr& node) 
 
     // Allow for comparisons of types
     if (lhs.is<type_type>() && rhs.is<type_type>()) {
+        node.token.assert(lhs_value.is<value_ptr<type_name>>(), "value of type must be known at compile time");
+        node.token.assert(rhs_value.is<value_ptr<type_name>>(), "value of type must be known at compile time");
+        const auto l = *lhs_value.as<value_ptr<type_name>>();
+        const auto r = *rhs_value.as<value_ptr<type_name>>();
         switch (node.token.type) {
-            case tt::equal_equal: return { bool_type(), {*lhs.as<type_type>().type_val == *rhs.as<type_type>().type_val} };
-            case tt::bang_equal:  return { bool_type(), {*lhs.as<type_type>().type_val != *rhs.as<type_type>().type_val} };
+            case tt::equal_equal: return { bool_type(), {l == r} };
+            case tt::bang_equal:  return { bool_type(), {l != r} };
         }
         node.token.error("could not find op '{} {} {}'", lhs, node.token.type, rhs);
     }
 
     // Types can compare to null, since null is also its own type, allows for T == null
     if ((lhs.is<type_type>() && rhs == null_type()) || (rhs.is<type_type>() && lhs == null_type())) {
-        const auto lhs_inner = lhs.is<type_type>() ? *lhs.as<type_type>().type_val : null_type();
-        const auto rhs_inner = rhs.is<type_type>() ? *rhs.as<type_type>().type_val : null_type();
+        const auto lhs_inner = lhs_value.is<value_ptr<type_name>>() ? *lhs_value.as<value_ptr<type_name>>() : null_type();
+        const auto rhs_inner = rhs_value.is<value_ptr<type_name>>() ? *rhs_value.as<value_ptr<type_name>>() : null_type();
         switch (node.token.type) {
             case tt::equal_equal: return { bool_type(), {lhs_inner == rhs_inner} };
             case tt::bang_equal:  return { bool_type(), {lhs_inner != rhs_inner} };
@@ -864,15 +869,17 @@ auto push_expr(compiler& com, compile_type ct, const node_binary_op_expr& node) 
 auto push_expr(compiler& com, compile_type ct, const node_call_expr& node) -> expr_result
 {
     node.token.assert(ct == compile_type::val, "cannot take the address of a call expression");
-    const auto type = type_of_expr(com, *node.expr).type;
+    const auto [type, value] = type_of_expr(com, *node.expr);
 
     if (auto info = type.get_if<type_type>()) { // constructor
+        node.token.assert(value.is<value_ptr<type_name>>(), "value of type must be known at compile time");
+        const auto inner = *value.as<value_ptr<type_name>>();
         if (node.args.empty()) { // default constructor
-            push_value(code(com), op::push, com.types.size_of(*info->type_val));
+            push_value(code(com), op::push, com.types.size_of(inner));
         } else {
-            push_args_typechecked(com, node.token, node.args, constructor_params(com, *info->type_val));
+            push_args_typechecked(com, node.token, node.args, constructor_params(com, inner));
         }
-        return { *info->type_val };
+        return { inner };
     }
     else if (auto info = type.get_if<type_struct_template>()) {
         const auto& ast = com.struct_templates[*info];
@@ -974,7 +981,7 @@ auto push_expr(compiler& com, compile_type ct, const node_template_expr& node) -
         }
 
         node.token.assert(com.types.contains(name), "could not find struct {}", type_name{name});
-        return { type_type{type_name{name}}, {type_name{name}} };
+        return { type_type{}, {type_name{name}} };
     }
     node.token.error("object of type {} can not be called with template parameters", type);
 }
@@ -1014,11 +1021,12 @@ auto push_expr(compiler& com, compile_type ct, const node_addrof_expr& node) -> 
             curr_struct(com) != no_struct,
             "Tried to use a bare '&', but this only makes sense for member functions"
         );
-        return { type_type{type_name{curr_struct(com)}.add_ptr()}, {type_name{curr_struct(com)}.add_ptr()} };
+        return { type_type{}, {type_name{curr_struct(com)}.add_ptr()} };
     }
-    const auto type = type_of_expr(com, *node.expr).type;
+    const auto [type, value] = type_of_expr(com, *node.expr);
     if (type.is<type_type>()) {
-        return { type_type{type.as<type_type>().type_val->add_ptr()}, {type.as<type_type>().type_val->add_ptr()} };
+        node.token.assert(value.is<value_ptr<type_name>>(), "value of type must be known at compile time");
+        return { type_type{}, {value.as<value_ptr<type_name>>()->add_ptr()} };
     }
     if (com.types.size_of(type) == 0) {
         node.token.error("cannot take address of a type of size 0 (type={})", type);
@@ -1034,9 +1042,10 @@ auto push_expr(compiler& com,compile_type ct, const node_span_expr& node) -> exp
         node.token.error("a span must either have both bounds set, or neither");
     }
 
-    const auto type = type_of_expr(com, *node.expr).type;
+    const auto [type, value] = type_of_expr(com, *node.expr);
     if (type.is<type_type>()) {
-        return { type_type{type.as<type_type>().type_val->add_span()}, {type.as<type_type>().type_val->add_span()} };
+        node.token.assert(value.is<value_ptr<type_name>>(), "value of type must be known at compile time");
+        return { type_type{}, {value.as<value_ptr<type_name>>()->add_span()} };
     }
 
     node.token.assert(
@@ -1096,7 +1105,7 @@ auto push_expr(compiler& com, compile_type ct, const node_function_ptr_type_expr
         inner.param_types.push_back(resolve_type(com, node.token, param));
     }
     inner.return_type = resolve_type(com, node.token, node.return_type);
-    return { type_type{type}, {type} };
+    return { type_type{}, {type} };
 }
 
 auto push_expr(compiler& com, compile_type ct, const node_const_expr& node) -> expr_result
@@ -1106,12 +1115,14 @@ auto push_expr(compiler& com, compile_type ct, const node_const_expr& node) -> e
             curr_struct(com) != no_struct,
             "Tried to use a bare 'const', but this only makes sense for member functions"
         );
-        return { type_type{type_name{curr_struct(com)}.add_const()}, {type_name{curr_struct(com)}.add_const()} };
+        return { type_type{}, {type_name{curr_struct(com)}.add_const()} };
     }
-    const auto type = type_of_expr(com, *node.expr).type;
+
+    const auto [type, value] = type_of_expr(com, *node.expr);
     if (type.is<type_type>()) {
         node.token.assert(ct == compile_type::val, "cannot take the address of a const type-expression");
-        return { type_type{type.as<type_type>().type_val->add_const()}, {type.as<type_type>().type_val->add_const()}};
+        node.token.assert(value.is<value_ptr<type_name>>(), "value of type must be known at compile time");
+        return { type_type{}, {value.as<value_ptr<type_name>>()->add_const()} };
     }
 
     const auto [t, v] = push_expr(com, ct, *node.expr);
@@ -1183,7 +1194,7 @@ auto push_expr(compiler& com, compile_type ct, const node_name_expr& node) -> ex
     // It might be a struct
     const auto sname = type_struct{node.name, curr_module(com)};
     if (com.types.contains(sname)) {
-        return { type_type{type_name{sname}}, {type_name{sname}} };
+        return { type_type{}, {type_name{sname}} };
     }
 
     // It might be a struct template
@@ -1196,24 +1207,24 @@ auto push_expr(compiler& com, compile_type ct, const node_name_expr& node) -> ex
     // It might be a fundamental type
     if (const auto t = get_builtin_type(node.name); t.has_value()) {
         node.token.assert(ct == compile_type::val, "cannot take the address of a type");
-        return { type_type{*t}, {*t} };
+        return { type_type{}, {*t} };
     }
 
     // It might be one of the current functions template aliases
     const auto& map1 = current(com).templates;
     if (auto it = map1.find(node.name); it != map1.end()) {
-        return { type_type{it->second}, {it->second} };
+        return { type_type{}, {it->second} };
     }
 
     // It might be one of the current structs template aliases
     const auto map2 = com.types.templates_of(curr_struct(com));
     if (auto it = map2.find(node.name); it != map2.end()) {
-        return { type_type{it->second}, {it->second} };
+        return { type_type{}, {it->second} };
     }
 
     // It might be a tempalte placeholder for a type the needs to be deduced
     if (!com.current_placeholders.empty() && com.current_placeholders.back().contains(node.name)) {
-        return { type_type{type_name{type_placeholder{node.name}}}, {type_name{type_placeholder{node.name}}} };
+        return { type_type{}, {type_name{type_placeholder{node.name}}} };
     }
 
     // The name might be a builtin (no module, struct or templates, so just the name);
@@ -1259,7 +1270,7 @@ auto push_expr(compiler& com, compile_type ct, const node_field_expr& node) -> e
         const auto sname = type_struct{ node.name, filepath };
         if (com.types.contains(sname)) {
             node.token.assert(ct == compile_type::val, "cannot take the address of a struct");
-            return { type_type{type_name{sname}}, {type_name{sname}} };
+            return { type_type{}, {type_name{sname}} };
         }
 
         // It might be a struct template
@@ -1277,23 +1288,27 @@ auto push_expr(compiler& com, compile_type ct, const node_field_expr& node) -> e
     }
     
     // If the expression is a type, allow for accessing the functions (only makes sense on structs)
-    if (type.is<type_type>() && type.as<type_type>().type_val->is<type_struct>()) {
-        const auto struct_info = type.as<type_type>().type_val->as<type_struct>();
-         
-        const auto fname = function_name{struct_info.module, struct_info, node.name};
-        if (const auto it = com.functions_by_name.find(fname); it != com.functions_by_name.end()) {
-            node.token.assert(ct == compile_type::val, "cannot take the address of a function");
-            const auto& func = com.functions[it->second];
-            return { type_function{func.id, func.params, func.return_type} };   
-        }
+    if (type.is<type_type>()) {
+        node.token.assert(value.is<value_ptr<type_name>>(), "value of type must be known at compile time");
+        const auto& actual = value.as<value_ptr<type_name>>();
+        if (actual->is<type_struct>()) {
+            const auto struct_info = actual->as<type_struct>();
+            
+            const auto fname = function_name{struct_info.module, struct_info, node.name};
+            if (const auto it = com.functions_by_name.find(fname); it != com.functions_by_name.end()) {
+                node.token.assert(ct == compile_type::val, "cannot take the address of a function");
+                const auto& func = com.functions[it->second];
+                return { type_function{func.id, func.params, func.return_type} };   
+            }
 
-        // It might be a function template
-        if (com.function_templates.contains(fname.as_template())) {
-            node.token.assert(ct == compile_type::val, "cannot take the address of a function template");
-            return { type_function_template{fname.module, struct_info, node.name} };
-        }
+            // It might be a function template
+            if (com.function_templates.contains(fname.as_template())) {
+                node.token.assert(ct == compile_type::val, "cannot take the address of a function template");
+                return { type_function_template{fname.module, struct_info, node.name} };
+            }
 
-        node.token.error("can only access member functions from structs");
+            node.token.error("can only access member functions from structs");
+        }
     }
     
     const auto stripped = strip_pointers(type);
@@ -1367,12 +1382,13 @@ auto push_expr(compiler& com, compile_type ct, const node_deref_expr& node) -> e
 
 auto push_expr(compiler& com, compile_type ct, const node_subscript_expr& node) -> expr_result
 {
-    const auto type = type_of_expr(com, *node.expr).type;
+    const auto [type, value] = type_of_expr(com, *node.expr);
     if (type.is<type_type>()) {
         const auto [index_type, index_value] = type_of_expr(com, *node.index);
         node.token.assert(index_type == u64_type(), "index must be a u64, got '{}'", index_type);
         node.token.assert(index_value.is<std::uint64_t>(), "array size must be known at compile time");
-        return { type_type{type.as<type_type>().type_val->add_array(index_value.as<std::uint64_t>())}, {type.as<type_type>().type_val->add_array(index_value.as<std::uint64_t>())}};
+        node.token.assert(value.is<value_ptr<type_name>>(), "value of type must be known at compile time");
+        return { type_type{}, {value.as<value_ptr<type_name>>()->add_array(index_value.as<std::uint64_t>())}};
     }
 
     const auto stripped = strip_pointers(type);
@@ -1394,7 +1410,7 @@ auto push_expr(compiler& com, compile_type ct, const node_subscript_expr& node) 
         if (is_array) return *stripped.as<type_array>().inner_type;
         return *stripped.as<type_span>().inner_type;
     }();
-    
+
     const auto index = push_expr(com, compile_type::val, *node.index).type;
     node.token.assert_eq(index, u64_type(), "subscript argument must be u64, got {}", index);
     const auto opcode = ct == compile_type::val ? op::nth_element_val : op::nth_element_ptr;
@@ -1469,9 +1485,10 @@ auto push_expr(compiler& com, compile_type ct, const node_intrinsic_expr& node) 
     }
     if (node.name == "size_of") {
         node.token.assert_eq(node.args.size(), 1, "@size_of only accepts one argument");
-        const auto type = type_of_expr(com, *node.args[0]).type;
+        const auto [type, value] = type_of_expr(com, *node.args[0]);
         if (type.is<type_type>()) { // can call sizeof on a type directly
-            push_value(code(com), op::push_u64, com.types.size_of(*type.as<type_type>().type_val));
+            node.token.assert(value.is<value_ptr<type_name>>(), "value of type must be known at compile time");
+            push_value(code(com), op::push_u64, com.types.size_of(*value.as<value_ptr<type_name>>()));
         } else {
             push_value(code(com), op::push_u64, com.types.size_of(type));
         }
@@ -1479,7 +1496,7 @@ auto push_expr(compiler& com, compile_type ct, const node_intrinsic_expr& node) 
     }
     if (node.name == "type_of") {
         node.token.assert_eq(node.args.size(), 1, "@type_of only accepts one argument");
-        return { type_type{type_of_expr(com, *node.args[0]).type}, {type_of_expr(com, *node.args[0]).type} };
+        return { type_type{}, {type_of_expr(com, *node.args[0]).type} };
     }
     if (node.name == "type_name_of") {
         node.token.assert_eq(node.args.size(), 1, "@type_name_of only accepts one argument");
@@ -1529,9 +1546,10 @@ auto push_expr(compiler& com, compile_type ct, const node_intrinsic_expr& node) 
     }
     if (node.name == "is_fundamental") {
         node.token.assert_eq(node.args.size(), 1, "@is_fundamental only accepts one argument");
-        const auto type = type_of_expr(com, *node.args[0]).type;
+        const auto [type, value] = type_of_expr(com, *node.args[0]);
         node.token.assert(type.is<type_type>(), "@is_fundamental expects a type");
-        return { bool_type(), {type.as<type_type>().type_val->is<type_fundamental>()} };
+        node.token.assert(value.is<value_ptr<type_name>>(), "value of type must be known at compile time");
+        return { bool_type(), {value.as<value_ptr<type_name>>()->is<type_fundamental>()} };
     }
     node.token.error("no intrisic function named @{} exists", node.name);
 }
@@ -1540,9 +1558,10 @@ auto push_expr(compiler& com, compile_type ct, const node_as_expr& node) -> expr
 {
     node.token.assert(ct == compile_type::val, "cannot take the address of an 'as' statement");
     const auto src_type = push_expr(com, ct, *node.expr).type;
-    const auto dst_wrapped = push_expr(com, ct, *node.type).type;
+    const auto [dst_wrapped, dst_val] = push_expr(com, ct, *node.type);
     node.token.assert(dst_wrapped.is<type_type>(), "expected a type, got {}", dst_wrapped);
-    const auto dst_type = *dst_wrapped.as<type_type>().type_val;
+    node.token.assert(dst_val.is<value_ptr<type_name>>(), "value of type must be known at compile time");
+    const auto dst_type = *dst_val.as<value_ptr<type_name>>();
 
     using tf = type_fundamental;
     std::visit(overloaded{

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -77,6 +77,7 @@ auto get_builtin_type(const std::string& name) -> std::optional<type_name>
     if (name == "f64")     return type_name(type_fundamental::f64_type);
     if (name == "module")  return type_name(type_fundamental::module_type);
     if (name == "arena")   return type_name(type_arena{});
+    if (name == "type")    return type_name(type_type{});
     return {};
 }
 
@@ -730,8 +731,14 @@ auto push_expr(compiler& com, compile_type ct, const node_binary_op_expr& node) 
         const auto l = *lhs_value.as<value_ptr<type_name>>();
         const auto r = *rhs_value.as<value_ptr<type_name>>();
         switch (node.token.type) {
-            case tt::equal_equal: return { bool_type(), {l == r} };
-            case tt::bang_equal:  return { bool_type(), {l != r} };
+            case tt::equal_equal: {
+                push_value(code(com), op::push_bool, l == r);
+                return { bool_type(), {l == r} };
+            } break;
+            case tt::bang_equal: {
+                push_value(code(com), op::push_bool, l != r);
+                return { bool_type(), {l != r} };
+            } break;
         }
         node.token.error("could not find op '{} {} {}'", lhs, node.token.type, rhs);
     }
@@ -741,8 +748,14 @@ auto push_expr(compiler& com, compile_type ct, const node_binary_op_expr& node) 
         const auto lhs_inner = lhs_value.is<value_ptr<type_name>>() ? *lhs_value.as<value_ptr<type_name>>() : null_type();
         const auto rhs_inner = rhs_value.is<value_ptr<type_name>>() ? *rhs_value.as<value_ptr<type_name>>() : null_type();
         switch (node.token.type) {
-            case tt::equal_equal: return { bool_type(), {lhs_inner == rhs_inner} };
-            case tt::bang_equal:  return { bool_type(), {lhs_inner != rhs_inner} };
+            case tt::equal_equal: {
+                push_value(code(com), op::push_bool, lhs_inner == rhs_inner);
+                return { bool_type(), {lhs_inner == rhs_inner} };
+            } break;
+            case tt::bang_equal: {
+                push_value(code(com), op::push_bool, lhs_inner != rhs_inner);
+                return { bool_type(), {lhs_inner != rhs_inner} };
+            } break;
         }
         node.token.error("could not find op '{} {} {}'", lhs, node.token.type, rhs);
     }

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -149,7 +149,7 @@ auto to_string(const type_arena& type) -> std::string
 
 auto to_string(const type_type& type) -> std::string
 {
-    return std::format("<type: {}>", *type.type_val);
+    return std::format("type");
 }
 
 auto to_string(const type_function& type) -> std::string

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -245,19 +245,4 @@ auto type_name::remove_span() const -> type_name
     return *as<type_span>().inner_type;
 }
 
-auto inner_type(const type_name& t) -> type_name
-{
-    if (auto type = t.get_if<type_array>()) {
-        return *type->inner_type;
-    }
-    if (auto type = t.get_if<type_span>()) {
-        return *type->inner_type; 
-    }
-    if (auto type = t.get_if<type_type>()) {
-        return *type->type_val; 
-    }
-    panic("tried to get the inner type of an invalid type category, "
-          "can only get the inner type for arrays, spans and type values, type={}", t);
-}
-
 }

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -266,10 +266,6 @@ auto module_type() -> type_name;
 auto arena_type() -> type_name;
 auto string_literal_type() -> type_name;
 
-// Extracts the single inner type of the given t. Undefined if the given t is not a compound
-// type with a single subtype.
-auto inner_type(const type_name& t) -> type_name;
-
 }
 
 template <>

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -140,9 +140,7 @@ struct type_arena
 
 struct type_type
 {
-    value_ptr<type_name> type_val;
-
-    auto to_hash() const { return hash(type_val); }
+    auto to_hash() const { return hash(0); }
     auto operator==(const type_type&) const -> bool = default;
 };
 

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -24,15 +24,16 @@ struct type_name;
 struct null_tag{};
 
 struct const_value : public std::variant<
-    std::monostate,       // no value
-    null_tag,             // null
-    bool,                 // bool
-    char,                 // char
-    std::int32_t,         // i32
-    std::int64_t,         // i64
-    std::uint64_t,        // u64
-    double,               // f64
-    std::filesystem::path // module
+    std::monostate,        // no value
+    null_tag,              // null
+    bool,                  // bool
+    char,                  // char
+    std::int32_t,          // i32
+    std::int64_t,          // i64
+    std::uint64_t,         // u64
+    double,                // f64
+    std::filesystem::path, // module
+    value_ptr<type_name>   // type
 >
 {
     using variant::variant;


### PR DESCRIPTION
* Using the new `const_value` mechanism, the `type_type` struct no longer contains type info.
* `@type_of(T)` is now just `type` for every type.
* Objects of type `type` must be known at compile time to be usable.
* The type of `type` is itself.
* Fixed the compile time bools which still need to push runtime code (but just a const value).