### PR TITLE
More Itertools

### DIFF
--- a/examples/test.az
+++ b/examples/test.az
@@ -1,6 +1,10 @@
 let std := @import("lib/std.az");
 
-arena a;
-let file := @read_file("examples/input.txt", a&);
 
-print("{}\n", std.sqrt(20000.0));
+
+let x := [1, 2, 3, 4];
+let y := ["a", "b", "c", "d"];
+
+for e in std.enumerate(std.zip(x[], y[])) {
+    print("{}: {} {}\n", e.index, e.value.left@, e.value.right@);
+}

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,3 +1,6 @@
 let std := @import("lib/std.az");
 
+arena a;
+let file := @read_file("examples/input.txt", a&);
+
 print("{}\n", std.sqrt(20000.0));

--- a/lib/std.az
+++ b/lib/std.az
@@ -67,14 +67,14 @@ fn abs(x: i64) -> i64
     return x >= 0 ? x : -x;
 }
 
-struct zip_pair!(T, U)
+struct zip_iterator_value!(T, U)
 {
     left:  T&;
     right: U&;
     index: u64;
 }
 
-struct zip_view!(T, U)
+struct zip_iterator!(T, U)
 {
     _left:  T[];
     _right: U[];
@@ -90,12 +90,12 @@ struct zip_view!(T, U)
         return self._curr < self.size();
     }
 
-    fn current(self: const&) -> zip_pair!(T, U)
+    fn current(self: const&) -> zip_iterator_value!(T, U)
     {
-        return zip_pair!(T, U)(self._left[self._curr]&, self._right[self._curr]&, self._curr);
+        return zip_iterator_value!(T, U)(self._left[self._curr]&, self._right[self._curr]&, self._curr);
     }
 
-    fn next(self: &) -> zip_pair!(T, U)
+    fn next(self: &) -> zip_iterator_value!(T, U)
     {
         let curr := self.current();
         self._curr = self._curr + 1u;
@@ -103,10 +103,10 @@ struct zip_view!(T, U)
     }
 }
 
-fn zip!(T, U)(left: T[], right: U[]) -> zip_view!(T, U)
+fn zip!(T, U)(left: T[], right: U[]) -> zip_iterator!(T, U)
 {
     assert @len(left) == @len(right);
-    return zip_view!(T, U)(left, right, 0u);
+    return zip_iterator!(T, U)(left, right, 0u);
 }
 
 fn equal(lhs: char const[], rhs: char const[]) -> bool
@@ -380,4 +380,39 @@ fn pairwise!(T)(elems: T[]) -> pairwise_iterator!(T)
 {
     assert @len(elems) >= 2u;
     return pairwise_iterator!(T)(elems, 0u);
+}
+
+struct enumerate_iterator_value!(A)
+{
+    index: u64;
+    value: A;
+}
+
+struct enumerate_iterator!(T)
+{
+    _iter: T;
+    _curr: u64;
+
+    fn valid(self: const&) -> bool
+    {
+        return self._iter.valid();
+    }
+
+    fn next(self: &) -> enumerate_iterator_value!(@type_of(self._iter.next()))
+    {
+        var v := self._iter.next();
+        let Z := enumerate_iterator_value!(@type_of(v));
+
+        var curr := Z();
+        curr.index = self._curr;
+        curr.value = v;
+
+        self._curr = self._curr + 1u;
+        return curr;
+    }
+}
+
+fn enumerate!(T)(iter: T) -> enumerate_iterator!(T)
+{
+    return enumerate_iterator!(T)(iter, 0u);
 }

--- a/lib/std.az
+++ b/lib/std.az
@@ -67,48 +67,6 @@ fn abs(x: i64) -> i64
     return x >= 0 ? x : -x;
 }
 
