### PR TITLE
Iterators

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
             "request": "launch",
             "program": "${workspaceFolder}/build/src/Debug/anzu.exe",
             "args": [
-                "${workspaceFolder}/examples/feature_test.az",
+                "${workspaceFolder}/examples/test.az",
                 "run"
             ],
             "stopAtEntry": false,

--- a/README.md
+++ b/README.md
@@ -75,12 +75,35 @@ while <condition> {
 ```
 
 ### `for` Statements
-Only implemented for spans. `name` is a pointer to the current element in the array.
+For loops are just syntactic sugar for regular loops. The basic syntax for a `for` loop is
 ```
-for <name> in <span> {
-    ...
+for <name> in <obj> {
+    <body>
 }
 ```
+There are two forms this takes:
+* `obj` can be a span. In this case, `name` is a pointer to the current element. This expands to
+    ```
+    var $s := <obj>;
+    var $idx := 0u;
+    loop {
+        if $idx == @len($s) { break; }
+        var <name> := $s[$idx];
+        <body>
+        $idx = $idx + 1u;
+    }
+    ```
+* `obj` can be an "iterable". This is any struct type that has two member functions; `valid` and `next`. Both take no arguments aside from the implicit this pointer. `valid` must return a bool, and `next` can return any type, and the return object is what gets bound to `name`.
+    ```
+    var $x := <obj>;
+    loop {
+        if !$x.valid() { break; }
+        var <name> := $s.next();
+        <body>
+    }
+    ```
+
+The temporary variables are prefixed with `$` in the above examples to make them unspellable (and there inaccessible) in user code.
 
 ### Functions
 Declared with the keyword `fn`.

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ There are two forms this takes:
         $idx = $idx + 1u;
     }
     ```
-* `obj` can be an "iterable". This is any struct type that has two member functions; `valid` and `next`. Both take no arguments aside from the implicit this pointer. `valid` must return a bool, and `next` can return any type, and the return object is what gets bound to `name`.
+* `obj` can be an "iterator". This is any struct type that has two member functions; `valid` and `next`. Both take no arguments aside from the implicit this pointer. `valid` must return a bool, and `next` can return any type, and the return object is what gets bound to `name`.
     ```
     var $x := <obj>;
     loop {

--- a/examples/aoc2023-1.az
+++ b/examples/aoc2023-1.az
@@ -45,7 +45,7 @@ while tokens.valid() {
     let part2 := process_line(line);
     total_part2 = total_part2 + part2;
 
-    tokens.advance();
+    tokens.next();
 }
 
 print("{} {}\n", total_part1, total_part2);

--- a/examples/aoc2024-1.az
+++ b/examples/aoc2024-1.az
@@ -9,10 +9,8 @@ var l := vec.vector!(i64).create(a&);
 var r := vec.vector!(i64).create(a&);
 var counts := [0; 1000u];
 
-var lines := str.split(file, "\r\n");
-while lines.valid() {
-    let line := lines.next();
-
+for line in str.split(file, "\r\n")
+{
     var splitter := str.split(line, "   ");
     l.push(str.str_to_i64(splitter.next()));
 
@@ -29,9 +27,8 @@ util.sort(r.to_span());
 var part1 := 0;
 var part2 := 0;
 
-var z := util.zip(l.to_span(), r.to_span());
-while z.valid() {
-    let curr := z.next();
+for curr in util.zip(l.to_span(), r.to_span())
+{
     part1 = part1 + util.abs(curr.left@ - curr.right@);
     part2 = part2 + counts[curr.left@ as u64] * curr.left@;
 }

--- a/examples/aoc2024-1.az
+++ b/examples/aoc2024-1.az
@@ -11,12 +11,12 @@ var counts := [0; 1000u];
 
 var lines := str.split(file, "\r\n");
 while lines.valid() {
-    let line := lines.advance();
+    let line := lines.next();
 
     var splitter := str.split(line, "   ");
-    l.push(str.str_to_i64(splitter.advance()));
+    l.push(str.str_to_i64(splitter.next()));
 
-    let right_val := str.str_to_i64(splitter.advance());
+    let right_val := str.str_to_i64(splitter.next());
     let right_u64 := right_val as u64;
     r.push(right_val);
     counts[right_u64] = counts[right_u64] + 1;
@@ -31,7 +31,7 @@ var part2 := 0;
 
 var z := util.zip(l.to_span(), r.to_span());
 while z.valid() {
-    let curr := z.advance();
+    let curr := z.next();
     part1 = part1 + util.abs(curr.left@ - curr.right@);
     part2 = part2 + counts[curr.left@ as u64] * curr.left@;
 }

--- a/examples/aoc2024-1.az
+++ b/examples/aoc2024-1.az
@@ -16,7 +16,6 @@ for line in str.split(file, "\r\n") {
 
     let right_u64 := r.back() as u64;
     counts[right_u64] = counts[right_u64] + 1;
-    assert !splitter.valid();
 }
 
 util.sort(l.to_span());

--- a/examples/aoc2024-1.az
+++ b/examples/aoc2024-1.az
@@ -9,14 +9,12 @@ var l := vec.vector!(i64).create(a&);
 var r := vec.vector!(i64).create(a&);
 var counts := [0; 1000u];
 
-for line in str.split(file, "\r\n")
-{
+for line in str.split(file, "\r\n") {
     var splitter := str.split(line, "   ");
     l.push(str.str_to_i64(splitter.next()));
+    r.push(str.str_to_i64(splitter.next()));
 
-    let right_val := str.str_to_i64(splitter.next());
-    let right_u64 := right_val as u64;
-    r.push(right_val);
+    let right_u64 := r.back() as u64;
     counts[right_u64] = counts[right_u64] + 1;
     assert !splitter.valid();
 }
@@ -27,8 +25,7 @@ util.sort(r.to_span());
 var part1 := 0;
 var part2 := 0;
 
-for curr in util.zip(l.to_span(), r.to_span())
-{
+for curr in util.zip(l.to_span(), r.to_span()) {
     part1 = part1 + util.abs(curr.left@ - curr.right@);
     part2 = part2 + counts[curr.left@ as u64] * curr.left@;
 }

--- a/examples/aoc2024-1.az
+++ b/examples/aoc2024-1.az
@@ -5,8 +5,8 @@ let util := @import("lib/utility.az");
 
 arena a;
 let file := io.read_file("examples/aoc2024-1-input.txt", a&);
-var l := vec.vector!(i64).create(a&);
-var r := vec.vector!(i64).create(a&);
+var l := vec.create!(i64)(a&);
+var r := vec.create!(i64)(a&);
 var counts := [0; 1000u];
 
 for line in str.split(file, "\r\n") {
@@ -23,7 +23,6 @@ util.sort(r.to_span());
 
 var part1 := 0;
 var part2 := 0;
-
 for curr in util.zip(l.to_span(), r.to_span()) {
     part1 = part1 + util.abs(curr.left@ - curr.right@);
     part2 = part2 + counts[curr.left@ as u64] * curr.left@;

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,17 +1,26 @@
-let util := @import("lib/utility.az");
+struct range_iter
+{
+    _curr: i64;
+    _max: i64;
 
-var x := 10;
-var y := 12;
+    fn valid(self: const&) -> bool
+    {
+        return self._curr < self._max;
+    }
 
-print("{} {}\n", x, y);
+    fn next(self: &) -> i64
+    {
+        let ret := self._curr;
+        self._curr = self._curr + 1;
+        return ret;
+    }
+}
 
-util.swap(x&, y&);
+fn range(max: i64) -> range_iter
+{
+    return range_iter(0, max);
+}
 
-print("{} {}\n", x, y);
-
-var arr := [6,3,9,1,6,2,1];
-util.sort(arr[]);
-
-for x in arr[] {
-    print("{}\n", x@);
+for x in range(10) {
+    print("{}\n", x);
 }

--- a/lib/str.az
+++ b/lib/str.az
@@ -37,7 +37,7 @@ struct tokenizer
     }
 
     # Returns the current string prior to advancing
-    fn advance(self: &) -> char const[]
+    fn next(self: &) -> char const[]
     {
         let curr := self.current();
 
@@ -68,7 +68,7 @@ struct tokenizer
     fn create(input: char const[], delim: char const[]) -> tokenizer
     {
         var t := tokenizer(input, delim, 0u, 0u, false, false);
-        t.advance(); # prime the tokenizer at the first word
+        t.next(); # prime the tokenizer at the first word
         return t;
     }
 }
@@ -113,7 +113,7 @@ fn replace(a: arena&, string: char const[], from: char const[], to: char const[]
     let size := @len(curr);
     @copy(new_string[idx : idx + size], tok.current());
     idx = idx + size;
-    tok.advance();
+    tok.next();
 
     while tok.valid() {
         @copy(new_string[idx : idx + @len(to)], to);
@@ -123,7 +123,7 @@ fn replace(a: arena&, string: char const[], from: char const[], to: char const[]
         let size := @len(curr);
         @copy(new_string[idx : idx + size], tok.current());
         idx = idx + size;
-        tok.advance();
+        tok.next();
     }
 
     return new_string;

--- a/lib/utility.az
+++ b/lib/utility.az
@@ -95,7 +95,7 @@ struct zip_view!(T, U)
         return zip_pair!(T, U)(self._left[self._curr]&, self._right[self._curr]&, self._curr);
     }
 
-    fn advance(self: &) -> zip_pair!(T, U)
+    fn next(self: &) -> zip_pair!(T, U)
     {
         let curr := self.current();
         self._curr = self._curr + 1u;

--- a/lib/vector.az
+++ b/lib/vector.az
@@ -30,6 +30,11 @@ struct vector!(T)
         return self._data[index];
     }
 
+    fn back(self: const&) -> T
+    {
+        return self._data[self._size - 1u];
+    }
+
     fn push(self: &, value: T) -> null
     {
         let cap := self.capacity();

--- a/lib/vector.az
+++ b/lib/vector.az
@@ -51,3 +51,8 @@ struct vector!(T)
         return vector!(T)(arr, null, 0u);
     }
 }
+
+fn create!(T)(arr: arena&) -> vector!(T)
+{
+    return vector!(T).create(arr);
+}

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -1731,13 +1731,16 @@ void push_for_loop_iterable(compiler& com, const node_for_stmt& node, const type
     node.token.assert(valid_it != com.functions_by_name.end(), "iterable type requires 'valid' function");
     const auto valid_fn = com.functions[valid_it->second];
     node.token.assert_eq(valid_fn.params.size(), 1, "'valid' must only take one arg");
+    node.token.assert_eq(valid_fn.params[0], type_name{type}.add_const().add_ptr(), "'valid' first arg must be a self pointer to const");
     node.token.assert_eq(valid_fn.return_type, type_name{type_bool{}}, "'valid' must return bool");
 
+    // Fetch and verify the next() function
     const auto next_name = function_name{.module=type.module, .struct_name=type, .name="next"};
     const auto next_it = com.functions_by_name.find(next_name);
     node.token.assert(next_it != com.functions_by_name.end(), "iterable type requires 'next' function");
     const auto next_fn = com.functions[next_it->second];
     node.token.assert_eq(next_fn.params.size(), 1, "'next' must only take one arg");
+    node.token.assert_eq(next_fn.params[0], type_name{type}.add_ptr(), "'next' first arg must be a self pointer");
 
     push_loop(com, [&] {
         // if !obj.valid() { break; }

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -1721,7 +1721,7 @@ void push_for_loop_span(compiler& com, const node_for_stmt& node, const type_spa
 //        <body>
 //    }
 //}
-void push_for_loop_iterable(compiler& com, const node_for_stmt& node, const type_struct& type)
+void push_for_loop_iterator(compiler& com, const node_for_stmt& node, const type_struct& type)
 {
     declare_var(com, node.token, "$iter", type);
 
@@ -1772,7 +1772,7 @@ void push_stmt(compiler& com, const node_for_stmt& node)
         push_for_loop_span(com, node, iter_type.as<type_span>());
     }
     else if (iter_type.is<type_struct>()) {
-        push_for_loop_iterable(com, node, iter_type.as<type_struct>());
+        push_for_loop_iterator(com, node, iter_type.as<type_struct>());
     }
     else {
         node.token.error("cannot iterator over object of type '{}'", iter_type);

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -1735,7 +1735,7 @@ void push_for_loop_iterable(compiler& com, const node_for_stmt& node, const type
 
     const auto next_name = function_name{.module=type.module, .struct_name=type, .name="next"};
     const auto next_it = com.functions_by_name.find(next_name);
-    node.token.assert(valid_it != com.functions_by_name.end(), "iterable type requires 'next' function");
+    node.token.assert(next_it != com.functions_by_name.end(), "iterable type requires 'next' function");
     const auto next_fn = com.functions[next_it->second];
     node.token.assert_eq(next_fn.params.size(), 1, "'next' must only take one arg");
 


### PR DESCRIPTION
* Added the notion of an "iterator protocol". Any struct that has the member functions `fn valid(self: const&) -> bool` and `fn next(self: &) -> T` for any `T` is classed as an iterator and can be iterated over in a for loop.
* Added a `back()` function to `vector`.
* Renamed `advance` to `next` on both `tokenizer` and `zip` to make them iterators.