### PR TITLE
SImpler Quicksort

### DIFF
--- a/examples/test.az
+++ b/examples/test.az
@@ -10,7 +10,7 @@ util.swap(x&, y&);
 print("{} {}\n", x, y);
 
 var arr := [6,3,9,1,6,2,1];
-util.quick_sort(arr[], 0u, @len(arr) - 1u);
+util.quick_sort(arr[]);
 
 for x in arr[] {
     print("{}\n", x@);

--- a/examples/test.az
+++ b/examples/test.az
@@ -10,7 +10,7 @@ util.swap(x&, y&);
 print("{} {}\n", x, y);
 
 var arr := [6,3,9,1,6,2,1];
-util.quick_sort(arr[]);
+util.sort(arr[]);
 
 for x in arr[] {
     print("{}\n", x@);

--- a/lib/utility.az
+++ b/lib/utility.az
@@ -45,16 +45,15 @@ fn qs_partition!(T)(arr: T[], low: u64, high: u64) -> u64
     return j;
 }
 
-fn qs_impl!(T)(arr: T[], low: u64, high: u64)
+fn partial_sort!(T)(arr: T[], low: u64, high: u64)
 {
-    if (low < high) {
-        let pi := qs_partition!(T)(arr, low, high);
-        qs_impl!(T)(arr, low, pi - 1u);
-        qs_impl!(T)(arr, pi + 1u, high);
-    }
+    if (low >= high) return;
+    let pi := qs_partition!(T)(arr, low, high);
+    partial_sort!(T)(arr, low, pi - 1u);
+    partial_sort!(T)(arr, pi + 1u, high);
 }
 
-fn quick_sort!(T)(arr: T[])
+fn sort!(T)(arr: T[])
 {
-    qs_impl!(T)(arr, 0u, @len(arr) - 1u);
+    partial_sort!(T)(arr, 0u, @len(arr) - 1u);
 }

--- a/lib/utility.az
+++ b/lib/utility.az
@@ -45,11 +45,16 @@ fn qs_partition!(T)(arr: T[], low: u64, high: u64) -> u64
     return j;
 }
 
-fn quick_sort!(T)(arr: T[], low: u64, high: u64)
+fn qs_impl!(T)(arr: T[], low: u64, high: u64)
 {
     if (low < high) {
         let pi := qs_partition!(T)(arr, low, high);
-        quick_sort!(T)(arr, low, pi - 1u);
-        quick_sort!(T)(arr, pi + 1u, high);
+        qs_impl!(T)(arr, low, pi - 1u);
+        qs_impl!(T)(arr, pi + 1u, high);
     }
+}
+
+fn quick_sort!(T)(arr: T[])
+{
+    qs_impl!(T)(arr, 0u, @len(arr) - 1u);
 }


### PR DESCRIPTION
* Wrap the initial call to quicksort so only the span needs to be passed in.
* Rename `quick_sort` to just `sort`.
* The original sort function is called `partial_sort`.