### PR TITLE
Make For Loops Return Copies

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ for <name> in <obj> {
 }
 ```
 There are two forms this takes:
-* `obj` can be a span. In this case, `name` is a pointer to the current element. This expands to
+* `obj` can be a span. In this case, `name` is a copy of the current element. This expands to
     ```
     var $s := <obj>;
     var $idx := 0u;
@@ -93,6 +93,12 @@ There are two forms this takes:
         var <name> := $s[$idx];
         <body>
         $idx = $idx + 1u;
+    }
+    ```
+    If you want to avoid the copy and/or mutate the underlying value, you can instead get a pointer to the current element via
+    ```
+    for <name>& in <obj> {  # Note the & here
+        <body>
     }
     ```
 * `obj` can be an "iterator". This is any struct type that has two member functions; `valid` and `next`. Both take no arguments aside from the implicit this pointer. `valid` must return a bool, and `next` can return any type, and the return object is what gets bound to `name`.
@@ -104,6 +110,15 @@ There are two forms this takes:
         <body>
     }
     ```
+    The `&` syntax is not available for iterator-based for loops, instead it is up to the iterator type itself to return a pointer if a mutable value is required.
+
+For loops can also use unpacking syntax as seen above in declarations:
+```
+for [index, value] in std.enumerate(std.valspan(array[])) {
+    ...
+}
+```
+Here, `enumerate` is an iterator adaptor that acts like Python's enumerate by returning a pair containing an index and a value. `std.valspan` is a bit of a hack to turn a span into an iterator. In the future I would like to make spans and iterators more composable in a natural way. The `&` syntax cannot be used with unpacking since unpacking is syntaxtic sugar over a value.
 
 The temporary variables are prefixed with `$` in the above examples to make them unspellable (and there inaccessible) in user code.
 

