### PR TITLE
All Types Printable

### DIFF
--- a/lib/std.az
+++ b/lib/std.az
@@ -272,15 +272,6 @@ struct vector!(T)
     }
 }
 
-fn sqrt(value: f64) -> f64
-{
-    var z := 1.0;
-    for _ in range(15) {
-        z = z - (z * z - value) / (2.0 * z);
-    }
-    return z;
-}
-
 struct range_iter!(T)
 {
     _curr: T;
@@ -303,6 +294,15 @@ fn range!(T)(max: T) -> range_iter!(T)
 {
     assert T == i64 || T == u64;
     return range_iter!(T)(0 as T, max);
+}
+
+fn sqrt(value: f64) -> f64
+{
+    var z := 1.0;
+    for _ in range(15) {
+        z = z - (z * z - value) / (2.0 * z);
+    }
+    return z;
 }
 
 struct pairwise_iterator_value!(T)

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -189,7 +189,7 @@ auto push_field_offset(
         offset += com.types.size_of(field.type);
     }
     
-    tok.error("could not find field '{}' for type '{}'\n", field_name, to_string(type));
+    tok.error("could not find field '{}' for type '{}'\n", field_name, type);
 }
 
 auto constructor_params(const compiler& com, const type_name& type) -> std::vector<type_name>
@@ -627,7 +627,7 @@ auto compile_struct_template(
     com.current_struct.emplace_back(name);
     com.current_module.emplace_back(name.module);
     const auto success = com.types.add_type(name, map);
-    tok.assert(success, "multiple definitions for struct {} found", to_string(name));
+    tok.assert(success, "multiple definitions for struct {} found", name);
     for (const auto& p : stmt.fields) {
         const auto f = type_field{p.name, resolve_type(com, tok, p.type)};
         com.types.add_field(name, f);
@@ -1012,7 +1012,7 @@ auto push_expr(compiler& com, compile_type ct, const node_template_expr& node) -
             compile_struct_template(com, node.token, name, ast);
         }
 
-        node.token.assert(com.types.contains(name), "could not find struct {}", type_name{name});
+        node.token.assert(com.types.contains(name), "could not find struct {}", name);
         return { type_type{}, {type_name{name}} };
     }
     node.token.error("object of type {} can not be called with template parameters", type);
@@ -1831,7 +1831,7 @@ void push_stmt(compiler& com, const node_struct_stmt& node)
     const auto sname = type_struct{ .name=node.name, .module=curr_module(com) };
     com.current_struct.emplace_back(sname);
     const auto success = com.types.add_type(sname);
