### PR TITLE
Nested Unpacking and For Loop Use

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ Declare with `:=` operator and either `let` or `var`: `let x := 5` or `var x := 
 * `let` declares a const value and `var` declares a mutable value.
 * Explicit typing can be provided: `let x : i64 = 10`. Safe type conversions can happen here (see more info below).
 * Assign to existing variable with `=` operator: `x = 6`.
+* If the object on the right is a struct or an array, it can be unpacked: `let [a, b] := <object>`.
+* Unpacking can be nested: `let [a, [b, c]] := <object>`.
 
 ### Comments
 Uses the `#` symbol.

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,8 +1,6 @@
+let std := @import("lib/std.az");
+let x := [1, 2, 3, 4];
 
-struct foo {
-    x: i64;
+for [idx, value] in std.enumerate(x[]) {
+    
 }
-
-let [a] := foo(10);
-let [b, c] := [1, 2];
-print("{} {} {}\n", a, b, c);

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,6 +1,6 @@
 let std := @import("lib/std.az");
 let x := [1, 2, 3, 4];
 
-for [idx, value] in std.enumerate(x[]) {
-    
+for [idx, value] in std.enumerate(std.iterspan(x[])) {
+    print("{}: {}\n", idx, value@);
 }

--- a/examples/test.az
+++ b/examples/test.az
@@ -4,4 +4,5 @@ struct foo {
 }
 
 let [a] := foo(10);
-@type_name_of(a);
+let [b, c] := [1, 2];
+print("{} {} {}\n", a, b, c);

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,6 +1,7 @@
 let std := @import("lib/std.az");
 let x := [1, 2, 3, 4];
+let y := ["a", "b", "c", "d"];
 
-for [idx, value] in std.enumerate(std.iterspan(x[])) {
-    print("{}: {}\n", idx, value@);
+for [idx, [left, right]] in std.enumerate(std.zip(x[], y[])) {
+    print("{}: {} {}\n", idx, left@, right@);
 }

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,7 +1,17 @@
 let std := @import("lib/std.az");
-let x := [1, 2, 3, 4];
-let y := ["a", "b", "c", "d"];
 
-for [idx, [left, right]] in std.enumerate(std.zip(x[], y[])) {
-    print("{}: {} {}\n", idx, left@, right@);
+struct bar
+{
+    x: i64;
+    y: i64;
 }
+
+struct foo
+{
+    b: bar;
+    x: f64;
+}
+
+let f := foo(bar(2, 3), 1.0);
+let [[r, t], y] := f;
+print("{} {} {}\n", r, t, y);

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,5 +1,7 @@
 
-var x := [1, 2, 3];
-let [a, b, c] := x;
-x[1u] = 10;
-print("{} {} {}\n", a, b, c);
+struct foo {
+    x: i64;
+}
+
+let [a] := foo(10);
+@type_name_of(a);

--- a/lib/std.az
+++ b/lib/std.az
@@ -373,7 +373,6 @@ struct zip_iterator_value!(T, U)
 {
     left:  T&;
     right: U&;
-    index: u64;
 }
 
 struct zip_iterator!(T, U)
@@ -394,7 +393,7 @@ struct zip_iterator!(T, U)
 
     fn current(self: const&) -> zip_iterator_value!(T, U)
     {
-        return zip_iterator_value(self._left[self._curr]&, self._right[self._curr]&, self._curr);
+        return zip_iterator_value(self._left[self._curr]&, self._right[self._curr]&);
     }
 
     fn next(self: &) -> zip_iterator_value!(T, U)

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -205,7 +205,8 @@ auto print_node(const node_stmt& root, int indent) -> void
             print_node(*node.body, indent + 1);
         },
         [&](const node_for_stmt& node) {
-            std::print("{}For (name={}):\n", spaces, node.name);
+            std::print("{}For:\n", spaces);
+            print_name_pack(spaces, node.names);
             std::print("{}- Iter:\n", spaces);
             print_node(*node.iter, indent + 1);
             std::print("{}- Body:\n", spaces);

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -233,11 +233,12 @@ auto print_node(const node_stmt& root, int indent) -> void
         },
         [&](const node_declaration_stmt& node) {
             std::print("{}Declaration:\n", spaces);
-            if (node.names.size() == 1) {
-                std::print("{}- Name: {}\n", spaces, node.names[0]);
-            } else {
+            if (node.is_unpack) {
                 std::print("{}- Names: {}\n", spaces, format_comma_separated(node.names));
+            } else {
+                std::print("{}- Name: {}\n", spaces, node.names[0]);
             }
+            std::print("{}- Unpacked: {}\n", spaces, node.is_unpack);
             if (node.explicit_type) {
                 std::print("{}- ExplicitType:\n", spaces);
                 print_node(*node.explicit_type, indent + 1);

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -5,6 +5,19 @@
 #include <ranges>
 
 namespace anzu {
+namespace {
+
+auto print_name_pack(std::string_view spaces, const name_pack& names) -> void
+{
+    if (names.is_pack) {
+        std::print("{}- Names: {}\n", spaces, format_comma_separated(names.names));
+    } else {
+        std::print("{}- Name: {}\n", spaces, names.names[0]);
+    }
+    std::print("{}- Is Pack: {}\n", spaces, names.is_pack);
+}
+
+}
 
 auto print_node(const node_expr& root, int indent) -> void
 {
@@ -233,12 +246,7 @@ auto print_node(const node_stmt& root, int indent) -> void
         },
         [&](const node_declaration_stmt& node) {
             std::print("{}Declaration:\n", spaces);
-            if (node.is_unpack) {
-                std::print("{}- Names: {}\n", spaces, format_comma_separated(node.names));
-            } else {
-                std::print("{}- Name: {}\n", spaces, node.names[0]);
-            }
-            std::print("{}- Unpacked: {}\n", spaces, node.is_unpack);
+            print_name_pack(spaces, node.names);
             if (node.explicit_type) {
                 std::print("{}- ExplicitType:\n", spaces);
                 print_node(*node.explicit_type, indent + 1);

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -302,6 +302,7 @@ struct node_continue_stmt
 struct node_declaration_stmt
 {
     std::vector<std::string> names;
+    bool                     is_unpack;
     node_expr_ptr            expr;
     node_expr_ptr            explicit_type;
     bool                     add_const;

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -269,7 +269,7 @@ struct node_while_stmt
 
 struct node_for_stmt
 {
-    std::string name;
+    name_pack     names;
     node_expr_ptr iter;
     node_stmt_ptr body;
 

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -14,6 +14,12 @@ using node_expr_ptr = std::shared_ptr<node_expr>;
 struct node_stmt;
 using node_stmt_ptr = std::shared_ptr<node_stmt>;
 
+struct name_pack
+{
+    std::vector<std::string> names;
+    bool                     is_pack;
+};
+
 struct node_literal_i32_expr
 {
     std::int32_t value;
@@ -301,11 +307,10 @@ struct node_continue_stmt
 
 struct node_declaration_stmt
 {
-    std::vector<std::string> names;
-    bool                     is_unpack;
-    node_expr_ptr            expr;
-    node_expr_ptr            explicit_type;
-    bool                     add_const;
+    name_pack     names;
+    node_expr_ptr expr;
+    node_expr_ptr explicit_type;
+    bool          add_const;
 
     anzu::token token;
 };

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -16,8 +16,7 @@ using node_stmt_ptr = std::shared_ptr<node_stmt>;
 
 struct name_pack
 {
-    std::vector<std::string> names;
-    bool                     is_pack;
+    std::variant<std::string, std::vector<name_pack>> names;
 };
 
 struct node_literal_i32_expr

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -665,7 +665,7 @@ auto push_name_pack(
         [&](const std::vector<name_pack>& names) {
             if (type.is<type_struct>()) {
                 const auto fields = com.types.fields_of(type.as<type_struct>());
-                tok.assert_eq(names.size(), fields.size(), "invalid number of args to unpack struct into {} {}", type, fields.size());
+                tok.assert_eq(names.size(), fields.size(), "invalid number of args to unpack struct {} into", type);
                 for (const auto& [name, field] : std::views::zip(names, fields)) {
                     auto field_type = field.type;
                     field_type.is_const = type.is_const;
@@ -674,7 +674,7 @@ auto push_name_pack(
             }
             else if (type.is<type_array>()) {
                 const auto size = type.as<type_array>().count;
-                tok.assert_eq(names.size(), size, "invalid number of args to unpack array into");
+                tok.assert_eq(names.size(), size, "invalid number of args to unpack array {} into", type);
                 auto field_type = *type.as<type_array>().inner_type;
                 field_type.is_const = type.is_const;
                 for (const auto& name : names) {

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -650,6 +650,42 @@ auto compile_struct_template(
     }
 }
 
+auto push_name_pack(
+    compiler& com,
+    const token& tok,
+    const name_pack& np,
+    bool add_const,
+    const type_name& type,
+    const const_value& expr_value = {}
+) -> void
+{
+    if (!np.is_pack) {
+        declare_var(com, tok, np.names[0], type, expr_value);
+    } else {
+        if (type.is<type_struct>()) {
+            const auto fields = com.types.fields_of(type.as<type_struct>());
+            tok.assert_eq(np.names.size(), fields.size(), "invalid number of args to unpack struct into");
+            for (const auto& [name, field] : std::views::zip(np.names, fields)) {
+                auto field_type = field.type;
+                field_type.is_const = add_const;
+                declare_var(com, tok, name, field_type, expr_value);
+            }
+        }
+        else if (type.is<type_array>()) {
+            const auto size = type.as<type_array>().count;
+            tok.assert_eq(np.names.size(), size, "invalid number of args to unpack array into");
+            auto field_type = *type.as<type_array>().inner_type;
+            field_type.is_const = add_const;
+            for (const auto& name : np.names) {
+                declare_var(com, tok, name, field_type, expr_value);
+            }
+        }
+        else {
+            tok.error("objects of type {} cannot be unpacked", type);
+        }
+    }
+}
+
 auto push_expr(compiler& com, compile_type ct, const node_literal_i32_expr& node) -> expr_result
 {
     node.token.assert(ct == compile_type::val, "cannot take the address of a i32 literal");
@@ -1704,7 +1740,7 @@ void push_for_loop_span(compiler& com, const node_for_stmt& node, const type_spa
         push_var_val(com, node.token, curr_module(com), "$iter");
         push_var_val(com, node.token, curr_module(com), "$idx");
         push_value(code(com), op::nth_element_ptr, com.types.size_of(inner));
-        declare_var(com, node.token, node.name, inner.add_ptr());
+        push_name_pack(com, node.token, node.names, false, inner.add_ptr());
 
         // idx = idx + 1;
         push_var_val(com, node.token, curr_module(com), "$idx");
@@ -1758,7 +1794,7 @@ void push_for_loop_iterator(compiler& com, const node_for_stmt& node, const type
         // var name := obj.next();
         push_var_addr(com, node.token, curr_module(com), "$iter");
         push_value(code(com), op::call_static, next_fn.id, sizeof(std::byte*));
-        declare_var(com, node.token, node.name, next_fn.return_type);
+        push_name_pack(com, node.token, node.names, false, next_fn.return_type);
 
         // main body
         push_stmt(com, *node.body);
@@ -1855,42 +1891,6 @@ void push_stmt(compiler& com, const node_continue_stmt& node)
     push_value(code(com), op::jump);
     const auto pos = push_value(code(com), std::uint64_t{0}); // filled in later
     variables(com).get_loop_info().continues.push_back(pos);
-}
-
-auto push_name_pack(
-    compiler& com,
-    const token& tok,
-    const name_pack& np,
-    bool add_const,
-    const type_name& type,
-    const const_value& expr_value = {}
-) -> void
-{
-    if (!np.is_pack) {
-        declare_var(com, tok, np.names[0], type, expr_value);
-    } else {
-        if (type.is<type_struct>()) {
-            const auto fields = com.types.fields_of(type.as<type_struct>());
-            tok.assert_eq(np.names.size(), fields.size(), "invalid number of args to unpack struct into");
-            for (const auto& [name, field] : std::views::zip(np.names, fields)) {
-                auto field_type = field.type;
-                field_type.is_const = add_const;
-                declare_var(com, tok, name, field_type);
-            }
-        }
-        else if (type.is<type_array>()) {
-            const auto size = type.as<type_array>().count;
-            tok.assert_eq(np.names.size(), size, "invalid number of args to unpack array into");
-            auto field_type = *type.as<type_array>().inner_type;
-            field_type.is_const = add_const;
-            for (const auto& name : np.names) {
-                declare_var(com, tok, name, field_type);
-            }
-        }
-        else {
-            tok.error("objects of type {} cannot be unpacked", type);
-        }
-    }
 }
 
 auto push_stmt(compiler& com, const node_declaration_stmt& node) -> void

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -1867,7 +1867,7 @@ auto push_stmt(compiler& com, const node_declaration_stmt& node) -> void
     node.token.assert(!type.is<type_arena>(), "cannot create copies of arenas");
 
     push_copy_typechecked(com, *node.expr, type, node.token);
-    if (node.names.size() == 1) {
+    if (!node.is_unpack) {
         declare_var(com, node.token, node.names[0], type, expr_value);
     } else {
         if (type.is<type_struct>()) {

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -45,13 +45,12 @@ auto parse_name_pack(tokenstream& tokens) -> name_pack
 {
     name_pack np;
     if (tokens.consume_maybe(token_type::left_bracket)) {
-        np.is_pack = true;
+        auto& names = np.names.emplace<std::vector<name_pack>>();
         tokens.consume_comma_separated_list(token_type::right_bracket, [&] {
-            np.names.push_back(parse_identifier(tokens));
+            names.push_back(parse_name_pack(tokens));
         });
     } else {
-        np.is_pack = false;
-        np.names.push_back(parse_identifier(tokens));
+        np.names = parse_identifier(tokens);
     }
     return np;
 }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -512,7 +512,7 @@ auto parse_for_stmt(tokenstream& tokens) -> node_stmt_ptr
     auto& stmt = node->emplace<node_for_stmt>();
 
     stmt.token = tokens.consume_only(token_type::kw_for);
-    stmt.name = parse_identifier(tokens);
+    stmt.names = parse_name_pack(tokens);
     tokens.consume_only(token_type::kw_in);
     stmt.iter = parse_expression(tokens);
     stmt.body = parse_statement(tokens);

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -562,10 +562,12 @@ auto parse_declaration_stmt(tokenstream& tokens) -> node_stmt_ptr
     }
 
     if (tokens.consume_maybe(token_type::left_bracket)) {
+        stmt.is_unpack = true;
         tokens.consume_comma_separated_list(token_type::right_bracket, [&] {
             stmt.names.push_back(parse_identifier(tokens));
         });
     } else {
+        stmt.is_unpack = false;
         stmt.names.push_back(parse_identifier(tokens));
     }
 


### PR DESCRIPTION
* Unpacking syntax has been expanded to nest to allow for nested unpacking: `let [a, [b, c]] := foo`.
* For for loops using iterators, you can now unpack the object: `for [index, value] in std.enumerate(...) {}`.
* Allows for a more convenient way to compose zip and enumerate: `for [index, [left, right]] in std.enumerate(std.zip(a, b)) {}`.
* Unpacking does not work for looping over spans since that returns pointers, maybe this needs to be changed?