### PR TITLE
Fix Nested Template Deduction

### DIFF
--- a/examples/feature_test.az
+++ b/examples/feature_test.az
@@ -367,3 +367,13 @@ print("{}\n", my_vec.size());
 for x in my_vec.to_span() {
     print("{} ", x@);
 }
+print("\n");
+
+# Iterators from the stdlib, nested
+let x := [1, 2, 3];
+let y := ["a", "b", "c"];
+
+for elem in std.enumerate(std.zip(x[], y[])) {
+    print("{}: {} {}\n", elem.index, elem.value.left@, elem.value.right@);
+}
+print("{}\n", @type_name_of(std.enumerate(std.zip(x[], y[]))));

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,10 +1,8 @@
 let std := @import("lib/std.az");
 
+let x := [1, 2, 3];
+let y := ["a", "b", "c"];
 
-
-let x := [1, 2, 3, 4];
-let y := ["a", "b", "c", "d"];
-
-for e in std.enumerate(std.zip(x[], y[])) {
-    print("{}: {} {}\n", e.index, e.value.left@, e.value.right@);
+for elem in std.enumerate(std.zip(x[], y[])) {
+    print("{}: {} {}\n", elem.index, elem.value.left@, elem.value.right@);
 }

--- a/examples/test.az
+++ b/examples/test.az
@@ -3,6 +3,6 @@ let std := @import("lib/std.az");
 let x := [1, 2, 3];
 let y := ["a", "b", "c"];
 
-for elem in std.enumerate(std.zip(x[], y[])) {
-    print("{}: {} {}\n", elem.index, elem.value.left@, elem.value.right@);
+for elem in std.enumerate(std.iterspan(x[])) {
+    print("{}: {}\n", elem.index, elem.value@);
 }

--- a/lib/std.az
+++ b/lib/std.az
@@ -318,7 +318,7 @@ struct pairwise_iterator!(T)
 
     fn current(self: const&) -> pairwise_iterator_value!(T)
     {
-        return pairwise_iterator_value!(T)(self._elems[self._curr]&, self._elems[self._curr + 1u]&);
+        return pairwise_iterator_value(self._elems[self._curr]&, self._elems[self._curr + 1u]&);
     }
 
     fn valid(self: const&) -> bool
@@ -337,7 +337,7 @@ struct pairwise_iterator!(T)
 fn pairwise!(T)(elems: T[]) -> pairwise_iterator!(T)
 {
     assert @len(elems) >= 2u;
-    return pairwise_iterator!(T)(elems, 0u);
+    return pairwise_iterator(elems, 0u);
 }
 
 struct enumerate_iterator_value!(A)
@@ -358,13 +358,7 @@ struct enumerate_iterator!(T)
 
     fn next(self: &) -> enumerate_iterator_value!(@type_of(self._iter.next()))
     {
-        var v := self._iter.next();
-        let Z := enumerate_iterator_value!(@type_of(v));
-
-        var curr := Z();
-        curr.index = self._curr;
-        curr.value = v;
-
+        let curr := enumerate_iterator_value(self._curr, self._iter.next());
         self._curr = self._curr + 1u;
         return curr;
     }
@@ -372,7 +366,7 @@ struct enumerate_iterator!(T)
 
 fn enumerate!(T)(iter: T) -> enumerate_iterator!(T)
 {
-    return enumerate_iterator!(T)(iter, 0u);
+    return enumerate_iterator(iter, 0u);
 }
 
 struct zip_iterator_value!(T, U)
@@ -400,7 +394,7 @@ struct zip_iterator!(T, U)
 
     fn current(self: const&) -> zip_iterator_value!(T, U)
     {
-        return zip_iterator_value!(T, U)(self._left[self._curr]&, self._right[self._curr]&, self._curr);
+        return zip_iterator_value(self._left[self._curr]&, self._right[self._curr]&, self._curr);
     }
 
     fn next(self: &) -> zip_iterator_value!(T, U)
@@ -414,5 +408,5 @@ struct zip_iterator!(T, U)
 fn zip!(T, U)(left: T[], right: U[]) -> zip_iterator!(T, U)
 {
     assert @len(left) == @len(right);
-    return zip_iterator!(T, U)(left, right, 0u);
+    return zip_iterator(left, right, 0u);
 }

--- a/lib/std.az
+++ b/lib/std.az
@@ -410,3 +410,31 @@ fn zip!(T, U)(left: T[], right: U[]) -> zip_iterator!(T, U)
     assert @len(left) == @len(right);
     return zip_iterator(left, right, 0u);
 }
+
+struct iterspan_iterator!(T)
+{
+    _iter: T[];
+    _curr: u64;
+
+    fn valid(self: const&) -> bool
+    {
+        return self._curr < @len(self._iter);
+    }
+
+    fn current(self: const&) -> T&
+    {
+        return self._iter[self._curr]&;
+    }
+
+    fn next(self: &) -> T&
+    {
+        let curr := self.current();
+        self._curr = self._curr + 1u;
+        return curr;
+    }
+}
+
+fn iterspan!(T)(elems: T[]) -> iterspan_iterator!(T)
+{
+    return iterspan_iterator(elems, 0u);
+}

--- a/src/compiler.hpp
+++ b/src/compiler.hpp
@@ -45,7 +45,7 @@ struct compiler
     std::vector<type_struct>           current_struct;
     std::vector<std::size_t>           current_function;
 
-    std::vector<std::unordered_set<std::string>> current_placeholders;
+    std::vector<const std::unordered_set<std::string>*> current_placeholders;
 };
 
 auto compile(const anzu_module& ast) -> bytecode_program;


### PR DESCRIPTION
* Doing a template deduction within a template function was broken, but only if the two functions used the same name for the placeholder.
* This was due to two things; firstly, name lookup when compiling `node_name_expr` would check the current function and struct template parameters before checking the "current_placeholders", which is set during type deduction (naming here is bad I know). It should always check the current_placeholders first.
* Second, the current_placeholders should only be set when resolving the function params; not the arguments passed to the function. Otherwise, if both the caller and callee have a template placeholder with the same name (say `T`), then it sets the type of a variable passed in (which uses `T` from the caller) to `T` from the callee, which doesn't make sense.
* Updated the standard library to use more type deduction.
* Added `iterspan!(T)` to the stdlib, which is just a wrapper around a span that gives it an iterator interface so that it can compose with other iterators. This is a bit hacky and spans should naturally implement an iterator protocol, but I think the "real" solution would be a `@iter` intrinsic, which isn't much cleaner anyway. I quite like how this can be implemented in the library rather than the language.