-    node.token.assert(success, "multiple definitions for struct {} found", to_string(sname));
+    node.token.assert(success, "multiple definitions for struct {} found", sname);
     for (const auto& p : node.fields) {
         const auto f = type_field{p.name, resolve_type(com, node.token, p.type)};
         com.types.add_field(sname, f);

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -9,11 +9,6 @@
 
 namespace anzu {
 
-auto type_function_template::to_string() const -> std::string
-{
-    return anzu::to_string(*this);
-}
-
 auto type_function::to_pointer() const -> type_name
 {
     return type_function_ptr{ param_types, return_type };
@@ -46,145 +41,137 @@ auto type_name::remove_const() const -> type_name
 
 auto to_string_paren(const type_name& type) -> std::string
 {
-    const auto str = to_string(type);
+    const auto str = type.to_string();
     if (type.is<type_function_ptr>()) {
         return std::format("({})", str);
     }
     return str;
 }
 
-auto to_string(const type_name& type) -> std::string
-{
-    const auto string_inner = std::visit([](const auto& t) {
-        return ::anzu::to_string(t);
-    }, type);
-    return type.is_const ? std::format("{} const", string_inner) : string_inner;
-}
-
-auto to_string(const type_null&) -> std::string
+auto type_null::to_string() const -> std::string
 {
     return "null";
 }
 
-auto to_string(const type_bool&) -> std::string
+auto type_bool::to_string() const -> std::string
 {
     return "bool";
 }
 
-auto to_string(const type_char&) -> std::string
+auto type_char::to_string() const -> std::string
 {
     return "char";
 }
 
-auto to_string(const type_i32&) -> std::string
+auto type_i32::to_string() const -> std::string
 {
     return "i32";
 }
 
-auto to_string(const type_i64&) -> std::string
+auto type_i64::to_string() const -> std::string
 {
     return "i64";
 }
 
-auto to_string(const type_u64&) -> std::string
+auto type_u64::to_string() const -> std::string
 {
     return "u64";
 }
 
-auto to_string(const type_f64&) -> std::string
+auto type_f64::to_string() const -> std::string
 {
     return "f64";
 }
 
-auto to_string(const type_type&) -> std::string
+auto type_type::to_string() const -> std::string
 {
     return "type";
 }
 
-auto to_string(const type_arena&) -> std::string
+auto type_arena::to_string() const -> std::string
 {
     return "arena";
 }
 
-auto to_string(const type_module&) -> std::string
+auto type_module::to_string() const -> std::string
 {
     return "module";
 }
 
-auto to_string(const type_struct& type) -> std::string
+auto type_struct::to_string() const -> std::string
 {
-    if (!type.templates.empty()) {
-        return std::format("<{}>.{}!({})", type.module.string(), type.name, format_comma_separated(type.templates));
+    if (!templates.empty()) {
+        return std::format("<{}>.{}!({})", module.string(), name, format_comma_separated(templates));
     } else {
-        return std::format("<{}>.{}", type.module.string(), type.name);
+        return std::format("<{}>.{}", module.string(), name);
     }
 }
 
-auto to_string(const type_array& type) -> std::string
+auto type_array::to_string() const -> std::string
 {
-    return std::format("{}[{}]", to_string_paren(*type.inner_type), type.count);
+    return std::format("{}[{}]", to_string_paren(*inner_type), count);
 }
 
-auto to_string(const type_ptr& type) -> std::string
+auto type_ptr::to_string() const -> std::string
 {
-    return std::format("{}&", to_string_paren(*type.inner_type));
+    return std::format("{}&", to_string_paren(*inner_type));
 }
 
-auto to_string(const type_span& type) -> std::string
+auto type_span::to_string() const -> std::string
 {
-    return std::format("{}[]", to_string_paren(*type.inner_type));
+    return std::format("{}[]", to_string_paren(*inner_type));
 }
 
-auto to_string(const type_function_ptr& type) -> std::string
+auto type_function_ptr::to_string() const -> std::string
 {
     return std::format(
         "{}({}) -> {}",
-        to_string(token_type::kw_function),
-        format_comma_separated(type.param_types),
-        to_string_paren(*type.return_type)
+        anzu::to_string(token_type::kw_function),
+        format_comma_separated(param_types),
+        to_string_paren(*return_type)
     );
 }
 
-auto to_string(const type_bound_method& type) -> std::string
+auto type_bound_method::to_string() const -> std::string
 {
     return std::format(
         "<bound_method: '{}({}) -> {}'>",
-        to_string(token_type::kw_function),
-        type.id,
-        format_comma_separated(type.param_types),
-        to_string_paren(*type.return_type)
+        anzu::to_string(token_type::kw_function),
+        id,
+        format_comma_separated(param_types),
+        to_string_paren(*return_type)
     );
 }
 
-auto to_string(const type_bound_method_template& type) -> std::string
+auto type_bound_method_template::to_string() const -> std::string
 {
     return std::format(
         "<bound_method_template: <{}>.{}.{}>",
-        type.module.string(),
-        to_string(type.struct_name),
-        type.name
+        module.string(),
+        struct_name,
+        name
     );
 }
 
-auto to_string(const type_function& type) -> std::string
+auto type_function::to_string() const -> std::string
 {
-    const auto function_ptr_type = type_function_ptr{type.param_types, type.return_type};
-    return std::format("<function: id {} {}>", type.id, to_string(function_ptr_type));
+    const auto function_ptr_type = type_function_ptr{param_types, return_type};
+    return std::format("<function: id {} {}>", id, function_ptr_type);
 }
 
-auto to_string(const type_function_template& type) -> std::string
+auto type_function_template::to_string() const -> std::string
 {
-    return std::format("<function_template: <{}>.{}.{}>", type.module.string(), type.struct_name.name, type.name);
+    return std::format("<function_template: <{}>.{}.{}>", module.string(), struct_name.name, name);
 }
 
-auto to_string(const type_struct_template& type) -> std::string
+auto type_struct_template::to_string() const -> std::string
 {
-    return std::format("<struct_template: <{}>.{}>", type.module.string(), type.name);
+    return std::format("<struct_template: <{}>.{}>", module.string(), name);
 }
 
-auto to_string(const type_placeholder& type) -> std::string
+auto type_placeholder::to_string() const -> std::string
 {
-    return std::format("<placeholder: {}>", type.name);
+    return std::format("<placeholder: {}>", name);
 }
 
 auto string_literal_type() -> type_name

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -24,54 +24,63 @@ struct type_name;
 struct type_null
 {
     auto to_hash() const { return hash(0); }
+    auto to_string() const -> std::string;
     auto operator==(const type_null&) const -> bool = default;
 };
 
 struct type_bool
 {
     auto to_hash() const { return hash(0); }
+    auto to_string() const -> std::string;
     auto operator==(const type_bool&) const -> bool = default;
 };
 
 struct type_char
 {
     auto to_hash() const { return hash(0); }
+    auto to_string() const -> std::string;
     auto operator==(const type_char&) const -> bool = default;
 };
 
 struct type_i32
 {
     auto to_hash() const { return hash(0); }
+    auto to_string() const -> std::string;
     auto operator==(const type_i32&) const -> bool = default;
 };
 
 struct type_i64
 {
     auto to_hash() const { return hash(0); }
+    auto to_string() const -> std::string;
     auto operator==(const type_i64&) const -> bool = default;
 };
 
 struct type_u64
 {
     auto to_hash() const { return hash(0); }
+    auto to_string() const -> std::string;
     auto operator==(const type_u64&) const -> bool = default;
 };
 
 struct type_f64
 {
     auto to_hash() const { return hash(0); }
+    auto to_string() const -> std::string;
     auto operator==(const type_f64&) const -> bool = default;
 };
 
 struct type_type
 {
     auto to_hash() const { return hash(0); }
+    auto to_string() const -> std::string;
     auto operator==(const type_type&) const -> bool = default;
 };
 
 struct type_arena
 {
     auto to_hash() const { return hash(0); }
+    auto to_string() const -> std::string;
     auto operator==(const type_arena&) const -> bool = default;
 };
 
@@ -79,6 +88,7 @@ struct type_arena
 struct type_module
 {
     auto to_hash() const { return hash(0); }
+    auto to_string() const -> std::string;
     auto operator==(const type_module&) const -> bool = default;
 };
 
@@ -89,6 +99,7 @@ struct type_struct
     std::vector<type_name> templates;
 
     auto to_hash() const { return hash(name, module, templates); }
+    auto to_string() const -> std::string;
     auto operator==(const type_struct&) const -> bool = default;
 };
 
@@ -98,6 +109,7 @@ struct type_array
     std::size_t          count;
 
     auto to_hash() const { return hash(inner_type, count); }
+    auto to_string() const -> std::string;
     auto operator==(const type_array&) const -> bool = default;
 };
 
@@ -106,6 +118,7 @@ struct type_ptr
     value_ptr<type_name> inner_type;
 
     auto to_hash() const { return hash(inner_type); }
+    auto to_string() const -> std::string;
     auto operator==(const type_ptr&) const -> bool = default;
 };
 
@@ -114,6 +127,7 @@ struct type_span
     value_ptr<type_name> inner_type;
 
     auto to_hash() const { return hash(inner_type); }
+    auto to_string() const -> std::string;
     auto operator==(const type_span&) const -> bool = default;
 };
 
