### PR TITLE
Unpacking

### DIFF
--- a/examples/test.az
+++ b/examples/test.az
@@ -1,10 +1,5 @@
 
-struct foo {
-    x: i64;
-    y: i64;
-}
-
-let f := foo(1, 2);
-let [a, b] := f;
-a = 10;
-print("{} {}\n", a, b);
+var x := [1, 2, 3];
+let [a, b, c] := x;
+x[1u] = 10;
+print("{} {} {}\n", a, b, c);

--- a/examples/test.az
+++ b/examples/test.az
@@ -6,4 +6,5 @@ struct foo {
 
 let f := foo(1, 2);
 let [a, b] := f;
+a = 10;
 print("{} {}\n", a, b);

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,8 +1,9 @@
-let std := @import("lib/std.az");
 
-let x := [1, 2, 3];
-let y := ["a", "b", "c"];
-
-for elem in std.enumerate(std.iterspan(x[])) {
-    print("{}: {}\n", elem.index, elem.value@);
+struct foo {
+    x: i64;
+    y: i64;
 }
+
+let f := foo(1, 2);
+let [a, b] := f;
+print("{} {}\n", a, b);

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -233,7 +233,11 @@ auto print_node(const node_stmt& root, int indent) -> void
         },
         [&](const node_declaration_stmt& node) {
             std::print("{}Declaration:\n", spaces);
-            std::print("{}- Name: {}\n", spaces, node.name);
+            if (node.names.size() == 1) {
+                std::print("{}- Name: {}\n", spaces, node.names[0]);
+            } else {
+                std::print("{}- Names: {}\n", spaces, format_comma_separated(node.names));
+            }
             if (node.explicit_type) {
                 std::print("{}- ExplicitType:\n", spaces);
                 print_node(*node.explicit_type, indent + 1);

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -301,10 +301,10 @@ struct node_continue_stmt
 
 struct node_declaration_stmt
 {
-    std::string   name;
-    node_expr_ptr expr;
-    node_expr_ptr explicit_type;
-    bool          add_const;
+    std::vector<std::string> names;
+    node_expr_ptr            expr;
+    node_expr_ptr            explicit_type;
+    bool                     add_const;
 
     anzu::token token;
 };

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -1871,7 +1871,11 @@ auto push_stmt(compiler& com, const node_declaration_stmt& node) -> void
         declare_var(com, node.token, node.names[0], type, expr_value);
     } else {
         node.token.assert(type.is<type_struct>(), "can only unpack structs");
-        node.token.assert_eq(node.names.size(), com.types.fields_of(type.as<type_struct>()).size(), "invalid number of args to unpack into");
+        const auto fields = com.types.fields_of(type.as<type_struct>());
+        node.token.assert_eq(node.names.size(), fields.size(), "invalid number of args to unpack into");
+        for (const auto& [name, field] : std::views::zip(node.names, fields)) {
+            declare_var(com, node.token, name, field.type);
+        }
     }
 }
 

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -1870,13 +1870,26 @@ auto push_stmt(compiler& com, const node_declaration_stmt& node) -> void
     if (node.names.size() == 1) {
         declare_var(com, node.token, node.names[0], type, expr_value);
     } else {
-        node.token.assert(type.is<type_struct>(), "can only unpack structs");
-        const auto fields = com.types.fields_of(type.as<type_struct>());
-        node.token.assert_eq(node.names.size(), fields.size(), "invalid number of args to unpack into");
-        for (const auto& [name, field] : std::views::zip(node.names, fields)) {
-            auto field_type = field.type;
+        if (type.is<type_struct>()) {
+            const auto fields = com.types.fields_of(type.as<type_struct>());
+            node.token.assert_eq(node.names.size(), fields.size(), "invalid number of args to unpack struct into");
+            for (const auto& [name, field] : std::views::zip(node.names, fields)) {
+                auto field_type = field.type;
+                field_type.is_const = node.add_const;
+                declare_var(com, node.token, name, field_type);
+            }
+        }
+        else if (type.is<type_array>()) {
+            const auto size = type.as<type_array>().count;
+            node.token.assert_eq(node.names.size(), size, "invalid number of args to unpack array into");
+            auto field_type = *type.as<type_array>().inner_type;
             field_type.is_const = node.add_const;
-            declare_var(com, node.token, name, field_type);
+            for (const auto& name : node.names) {
+                declare_var(com, node.token, name, field_type);
+            }
+        }
+        else {
+            node.token.error("objects of type {} cannot be unpacked", type);
         }
     }
 }

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -1874,7 +1874,9 @@ auto push_stmt(compiler& com, const node_declaration_stmt& node) -> void
         const auto fields = com.types.fields_of(type.as<type_struct>());
         node.token.assert_eq(node.names.size(), fields.size(), "invalid number of args to unpack into");
         for (const auto& [name, field] : std::views::zip(node.names, fields)) {
-            declare_var(com, node.token, name, field.type);
+            auto field_type = field.type;
+            field_type.is_const = node.add_const;
+            declare_var(com, node.token, name, field_type);
         }
     }
 }

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -1867,7 +1867,12 @@ auto push_stmt(compiler& com, const node_declaration_stmt& node) -> void
     node.token.assert(!type.is<type_arena>(), "cannot create copies of arenas");
 
     push_copy_typechecked(com, *node.expr, type, node.token);
-    declare_var(com, node.token, node.name, type, expr_value);
+    if (node.names.size() == 1) {
+        declare_var(com, node.token, node.names[0], type, expr_value);
+    } else {
+        node.token.assert(type.is<type_struct>(), "can only unpack structs");
+        node.token.assert_eq(node.names.size(), com.types.fields_of(type.as<type_struct>()).size(), "invalid number of args to unpack into");
+    }
 }
 
 auto push_stmt(compiler& com, const node_arena_declaration_stmt& node) -> void

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -561,7 +561,14 @@ auto parse_declaration_stmt(tokenstream& tokens) -> node_stmt_ptr
                                   stmt.token.text);
     }
 
-    stmt.name = parse_identifier(tokens);
+    if (tokens.consume_maybe(token_type::left_bracket)) {
+        tokens.consume_comma_separated_list(token_type::right_bracket, [&] {
+            stmt.names.push_back(parse_identifier(tokens));
+        });
+    } else {
+        stmt.names.push_back(parse_identifier(tokens));
+    }
+
     if (tokens.consume_maybe(token_type::colon)) {
         stmt.explicit_type = parse_expression(tokens);
         tokens.consume_only(token_type::equal);


### PR DESCRIPTION
* It is now possible to unpack the fields of a struct, or an array, into a set of named variables.
* For example, given an object `s` of type `S` with two fields, the following syntax is now valid: `let [a, b] := s;`.
* This is no less efficient than a normal declaration; the actual code hasn't changed and the entire object is loaded onto the stack, the only thing that has changed is the compilers internal representation of the values.
* It is a compiler error if there is a mismatch in the number of elements.
* With this, it is also possible to declare several objects of the same type in one line: `let [a, b, c] := [1, 2, 3];`, which is a nice quirk.
* Next, I would like to expand it to be usable in for loops, as well as allow nested unpacking.