### PR TITLE
Remove `type_fundamental`

### DIFF
--- a/examples/feature_test.az
+++ b/examples/feature_test.az
@@ -178,6 +178,7 @@ struct vec3
         let x_squared := square(self.x);
         let y_squared := square(self.y);
         let z_squared := square(self.z);
+        return 0.0;
         return sqrt(x_squared + y_squared + z_squared);
     }
 }

--- a/examples/feature_test.az
+++ b/examples/feature_test.az
@@ -178,7 +178,6 @@ struct vec3
         let x_squared := square(self.x);
         let y_squared := square(self.y);
         let z_squared := square(self.z);
-        return 0.0;
         return sqrt(x_squared + y_squared + z_squared);
     }
 }

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,11 +1,2 @@
 
-struct vec3
-{
-    fn length(self: vec3 const&) -> f64
-    {
-        return sqrt(4.0);
-    }
-}
-
-let v := vec3();
-print("{}\n", v.length());
+5 as i64;

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,6 +1,11 @@
 
-if 2 == 2 {
-    print("A\n");
-} else {
-    print("B\n");
+struct vec3
+{
+    fn length(self: vec3 const&) -> f64
+    {
+        return sqrt(4.0);
+    }
 }
+
+let v := vec3();
+print("{}\n", v.length());

--- a/src/compilation/type_manager.cpp
+++ b/src/compilation/type_manager.cpp
@@ -29,23 +29,35 @@ auto type_manager::contains(const type_struct& type) const -> bool
 auto type_manager::size_of(const type_name& type) const -> std::size_t
 {
     return std::visit(overloaded{
-        [](type_fundamental t) -> std::size_t {
-            switch (t) {
-                case type_fundamental::null_type:
-                case type_fundamental::bool_type:
-                case type_fundamental::char_type:
-                    return 1;
-                case type_fundamental::i32_type:
-                    return 4;
-                case type_fundamental::i64_type:
-                case type_fundamental::u64_type:
-                case type_fundamental::f64_type:
-                    return 8;
-                case type_fundamental::module_type:
-                    return 0;
-                default:
-                    return 0;
-            }
+        [](type_null) {
+            return std::size_t{1};
+        },
+        [](type_bool) {
+            return std::size_t{1};
+        },
+        [](type_char) {
+            return std::size_t{1};
+        },
+        [](type_i32) {
+            return std::size_t{4};
+        },
+        [](type_i64) {
+            return std::size_t{8};
+        },
+        [](type_u64) {
+            return std::size_t{8};
+        },
+        [](type_f64) {
+            return std::size_t{8};
+        },
+        [](type_arena) {
+            return sizeof(std::byte*); // the runtime will store the arena separately
+        },
+        [](type_module) {
+            return std::size_t{0};
+        },
+        [](type_type) {
+            return std::size_t{0};
         },
         [&](const type_struct& t) -> std::size_t {
             if (!d_classes.contains(t)) {
@@ -75,14 +87,8 @@ auto type_manager::size_of(const type_name& type) const -> std::size_t
         [](const type_bound_method_template&) {
             return sizeof(std::byte*); // pointer to the object, first arg to the function
         },
-        [](const type_arena& arena) {
-            return sizeof(std::byte*); // the runtime will store the arena separately
-        },
         [](const type_builtin&) {
             return std::size_t{0};
-        },
-        [](const type_type&) {
-            return std::size_t{0}; 
         },
         [](const type_function&) {
             return std::size_t{0};

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -1604,6 +1604,8 @@ auto push_expr(compiler& com, compile_type ct, const node_as_expr& node) -> expr
     const auto dst_type = get_type_value(node.token, result);
 
     std::visit(overloaded{
+        [&] <class T> (const T&, const T&) {}, // noop
+
         [&](type_null, type_i64) { push_value(code(com), op::null_to_i64); },
         [&](type_bool, type_i64) { push_value(code(com), op::bool_to_i64); },
         [&](type_char, type_i64) { push_value(code(com), op::char_to_i64); },
@@ -1618,7 +1620,7 @@ auto push_expr(compiler& com, compile_type ct, const node_as_expr& node) -> expr
         [&](type_i64,  type_u64) { push_value(code(com), op::i64_to_u64);  },
         [&](type_f64,  type_u64) { push_value(code(com), op::f64_to_u64);  },
 
-        [&](const auto& src, const auto& dst) {
+        [&](const auto&, const auto&) {
             node.token.error("cannot convert expression of type '{}' to '{}'", src_type, dst_type);
         }
     }, src_type, dst_type);

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -696,7 +696,7 @@ auto push_expr(compiler& com, compile_type ct, const node_literal_null_expr& nod
 {
     node.token.assert(ct == compile_type::val, "cannot take the address of a null literal");
     push_value(code(com), op::push_null);
-    return { type_null{}, null_tag{} };
+    return { type_null{} };
 }
 
 auto push_expr(compiler& com, compile_type ct, const node_literal_string_expr& node) -> expr_result
@@ -1106,9 +1106,9 @@ auto push_expr(compiler& com,compile_type ct, const node_span_expr& node) -> exp
     // next push the size to make up the second half of the span
     if (node.lower_bound && node.upper_bound) {
         const auto lower_bound_type = push_expr(com, compile_type::val, *node.lower_bound).type;
-        node.token.assert(lower_bound_type.is<type_i64>(), "subspan lower bound must be u64");
+        node.token.assert(lower_bound_type.is<type_u64>(), "subspan lower bound must be u64");
         const auto upper_bound_type = push_expr(com, compile_type::val, *node.upper_bound).type;
-        node.token.assert(upper_bound_type.is<type_i64>(), "subspan upper bound must be u64");
+        node.token.assert(upper_bound_type.is<type_u64>(), "subspan upper bound must be u64");
         push_value(code(com), op::push_subspan, type_size);
     } else if (type.is<type_span>()) {
         // Push the span pointer, offset to the size, and load the size

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -92,7 +92,7 @@ auto construct_builtin_array() -> std::vector<builtin>
 
     auto b = std::vector<builtin>{};
 
-    b.push_back(builtin{"sqrt", b.size(), builtin_sqrt, {type_f64{}, type_f64{}}});
+    b.push_back(builtin{"sqrt", b.size(), builtin_sqrt, {type_f64{}}, type_f64{}});
 
     b.push_back(builtin{"fopen", b.size(), builtin_fopen, {char_span, char_span}, {type_u64{}}});
     b.push_back(builtin{"fclose", b.size(), builtin_fclose, {type_u64{}}, {type_null{}}});

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -87,17 +87,17 @@ auto builtin_fread(bytecode_context& ctx) -> void
 
 auto construct_builtin_array() -> std::vector<builtin>
 {
-    const auto char_span = char_type().add_const().add_span();
-    const auto char_ptr = char_type().add_const().add_ptr();
+    const auto char_span = type_name{type_char{}}.add_const().add_span();
+    const auto char_ptr = type_name{type_char{}}.add_const().add_ptr();
 
     auto b = std::vector<builtin>{};
 
-    b.push_back(builtin{"sqrt", b.size(), builtin_sqrt, {f64_type()}, f64_type()});
+    b.push_back(builtin{"sqrt", b.size(), builtin_sqrt, {type_f64{}, type_f64{}}});
 
-    b.push_back(builtin{"fopen", b.size(), builtin_fopen, {char_span, char_span}, u64_type()});
-    b.push_back(builtin{"fclose", b.size(), builtin_fclose, {u64_type()}, null_type()});
-    b.push_back(builtin{"fputs", b.size(), builtin_fputs, {u64_type(), char_span}, null_type()});
-    b.push_back(builtin{"fread", b.size(), builtin_fread, {u64_type(), arena_type().add_ptr()}, char_span});
+    b.push_back(builtin{"fopen", b.size(), builtin_fopen, {char_span, char_span}, {type_u64{}}});
+    b.push_back(builtin{"fclose", b.size(), builtin_fclose, {type_u64{}}, {type_null{}}});
+    b.push_back(builtin{"fputs", b.size(), builtin_fputs, {type_u64{}, char_span}, type_null{}});
+    b.push_back(builtin{"fread", b.size(), builtin_fread, {type_u64{}, type_name{type_arena{}}.add_ptr()}, char_span});
 
     return b;
 }

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -61,19 +61,54 @@ auto to_string(const type_name& type) -> std::string
     return type.is_const ? std::format("{} const", string_inner) : string_inner;
 }
 
-auto to_string(type_fundamental t) -> std::string
+auto to_string(const type_null&) -> std::string
 {
-    switch (t) {
-        case type_fundamental::null_type:    return "null";
-        case type_fundamental::bool_type:    return "bool";
-        case type_fundamental::char_type:    return "char";
-        case type_fundamental::i32_type:     return "i32";
-        case type_fundamental::i64_type:     return "i64";
-        case type_fundamental::u64_type:     return "u64";
-        case type_fundamental::f64_type:     return "f64";
-        case type_fundamental::module_type:  return "module";
-        default: return "UNKNOWN FUNDAMENTAL";
-    }
+    return "null";
+}
+
+auto to_string(const type_bool&) -> std::string
+{
+    return "bool";
+}
+
+auto to_string(const type_char&) -> std::string
+{
+    return "char";
+}
+
+auto to_string(const type_i32&) -> std::string
+{
+    return "i32";
+}
+
+auto to_string(const type_i64&) -> std::string
+{
+    return "i64";
+}
+
+auto to_string(const type_u64&) -> std::string
+{
+    return "u64";
+}
+
+auto to_string(const type_f64&) -> std::string
+{
+    return "f64";
+}
+
+auto to_string(const type_type&) -> std::string
+{
+    return "type";
+}
+
+auto to_string(const type_arena&) -> std::string
+{
+    return "arena";
+}
+
+auto to_string(const type_module&) -> std::string
+{
+    return "module";
 }
 
 auto to_string(const type_struct& type) -> std::string
@@ -142,16 +177,6 @@ auto to_string(const type_bound_method_template& type) -> std::string
     );
 }
 
-auto to_string(const type_arena& type) -> std::string
-{
-    return std::string{"<arena>"};
-}
-
-auto to_string(const type_type& type) -> std::string
-{
-    return std::format("type");
-}
-
 auto to_string(const type_function& type) -> std::string
 {
     const auto function_ptr_type = type_function_ptr{type.param_types, type.return_type};
@@ -175,47 +200,47 @@ auto to_string(const type_placeholder& type) -> std::string
 
 auto null_type() -> type_name
 {
-    return {type_fundamental::null_type};
+    return type_null{};
 }
 
 auto bool_type() -> type_name
 {
-    return {type_fundamental::bool_type};
+    return type_bool{};
 }
 
 auto char_type() -> type_name
 {
-    return {type_fundamental::char_type};
+    return type_char{};
 }
 
 auto i32_type() -> type_name
 {
-    return {type_fundamental::i32_type};
+    return type_i32{};
 }
 
 auto i64_type() -> type_name
 {
-    return {type_fundamental::i64_type};
+    return type_i64{};
 }
 
 auto u64_type() -> type_name
 {
-    return {type_fundamental::u64_type};
+    return type_u64{};
 }
 
 auto f64_type() -> type_name
 {
-    return {type_fundamental::f64_type};
+    return type_f64{};
 }
 
 auto module_type() -> type_name
 {
-    return {type_fundamental::module_type};
+    return type_module{};
 }
 
 auto arena_type() -> type_name
 {
-    return {type_arena{}};
+    return type_arena{};
 }
 
 auto string_literal_type() -> type_name

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -198,54 +198,9 @@ auto to_string(const type_placeholder& type) -> std::string
     return std::format("<placeholder: {}>", type.name);
 }
 
-auto null_type() -> type_name
-{
-    return type_null{};
-}
-
-auto bool_type() -> type_name
-{
-    return type_bool{};
-}
-
-auto char_type() -> type_name
-{
-    return type_char{};
-}
-
-auto i32_type() -> type_name
-{
-    return type_i32{};
-}
-
-auto i64_type() -> type_name
-{
-    return type_i64{};
-}
-
-auto u64_type() -> type_name
-{
-    return type_u64{};
-}
-
-auto f64_type() -> type_name
-{
-    return type_f64{};
-}
-
-auto module_type() -> type_name
-{
-    return type_module{};
-}
-
-auto arena_type() -> type_name
-{
-    return type_arena{};
-}
-
 auto string_literal_type() -> type_name
 {
-    return char_type().add_const().add_span();
+    return type_name{type_char{}}.add_const().add_span();
 }
 
 auto type_name::add_array(std::size_t size) const -> type_name

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -19,19 +19,67 @@ namespace anzu {
 // Want these to be equivalent since we want uints available in the runtime but we also want
 // to use it as indexes into C++ vectors which use size_t.
 static_assert(std::is_same_v<std::uint64_t, std::size_t>);
-
 struct type_name;
 
-enum class type_fundamental : std::uint8_t
+struct type_null
 {
-    null_type,
-    bool_type,
-    char_type,
-    i32_type,
-    i64_type,
-    u64_type,
-    f64_type,
-    module_type,
+    auto to_hash() const { return hash(0); }
+    auto operator==(const type_null&) const -> bool = default;
+};
+
+struct type_bool
+{
+    auto to_hash() const { return hash(0); }
+    auto operator==(const type_bool&) const -> bool = default;
+};
+
+struct type_char
+{
+    auto to_hash() const { return hash(0); }
+    auto operator==(const type_char&) const -> bool = default;
+};
+
+struct type_i32
+{
+    auto to_hash() const { return hash(0); }
+    auto operator==(const type_i32&) const -> bool = default;
+};
+
+struct type_i64
+{
+    auto to_hash() const { return hash(0); }
+    auto operator==(const type_i64&) const -> bool = default;
+};
+
+struct type_u64
+{
+    auto to_hash() const { return hash(0); }
+    auto operator==(const type_u64&) const -> bool = default;
+};
+
+struct type_f64
+{
+    auto to_hash() const { return hash(0); }
+    auto operator==(const type_f64&) const -> bool = default;
+};
+
+struct type_type
+{
+    auto to_hash() const { return hash(0); }
+    auto operator==(const type_type&) const -> bool = default;
+};
+
+struct type_arena
+{
+    auto to_hash() const { return hash(0); }
+    auto operator==(const type_arena&) const -> bool = default;
+};
+
+
+struct type_module
+{
+    auto to_hash() const { return hash(0); }
+    auto operator==(const type_module&) const -> bool = default;
 };
 
 struct type_struct
@@ -109,18 +157,6 @@ struct type_bound_method_template
     auto operator==(const type_bound_method_template&) const -> bool = default;
 };
 
-struct type_arena
-{
-    auto to_hash() const { return hash(0); }
-    auto operator==(const type_arena&) const -> bool = default;
-};
-
-struct type_type
-{
-    auto to_hash() const { return hash(0); }
-    auto operator==(const type_type&) const -> bool = default;
-};
-
 struct type_function
 {
     std::size_t            id;
@@ -163,7 +199,17 @@ struct type_placeholder
 };
 
 auto to_string(const type_name& type) -> std::string;
-auto to_string(type_fundamental t) -> std::string;
+
+auto to_string(const type_null&) -> std::string;
+auto to_string(const type_bool&) -> std::string;
+auto to_string(const type_char&) -> std::string;
+auto to_string(const type_i32&) -> std::string;
+auto to_string(const type_i64&) -> std::string;
+auto to_string(const type_u64&) -> std::string;
+auto to_string(const type_f64&) -> std::string;
+auto to_string(const type_module&) -> std::string;
+auto to_string(const type_type&) -> std::string;
+auto to_string(const type_arena&) -> std::string;
 auto to_string(const type_array& type) -> std::string;
 auto to_string(const type_ptr& type) -> std::string;
 auto to_string(const type_span& type) -> std::string;
@@ -172,25 +218,32 @@ auto to_string(const type_function_ptr& type) -> std::string;
 auto to_string(const type_builtin& type) -> std::string;
 auto to_string(const type_bound_method& type) -> std::string;
 auto to_string(const type_bound_method_template& type) -> std::string;
-auto to_string(const type_arena& type) -> std::string;
-auto to_string(const type_type& type) -> std::string;
 auto to_string(const type_function& type) -> std::string;
 auto to_string(const type_function_template& type) -> std::string;
 auto to_string(const type_struct_template& type) -> std::string;
 auto to_string(const type_placeholder& type) -> std::string;
 
 struct type_name : public std::variant<
-    type_fundamental,
-    type_struct,
+    type_null,
+    type_bool,
+    type_char,
+    type_i32,
+    type_i64,
+    type_u64,
+    type_f64,
+    type_type,
+    type_arena,
+    type_module,
+
     type_array,
+    type_struct,
     type_ptr,
     type_span,
-    type_arena,
+
     type_function_ptr,
     type_bound_method,
     type_bound_method_template,
     type_builtin,
-    type_type,
     type_function,
     type_function_template,
     type_struct_template,

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -283,15 +283,6 @@ struct type_name : public std::variant<
 // Used for resolving template types. In the future could also be used for type aliases
 using template_map = std::unordered_map<std::string, type_name>;
 
-auto null_type() -> type_name;
-auto bool_type() -> type_name;
-auto char_type() -> type_name;
-auto i32_type() -> type_name;
-auto i64_type() -> type_name;
-auto u64_type() -> type_name;
-auto f64_type() -> type_name;
-auto module_type() -> type_name;
-auto arena_type() -> type_name;
 auto string_literal_type() -> type_name;
 
 struct null_tag{};

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -21,29 +21,6 @@ namespace anzu {
 static_assert(std::is_same_v<std::uint64_t, std::size_t>);
 
 struct type_name;
-struct null_tag{};
-
-struct const_value : public std::variant<
-    std::monostate,        // no value
-    null_tag,              // null
-    bool,                  // bool
-    char,                  // char
-    std::int32_t,          // i32
-    std::int64_t,          // i64
-    std::uint64_t,         // u64
-    double,                // f64
-    std::filesystem::path, // module
-    value_ptr<type_name>   // type
->
-{
-    using variant::variant;
-    const_value(const const_value&) = default;
-
-    template <typename T> auto is()     const -> bool     { return std::holds_alternative<T>(*this); }
-    template <typename T> auto as()     const -> const T& { return std::get<T>(*this); }
-    template <typename T> auto get_if() const -> const T* { return std::get_if<T>(this); }
-    auto has_value()                    const -> bool     { return !is<std::monostate>(); }
-};
 
 enum class type_fundamental : std::uint8_t
 {
@@ -263,6 +240,31 @@ auto f64_type() -> type_name;
 auto module_type() -> type_name;
 auto arena_type() -> type_name;
 auto string_literal_type() -> type_name;
+
+struct null_tag{};
+
+struct const_value : public std::variant<
+    std::monostate,        // no value
+    null_tag,              // null
+    bool,                  // bool
+    char,                  // char
+    std::int32_t,          // i32
+    std::int64_t,          // i64
+    std::uint64_t,         // u64
+    double,                // f64
+    std::filesystem::path, // module
+    type_name              // type
+>
+{
+    using variant::variant;
+    const_value(const const_value&) = default;
+
+    template <typename T> auto is()     const -> bool     { return std::holds_alternative<T>(*this); }
+    template <typename T> auto as()     const -> const T& { return std::get<T>(*this); }
+    template <typename T> auto get_if() const -> const T* { return std::get_if<T>(this); }
+    auto has_value()                    const -> bool     { return !is<std::monostate>(); }
+};
+
 
 }
 

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -285,11 +285,8 @@ using template_map = std::unordered_map<std::string, type_name>;
 
 auto string_literal_type() -> type_name;
 
-struct null_tag{};
-
 struct const_value : public std::variant<
-    std::monostate,        // no value
-    null_tag,              // null
+    std::monostate,        // no value, null
     bool,                  // bool
     char,                  // char
     std::int32_t,          // i32


### PR DESCRIPTION
* Added helper functions to improve accessing values of types and modules.
* Removed `type_fundamental`, now all fundamental types are their own structs, which simplifies a lot of the code.
* Definition of `is_fundamental` is now `null`, `bool`, `char`, `i32`, `i64`, `u64` and `f64`, excluding `arena`, `type` and `module` which could also be considered fundamental, but have special behaviour.
* Removed all the trivial factory functions like `i64_type()` since you can just do `type_i64{}` now.