@@ -123,6 +137,7 @@ struct type_function_ptr
     value_ptr<type_name>   return_type;
 
     auto to_hash() const { return hash(param_types, return_type); }
+    auto to_string() const -> std::string;
     auto operator==(const type_function_ptr&) const -> bool = default;
 };
 
@@ -133,6 +148,7 @@ struct type_bound_method
     value_ptr<type_name>   return_type;
 
     auto to_hash() const { return hash(id, param_types, return_type); }
+    auto to_string() const -> std::string;
     auto operator==(const type_bound_method&) const -> bool = default;
 };
 
@@ -143,6 +159,7 @@ struct type_bound_method_template
     std::string              name;
 
     auto to_hash() const { return hash(module, struct_name, name); }
+    auto to_string() const -> std::string;
     auto operator==(const type_bound_method_template&) const -> bool = default;
 };
 
@@ -155,6 +172,7 @@ struct type_function
     auto to_pointer() const -> type_name;
     auto to_hash() const { return hash(id, param_types, return_type); }
     auto to_bound_method() -> type_bound_method { return {id, param_types, return_type}; }
+    auto to_string() const -> std::string;
     auto operator==(const type_function&) const -> bool = default;
 };
 
@@ -175,6 +193,7 @@ struct type_struct_template
     std::string           name;
 
     auto to_hash() const { return hash(module, name); }