-struct zip_iterator_value!(T, U)
-{
-    left:  T&;
-    right: U&;
-    index: u64;
-}
-
-struct zip_iterator!(T, U)
-{
-    _left:  T[];
-    _right: U[];
-    _curr:  u64;
-
-    fn size(self: const&) -> u64
-    {
-        return @len(self._left) < @len(self._right) ? @len(self._left) : @len(self._right);
-    }
-
-    fn valid(self: const&) -> bool
-    {
-        return self._curr < self.size();
-    }
-
-    fn current(self: const&) -> zip_iterator_value!(T, U)
-    {
-        return zip_iterator_value!(T, U)(self._left[self._curr]&, self._right[self._curr]&, self._curr);
-    }
-
-    fn next(self: &) -> zip_iterator_value!(T, U)
-    {
-        let curr := self.current();
-        self._curr = self._curr + 1u;
-        return curr;
-    }
-}
-
-fn zip!(T, U)(left: T[], right: U[]) -> zip_iterator!(T, U)
-{
-    assert @len(left) == @len(right);
-    return zip_iterator!(T, U)(left, right, 0u);
-}
-
 fn equal(lhs: char const[], rhs: char const[]) -> bool
 {
     if @len(lhs) != @len(rhs) { return false; }
@@ -133,7 +91,28 @@ fn find(string: char const[], substr: char const[], start: u64) -> u64
     return @len(string);
 }
 
-struct tokenizer
+fn contains(string: char const[], substr: char const[]) -> bool
+{
+    return find(string, substr, 0u) != @len(string);
+}
+
+fn occurrences(string: char const[], substr: char const[]) -> u64
+{
+    var count := 0u;
+    var idx := 0u;
+    while idx < @len(string) {
+        let curr_substr := string[idx : idx + @len(substr)];
+        if equal(substr, curr_substr) {
+            count = count + 1u;
+            idx = idx + @len(substr);
+        } else {
+            idx = idx + 1u;
+        }
+    }
+    return count;
+}
+
+struct split_iterator
 {
     _string: char const[];
     _delim: char const[];
@@ -176,39 +155,18 @@ struct tokenizer
         return !self._finished;
     }
 
-    fn create(input: char const[], delim: char const[]) -> tokenizer
+    fn create(input: char const[], delim: char const[]) -> split_iterator
     {
-        var t := tokenizer(input, delim, 0u, 0u, false, false);
-        t.next(); # prime the tokenizer at the first word
+        var t := split_iterator(input, delim, 0u, 0u, false, false);
+        t.next(); # prime the split_iterator at the first word
         return t;
     }
 }
 
 # Convenience function, less typing needed
-fn split(input: char const[], delim: char const[]) -> tokenizer
+fn split(input: char const[], delim: char const[]) -> split_iterator
 {
-    return tokenizer.create(input, delim);
-}
-
-fn contains(string: char const[], substr: char const[]) -> bool
-{
-    return find(string, substr, 0u) != @len(string);
-}
-
-fn occurrences(string: char const[], substr: char const[]) -> u64
-{
-    var count := 0u;
-    var idx := 0u;
-    while idx < @len(string) {
-        let curr_substr := string[idx : idx + @len(substr)];
-        if equal(substr, curr_substr) {
-            count = count + 1u;
-            idx = idx + @len(substr);
-        } else {
-            idx = idx + 1u;
-        }
-    }
-    return count;
+    return split_iterator.create(input, delim);
 }
 
 fn replace(a: arena&, string: char const[], from: char const[], to: char const[]) -> char const[]
@@ -218,7 +176,7 @@ fn replace(a: arena&, string: char const[], from: char const[], to: char const[]
 
     var new_string := new(a, new_size) ' ';
     var idx := 0u;
-    var tok := tokenizer.create(string, from);
+    var tok := split_iterator.create(string, from);
     assert tok.valid(); # There is always at least one token (it may be the whole string)
     let curr := tok.current();
     let size := @len(curr);
@@ -314,6 +272,15 @@ struct vector!(T)
     }
 }
 