--- a/examples/aoc2015-1.az
+++ b/examples/aoc2015-1.az
@@ -2,10 +2,10 @@ var data := "()()(()()()(()()((()((()))((()((((()()((((()))()((((())(((((((()(((
 
 var count := 0;
 for c in data {
-    if c@ == '(' {
+    if c == '(' {
         count = count + 1;
     }
-    else if c@ == ')' {
+    else if c == ')' {
         count = count - 1;
     }
 }

--- a/examples/aoc2023-1.az
+++ b/examples/aoc2023-1.az
@@ -20,7 +20,7 @@ fn process_line(line: char const[]) -> i64
     var first := 0;
     var last := 0;
     for c in line {
-        let i := std.to_i64(c@);
+        let i := std.to_i64(c);
         if i != -1 {
             if first == 0 { first = i; }
             last = i;
@@ -47,4 +47,4 @@ while tokens.valid() {
     tokens.next();
 }
 
-print("{} {}\n", total_part1, total_part2);
+print("{}==55029 {}==55686\n", total_part1, total_part2);

--- a/examples/aoc2024-1.az
+++ b/examples/aoc2024-1.az
@@ -20,8 +20,8 @@ std.sort(r.to_span());
 
 var part1 := 0;
 var part2 := 0;
-for curr in std.zip(l.to_span(), r.to_span()) {
-    part1 = part1 + std.abs(curr.left@ - curr.right@);
-    part2 = part2 + counts[curr.left@ as u64] * curr.left@;
+for [left, right] in std.zip(l.to_span(), r.to_span()) {
+    part1 = part1 + std.abs(left - right);
+    part2 = part2 + counts[left as u64] * left;
 }
 print("{}\n{}\n", part1, part2);

--- a/examples/feature_test.az
+++ b/examples/feature_test.az
@@ -365,7 +365,7 @@ my_vec.push(3);
 my_vec.push(4);
 print("{}\n", my_vec.size());
 for x in my_vec.to_span() {
-    print("{} ", x@);
+    print("{} ", x);
 }
 print("\n");
 
@@ -374,6 +374,6 @@ let x := [1, 2, 3];
 let y := ["a", "b", "c"];
 
 for elem in std.enumerate(std.zip(x[], y[])) {
-    print("{}: {} {}\n", elem.index, elem.value.left@, elem.value.right@);
+    print("{}: {} {}\n", elem.index, elem.value.left, elem.value.right);
 }
 print("{}\n", @type_name_of(std.enumerate(std.zip(x[], y[]))));

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,6 +1,3 @@
 let std := @import("lib/std.az");
 
-let x := [1, 2, 3];
-for p in x[] {
-    print("{}\n", p);
-}
+print("{}\n", @is_span(i64[]&));

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,17 +1,6 @@
 let std := @import("lib/std.az");
 
-struct bar
-{
-    x: i64;
-    y: i64;
+let x := [1, 2, 3];
+for p in x[] {
+    print("{}\n", p);
 }
-
-struct foo
-{
-    b: bar;
-    x: f64;
-}
-
-let f := foo(bar(2, 3), 1.0);
-let [[r, t], y] := f;
-print("{} {} {}\n", r, t, y);

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,3 +1,11 @@
 let std := @import("lib/std.az");
 
-print("{}\n", @is_span(i64[]&));
+let arr := [
+    [1, 2],
+    [2, 3],
+    [3, 4]
+];
+
+for [x, y] in arr[] {
+    print("{} {}\n", x, y);
+}

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,11 +1,11 @@
 let std := @import("lib/std.az");
 
-let arr := [
-    [1, 2],
-    [2, 3],
-    [3, 4]
-];
+var arr := [[1], [2], [3]];
 
-for [x, y] in arr[] {
-    print("{} {}\n", x, y);
+for [x]& in arr[] {
+    x = 10;
+}
+
+for x in arr[] {
+    print("{}\n", x[0u]);
 }

--- a/lib/std.az
+++ b/lib/std.az
@@ -211,7 +211,7 @@ fn str_to_i64(str: char const[]) -> i64
 {
     var value := 0;
     for c in str {
-        let char_val := to_i64(c@);
+        let char_val := to_i64(c);
         if char_val == -1 { return -1; }
         value = 10 * value + char_val;
     }
@@ -371,8 +371,8 @@ fn enumerate!(T)(iter: T) -> enumerate_iterator!(T)
 
 struct zip_iterator_value!(T, U)
 {
-    left:  T&;
-    right: U&;
+    left:  T;
+    right: U;
 }
 
 struct zip_iterator!(T, U)
@@ -393,7 +393,7 @@ struct zip_iterator!(T, U)
 
     fn current(self: const&) -> zip_iterator_value!(T, U)
     {
-        return zip_iterator_value(self._left[self._curr]&, self._right[self._curr]&);
+        return zip_iterator_value(self._left[self._curr], self._right[self._curr]);
     }
 
     fn next(self: &) -> zip_iterator_value!(T, U)

--- a/lib/std.az
+++ b/lib/std.az
@@ -410,7 +410,35 @@ fn zip!(T, U)(left: T[], right: U[]) -> zip_iterator!(T, U)
     return zip_iterator(left, right, 0u);
 }
 
-struct iterspan_iterator!(T)
+struct valspan_iterator!(T)
+{
+    _iter: T[];
+    _curr: u64;
+
+    fn valid(self: const&) -> bool
+    {
+        return self._curr < @len(self._iter);
+    }
+
+    fn current(self: const&) -> T
+    {
+        return self._iter[self._curr];
+    }
+
+    fn next(self: &) -> T
+    {
+        let curr := self.current();
+        self._curr = self._curr + 1u;
+        return curr;
+    }
+}
+
+fn valspan!(T)(elems: T[]) -> valspan_iterator!(T)
+{
+    return valspan_iterator(elems, 0u);
+}
+
+struct ptrspan_iterator!(T)
 {
     _iter: T[];
     _curr: u64;
@@ -433,7 +461,7 @@ struct iterspan_iterator!(T)
     }
 }
 
-fn iterspan!(T)(elems: T[]) -> iterspan_iterator!(T)
+fn ptrspan!(T)(elems: T[]) -> ptrspan_iterator!(T)
 {
-    return iterspan_iterator(elems, 0u);
+    return ptrspan_iterator(elems, 0u);
 }

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -211,6 +211,7 @@ auto print_node(const node_stmt& root, int indent) -> void
         [&](const node_for_stmt& node) {
             std::print("{}For:\n", spaces);
             std::print("{}- Name(s): {}\n", spaces, name_pack_to_string(node.names));
+            std::print("{}- IsPtr: {}\n", spaces, node.is_ptr);
             std::print("{}- Iter:\n", spaces);
             print_node(*node.iter, indent + 1);
             std::print("{}- Body:\n", spaces);

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -269,6 +269,7 @@ struct node_while_stmt
 struct node_for_stmt
 {
     name_pack     names;
+    bool          is_ptr;
     node_expr_ptr iter;
     node_stmt_ptr body;
 

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -1741,8 +1741,8 @@ void push_for_loop_span(compiler& com, const node_for_stmt& node, const type_spa
         // var name := iter[idx]&;
         push_var_val(com, node.token, curr_module(com), "$iter");
         push_var_val(com, node.token, curr_module(com), "$idx");
-        push_value(code(com), op::nth_element_ptr, com.types.size_of(inner));
-        push_name_pack(com, node.token, node.names, inner.add_ptr());
+        push_value(code(com), op::nth_element_val, com.types.size_of(inner));
+        push_name_pack(com, node.token, node.names, inner);
 
         // idx = idx + 1;
         push_var_val(com, node.token, curr_module(com), "$idx");

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -1722,7 +1722,7 @@ void push_stmt(compiler& com, const node_while_stmt& node)
 //    var size := <<length of iter>>;
 //    loop {
 //        if idx == size break;
-//        var name := obj[idx]&;
+//        var name := obj[idx] or obj[idx]&;
 //        idx = idx + 1u;
 //        <body>
 //    }
@@ -1748,11 +1748,17 @@ void push_for_loop_span(compiler& com, const node_for_stmt& node, const type_spa
         push_break(com, node.token);
         write_value(code(com), jump_pos, code(com).size());
 
-        // var name := iter[idx]&;
+        // var name := iter[idx] or iter[idx]&;
         push_var_val(com, node.token, curr_module(com), "$iter");
         push_var_val(com, node.token, curr_module(com), "$idx");
-        push_value(code(com), op::nth_element_val, com.types.size_of(inner));
-        push_name_pack(com, node.token, node.names, inner);
+        if (node.is_ptr) {
+            node.token.assert(std::holds_alternative<std::string>(node.names.names), "span-based for loop cannot take a pointer to an unpacking");
+            push_value(code(com), op::nth_element_ptr, com.types.size_of(inner));
+            push_name_pack(com, node.token, node.names, inner.add_ptr());
+        } else {
+            push_value(code(com), op::nth_element_val, com.types.size_of(inner));
+            push_name_pack(com, node.token, node.names, inner);
+        }
 
         // idx = idx + 1;
         push_var_val(com, node.token, curr_module(com), "$idx");
@@ -1776,6 +1782,8 @@ void push_for_loop_span(compiler& com, const node_for_stmt& node, const type_spa
 void push_for_loop_iterator(compiler& com, const node_for_stmt& node, const type_struct& type)
 {
     declare_var(com, node.token, "$iter", type);
+
+    node.token.assert(!node.is_ptr, "an iterator-based loop cannot have a pointer argument");
 
     // Fetch and verify the valid() function
     const auto valid_name = function_name{.module=type.module, .struct_name=type, .name="valid"};

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -1620,7 +1620,17 @@ auto push_expr(compiler& com, compile_type ct, const node_intrinsic_expr& node) 
             [&](auto&&)      { return false; }
         }, type);
 
+        push_value(code(com), op::push_bool, is_fundamental);
         return { type_bool{}, {is_fundamental} };
+    }
+    if (node.name == "is_span") {
+        node.token.assert_eq(node.args.size(), 1, "@is_span only accepts one argument");
+        const auto result = type_of_expr(com, *node.args[0]);
+        const auto type = get_type_value(node.token, result);
+
+        const auto is_span = type.is<type_span>();
+        push_value(code(com), op::push_bool, is_span);
+        return { type_bool{}, {is_span} };
     }
     if (node.name == "read_file") {
         const auto char_span = type_name{type_char{}}.add_const().add_span();

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -512,6 +512,7 @@ auto parse_for_stmt(tokenstream& tokens) -> node_stmt_ptr
 
     stmt.token = tokens.consume_only(token_type::kw_for);
     stmt.names = parse_name_pack(tokens);
+    stmt.is_ptr = tokens.consume_maybe(token_type::ampersand);
     tokens.consume_only(token_type::kw_in);
     stmt.iter = parse_expression(tokens);
     stmt.body = parse_statement(tokens);


### PR DESCRIPTION
* Span based for loops used to return pointers, now they return values.
* If you want a pointer, you ask for it with a `&`, eg: `for x& in span { ... }`.
* Removed `std.iterspan` and replaced with `std.valspan` and `std.ptrspan` to turn both kinds of loops into their iterator equivalents to make spans composable with iterators. I don't like this but can't think of a better way.