+    auto to_string() const -> std::string;
     auto operator==(const type_struct_template&) const -> bool = default;
 };
 
@@ -184,32 +203,9 @@ struct type_placeholder
     std::string name;
 
     auto to_hash() const { return hash(name); }
+    auto to_string() const -> std::string;
     auto operator==(const type_placeholder&) const -> bool = default;
 };
-
-auto to_string(const type_name& type) -> std::string;
-
-auto to_string(const type_null&) -> std::string;
-auto to_string(const type_bool&) -> std::string;
-auto to_string(const type_char&) -> std::string;
-auto to_string(const type_i32&) -> std::string;
-auto to_string(const type_i64&) -> std::string;
-auto to_string(const type_u64&) -> std::string;
-auto to_string(const type_f64&) -> std::string;
-auto to_string(const type_module&) -> std::string;
-auto to_string(const type_type&) -> std::string;
-auto to_string(const type_arena&) -> std::string;
-auto to_string(const type_array& type) -> std::string;
-auto to_string(const type_ptr& type) -> std::string;
-auto to_string(const type_span& type) -> std::string;
-auto to_string(const type_struct& type) -> std::string;
-auto to_string(const type_function_ptr& type) -> std::string;
-auto to_string(const type_bound_method& type) -> std::string;
-auto to_string(const type_bound_method_template& type) -> std::string;
-auto to_string(const type_function& type) -> std::string;
-auto to_string(const type_function_template& type) -> std::string;
-auto to_string(const type_struct_template& type) -> std::string;
-auto to_string(const type_placeholder& type) -> std::string;
 
 struct type_name : public std::variant<
     type_null,
@@ -263,7 +259,7 @@ struct type_name : public std::variant<
     }
 
     auto to_string() const -> std::string {
-        const auto inner = std::visit([](const auto& obj) { return anzu::to_string(obj); }, *this);
+        const auto inner = std::visit([](const auto& obj) { return obj.to_string(); }, *this);
         return std::format("{}{}", inner, is_const ? " const" : "");
     }
 };


### PR DESCRIPTION
* Anzu has a custom formatter that lets any type with a `.to_string()` be printable, but for the type structs I have `anzu::to_string` free functions instead.
* Made all of these free functions member functions instead.
* Removed some redundant wrapping of types in some prints.