+fn sqrt(value: f64) -> f64
+{
+    var z := 1.0;
+    for _ in range(15) {
+        z = z - (z * z - value) / (2.0 * z);
+    }
+    return z;
+}
+
 struct range_iter!(T)
 {
     _curr: T;
@@ -336,15 +303,6 @@ fn range!(T)(max: T) -> range_iter!(T)
 {
     assert T == i64 || T == u64;
     return range_iter!(T)(0 as T, max);
-}
-
-fn sqrt(value: f64) -> f64
-{
-    var z := 1.0;
-    for _ in range(15) {
-        z = z - (z * z - value) / (2.0 * z);
-    }
-    return z;
 }
 
 struct pairwise_iterator_value!(T)
@@ -415,4 +373,46 @@ struct enumerate_iterator!(T)
 fn enumerate!(T)(iter: T) -> enumerate_iterator!(T)
 {
     return enumerate_iterator!(T)(iter, 0u);
+}
+
+struct zip_iterator_value!(T, U)
+{
+    left:  T&;
+    right: U&;
+    index: u64;
+}
+
+struct zip_iterator!(T, U)
+{
+    _left:  T[];
+    _right: U[];
+    _curr:  u64;
+
+    fn size(self: const&) -> u64
+    {
+        return @len(self._left) < @len(self._right) ? @len(self._left) : @len(self._right);
+    }
+
+    fn valid(self: const&) -> bool
+    {
+        return self._curr < self.size();
+    }
+
+    fn current(self: const&) -> zip_iterator_value!(T, U)
+    {
+        return zip_iterator_value!(T, U)(self._left[self._curr]&, self._right[self._curr]&, self._curr);
+    }
+
+    fn next(self: &) -> zip_iterator_value!(T, U)
+    {
+        let curr := self.current();
+        self._curr = self._curr + 1u;
+        return curr;
+    }
+}
+
+fn zip!(T, U)(left: T[], right: U[]) -> zip_iterator!(T, U)
+{
+    assert @len(left) == @len(right);
+    return zip_iterator!(T, U)(left, right, 0u);
 }

--- a/lib/std.az
+++ b/lib/std.az
@@ -346,3 +346,38 @@ fn sqrt(value: f64) -> f64
     }
     return z;
 }
+
+struct pairwise_iterator_value!(T)
+{
+    left: T&;
+    right: T&;
+}
+
+struct pairwise_iterator!(T)
+{
+    _elems: T[];
+    _curr: u64;
+
+    fn current(self: const&) -> pairwise_iterator_value!(T)
+    {
+        return pairwise_iterator_value!(T)(self._elems[self._curr]&, self._elems[self._curr + 1u]&);
+    }
+
+    fn valid(self: const&) -> bool
+    {
+        return self._curr + 1u < @len(self._elems);
+    }
+
+    fn next(self: &) -> pairwise_iterator_value!(T)
+    {
+        let curr := self.current();
+        self._curr = self._curr + 1u;
+        return curr;
+    }
+}
+
+fn pairwise!(T)(elems: T[]) -> pairwise_iterator!(T)
+{
+    assert @len(elems) >= 2u;
+    return pairwise_iterator!(T)(elems, 0u);
+}

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -247,20 +247,45 @@ auto strip_pointers(const type_name& type) -> type_name
     return t;
 }
 
-auto const_convertable_to(const token& tok, const type_name& src, const type_name& dst) {
+auto const_convertable_to_inner(const token& tok, const type_name& src, const type_name& dst) {
     if (src.is_const && !dst.is_const) {
         return false;
     }
 
     return std::visit(overloaded{
         [&](const type_array& l, const type_array& r) {
-            return l.count == r.count && const_convertable_to(tok, *l.inner_type, *r.inner_type);
+            return l.count == r.count && const_convertable_to_inner(tok, *l.inner_type, *r.inner_type);
         },
         [&](const type_ptr& l, const type_ptr& r) {
-            return const_convertable_to(tok, *l.inner_type, *r.inner_type);
+            return const_convertable_to_inner(tok, *l.inner_type, *r.inner_type);
         },
         [&](const type_span& l, const type_span& r) {
-            return const_convertable_to(tok, *l.inner_type, *r.inner_type);
+            return const_convertable_to_inner(tok, *l.inner_type, *r.inner_type);
+        },
+        [&](const type_arena& l, const type_arena& r) { return true; },
+        [&] <typename T> (const T& l, const T& r) { return l == r; },
+        [&](const auto& l, const auto& r) {
+            return false;
+        }
+    }, src, dst);
+}
+
+auto const_convertable_to(int id, const token& tok, const type_name& src, const type_name& dst) {
+    if (src.is_const && !dst.is_const) {
+        return false;
+    }
+
+    //std::print("id={} src={} dst={}\n", id, src, dst);
+
+    return std::visit(overloaded{
+        [&](const type_array& l, const type_array& r) {
+            return l.count == r.count && const_convertable_to_inner(tok, *l.inner_type, *r.inner_type);
+        },
+        [&](const type_ptr& l, const type_ptr& r) {
+            return const_convertable_to_inner(tok, *l.inner_type, *r.inner_type);
+        },
+        [&](const type_span& l, const type_span& r) {
+            return const_convertable_to_inner(tok, *l.inner_type, *r.inner_type);
         },
         [&](const type_arena& l, const type_arena& r) { return true; },
         [&] <typename T> (const T& l, const T& r) { return l == r; },
@@ -308,7 +333,7 @@ void push_copy_typechecked(compiler& com, const node_expr& expr, const type_name
         tok.error("arenas can not be copied or assigned");
     }
 
-    if (!const_convertable_to(tok, actual, expected)) {
+    if (!const_convertable_to(1, tok, actual, expected)) {
         tok.error("Cannot convert '{}' to '{}'", actual, expected);
     }
 }
@@ -1347,7 +1372,7 @@ auto push_expr(compiler& com, compile_type ct, const node_field_expr& node) -> e
         const auto actual = info.params[0];
         const auto expected = stripped.add_const().add_ptr().add_const();
         constexpr auto message = "tried to access static member function {} through an instance of {}, this can only be accessed directly on the class";
-        node.token.assert(const_convertable_to(node.token, actual, expected), message, info.name, stripped);
+        node.token.assert(const_convertable_to(2, node.token, actual, expected), message, info.name, stripped);
         if (stripped.is_const && !actual.remove_ptr().is_const) {
             node.token.error("cannot bind a const variable to a non-const member function");
         }
@@ -1369,7 +1394,7 @@ auto push_expr(compiler& com, compile_type ct, const node_field_expr& node) -> e
         com.current_module.pop_back();
         const auto expected = stripped.add_const().add_ptr().add_const();
         constexpr auto message = "tried to access static member function {} through an instance of {}, this can only be accessed directly on the class";
-        node.token.assert(const_convertable_to(node.token, actual, expected), message, info.name, stripped);
+        node.token.assert(const_convertable_to(3, node.token, actual, expected), message, info.name, stripped);
         if (stripped.is_const && !actual.remove_ptr().is_const) {
             node.token.error("cannot bind a const variable to a non-const member function");
         }

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -231,6 +231,7 @@ struct type_name : public std::variant<
     type_function_ptr,
     type_bound_method,
     type_bound_method_template,
+    
     type_function,
     type_function_template,
     type_struct_template,

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -170,19 +170,18 @@ auto execute_program(bytecode_context& ctx) -> void
                 ctx.stack.push(equal); // returns null;
             } break;
             case op::arena_new: {
+                memory_arena* arena = nullptr;
                 if (ctx.arena_free_list.empty()) {
                     ctx.arenas.push_back(std::make_unique<memory_arena>());
-                    const auto& arena = ctx.arenas.back();
-                    arena->next = 0;
+                    arena = ctx.arenas.back().get();
                     arena->index = ctx.arenas.size() - 1;
-                    ctx.stack.push(arena.get());
                 } else {
                     const auto index = ctx.arena_free_list.back();
                     ctx.arena_free_list.pop_back();
-                    const auto& arena = ctx.arenas.at(index);
-                    arena->next = 0;
-                    ctx.stack.push(arena.get());
+                    arena = ctx.arenas.at(index).get();
                 }
+                arena->next = 0;
+                ctx.stack.push(arena);
             } break;
             case op::arena_delete: {
                 const auto arena = ctx.stack.pop<memory_arena*>();

--- a/src/runtime.hpp
+++ b/src/runtime.hpp
@@ -6,6 +6,7 @@
 #include <print>
 #include <cstring>
 #include <memory>
+#include <unordered_set>
 
 #include "bytecode.hpp"
 
@@ -56,6 +57,7 @@ struct memory_arena
 {
     std::array<std::byte, 1024 * 1024 * 64> data; // 64MB;
     std::size_t next = 0;
+    std::size_t index = 0; // position of the arena in the arena vector
 };
 
 struct bytecode_context
@@ -64,8 +66,11 @@ struct bytecode_context
     std::string                    rom;
 
     std::vector<call_frame> frames = {};
-    vm_stack stack                 = {};
-    std::int64_t heap_size         = {};
+    vm_stack                stack  = {};
+
+    std::vector<std::unique_ptr<memory_arena>> arenas          = {};
+    std::vector<std::size_t>                   arena_free_list = {};
+
 };
 
 auto run_program(const bytecode_program& prog) -> void;


### PR DESCRIPTION
* Add `std.zip`, `std.enumerate` and `std.pairwise`.
* Rename `std.tokenizer` to `std.split_iterator` to make it consistent with the other iterators.
* Don't deallocate arenas, instead add them to a free-list so that can be reused. Unsure if this is a good idea but it makes using an arena in a hot loop performant.
* Found the issue that causes the bug of not being able to deduce template types within a template function; it's because the names of the placeholders overlap and need to be disambiguated. Will fix this in the next PR.