### PR TITLE
Merge function and function_ptr types

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,6 @@ They are more flexible than functions; some accept types as arguments and you ca
 * `@copy(dst, src)` takes two spans of the same type and copies the contents of one into the other. The size of `dst` must be big enough to fit `src`, otherwise it's a runtime error. This exists because it can efficiently memcpy the data rather than looping over the elements.
 * `@compare(lhs, rhs)` takes two pointers of the same type and compares them bytewise via memcmp. 
 * `@import(name)` for importing and using other modules (more info below). This can only be used in the global scope.
-* `@fn_ptr(func)` takes the name of a function an explicitly converts it to a function pointer.
 * `@is_fundamental(type)` returns `true` (compile time bool) if the given type of one of the builtin types.
 * `@read_file(path, arena&)` take a filepath and a pointer to an arena, and loads the contents of the file into the arena, returning a `char const[]`.
 
@@ -238,8 +237,6 @@ var my_vec := vec.vector!(u64).create(alloc&);
 Many compile time objects are represented in Anzu's type system, but have no runtime information since all their info is contained in their type. This results in types that are not particularly useful, but does have some nice quirks.
 
 For example, if I had `struct foo { x: i64; }`, then `foo` itself is an object of size zero, whose type is `<type: foo>`. A constructor call then, is simply implemented as the call operator on this object which returns an object of type `foo`. This then naturally allows you to create type aliases with the normal variable syntax: `let f := foo` creates a variable `f` of type `<type: foo>`, so calling it is just a constructor call for `foo` as if you had used `foo` directly.
-
-Just like how every struct definition is an object of its own type (for every type `T` there is the type `<type: T>`), the same applies to functions. `let f := func` gives a new name to the function, and `f` is a function type and not a function pointer type. To create a function pointer explicitly from a function, you can either declare the function pointer type in the declaration to make a safe type conversion happen, or use the more convention `@fn_ptr` intrinsic (`let f := @fn_ptr(func)`).
 
 Some more "size zero" types are:
 * Functions

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,9 +1,8 @@
-fn foo(x: i64) -> i64
+fn foo() 
 {
-    print("{}\n", x);
-    return x;
+
 }
 
+
 var f := foo;
-foo(1);
-f(2);
+f();

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,10 +1,13 @@
-
-fn foo() -> i64
+fn foo(x: i64) -> i64
 {
-    return 1;
+    print("{}\n", x);
+    return x;
 }
 
-let f := @fn_ptr(foo);
+fn bar(f: fn(i64) -> i64, x: i64)
+{
+    f(x);
+}
 
-foo();
-f();
+foo(1);
+bar(foo, 1);

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,11 +1,10 @@
-let std := @import("lib/std.az");
 
-var arr := [[1], [2], [3]];
-
-for [x]& in arr[] {
-    x = 10;
+fn foo() -> i64
+{
+    return 1;
 }
 
-for x in arr[] {
-    print("{}\n", x[0u]);
-}
+let f := @fn_ptr(foo);
+
+foo();
+f();

--- a/examples/test.az
+++ b/examples/test.az
@@ -4,10 +4,6 @@ fn foo(x: i64) -> i64
     return x;
 }
 
-fn bar(f: fn(i64) -> i64, x: i64)
-{
-    f(x);
-}
-
+var f := foo;
 foo(1);
-bar(foo, 1);
+f(2);

--- a/src/bytecode.cpp
+++ b/src/bytecode.cpp
@@ -165,7 +165,7 @@ auto print_op(std::string_view rom, const std::byte* start, const std::byte* ptr
         case op::call_static: {
             const auto id = read_at<std::uint64_t>(&ptr);
             const auto args_size = read_at<std::uint64_t>(&ptr);
-            std::print("CALL_PTR: id={} args_size={}\n", id, args_size);
+            std::print("CALL_STATIC: id={} args_size={}\n", id, args_size);
         } break;
         case op::call_ptr: {
             const auto args_size = read_at<std::uint64_t>(&ptr);

--- a/src/compilation/type_manager.cpp
+++ b/src/compilation/type_manager.cpp
@@ -50,14 +50,27 @@ auto type_manager::size_of(const type_name& type) const -> std::size_t
         [](type_f64) {
             return std::size_t{8};
         },
+        [](type_type) {
+            return std::size_t{0};
+        },
         [](type_arena) {
             return sizeof(std::byte*); // the runtime will store the arena separately
         },
         [](type_module) {
             return std::size_t{0};
         },
-        [](type_type) {
-            return std::size_t{0};
+        [&](const type_array& t) {
+            return size_of(*t.inner_type) * t.count;
+        },
+        [](const type_ptr&) {
+            return sizeof(std::byte*);
+        },
+        [](const type_span&) {
+            return sizeof(std::byte*) + sizeof(std::size_t);
+        },
+
+        [](const type_function&) {
+            return sizeof(std::uint64_t);
         },
         [&](const type_struct& t) -> std::size_t {
             if (!d_classes.contains(t)) {
@@ -69,33 +82,20 @@ auto type_manager::size_of(const type_name& type) const -> std::size_t
             }
             return std::max(std::size_t{1}, size); // empty structs take up one byte
         },
-        [&](const type_array& t) {
-            return size_of(*t.inner_type) * t.count;
-        },
-        [](const type_ptr&) {
-            return sizeof(std::byte*);
-        },
-        [](const type_span&) {
-            return sizeof(std::byte*) + sizeof(std::size_t);
-        },
-        [](const type_function_ptr&) {
-            return sizeof(std::byte*);
-        },
         [](const type_bound_method&) {
             return sizeof(std::byte*); // pointer to the object, first arg to the function
         },
-        [](const type_bound_method_template&) {
-            return sizeof(std::byte*); // pointer to the object, first arg to the function
-        },
-        [](const type_function&) {
-            return std::size_t{0};
-        },
+
         [](const type_function_template&) {
             return std::size_t{0};
         },
         [](const type_struct_template&) {
             return std::size_t{0};
         },
+        [](const type_bound_method_template&) {
+            return sizeof(std::byte*); // pointer to the object, first arg to the function
+        },
+        
         [](const type_placeholder&) {
             return std::size_t{0}; 
         }

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -277,7 +277,8 @@ void push_copy_typechecked(compiler& com, const node_expr& expr, const type_name
     // Remove top-level const since we are making a copy, ie- you should be able to pass a
     // 'u64 const' for a 'u64', but not a 'u64 const&' for a 'u64&' (though passing a 'u64&'
     // for a 'u64 const&' is fine)
-    const auto actual = type_of_expr(com, expr).type.remove_const();
+    const auto [a_type, a_value] = type_of_expr(com, expr);
+    const auto actual = a_type.remove_const();
     const auto expected = expected_raw.remove_const();
 
     // Nothing to do for size 0 types
@@ -297,12 +298,6 @@ void push_copy_typechecked(compiler& com, const node_expr& expr, const type_name
     }
 
     push_expr(com, compile_type::val, expr);
-
-    // Let functions convert to function ptrs
-    if (auto func = actual.get_if<type_function>(); func && func->to_pointer() == expected) {
-        push_value(code(com), op::push_function_ptr, func->id); // push the id
-        return;
-    }
 
     if (actual.is<type_arena>() || expected.is<type_arena>()) {
         tok.error("arenas can not be copied or assigned");
@@ -980,13 +975,12 @@ auto push_expr(compiler& com, compile_type ct, const node_call_expr& node) -> ex
     }
     else if (auto info = type.get_if<type_function_ptr>()) {
         const auto args_size = push_args_typechecked(com, node.token, node.args, info->param_types);
-        push_expr(com, compile_type::val, *node.expr);
-        push_value(code(com), op::call_ptr, args_size);
-        return { *info->return_type };
-    }
-    else if (auto info = type.get_if<type_function>()) {
-        const auto args_size = push_args_typechecked(com, node.token, node.args, info->param_types);
-        push_value(code(com), op::call_static, info->id, args_size);
+        if (value.is<std::uint64_t>()) {
+            push_value(code(com), op::call_static, value.as<std::uint64_t>(), args_size);
+        } else {
+            push_expr(com, compile_type::val, *node.expr);
+            push_value(code(com), op::call_ptr, args_size);
+        }
         return { *info->return_type };
     }
     else if (auto info = type.get_if<type_function_template>()) {
@@ -1044,6 +1038,7 @@ auto push_expr(compiler& com, compile_type ct, const node_template_expr& node) -
     if (auto info = type.get_if<type_function_template>()) {
         const auto name = function_name{ .module=info->module, .struct_name=info->struct_name, .name=info->name, .templates=templates };
         const auto fn = fetch_function(com, node.token, name);
+        push_value(code(com), op::push_function_ptr, fn.id);
         return { type_function_ptr{fn.param_types, fn.return_type}, fn.id };
     }
     else if (auto info = type.get_if<type_bound_method_template>()) {
@@ -1261,7 +1256,8 @@ auto push_expr(compiler& com, compile_type ct, const node_name_expr& node) -> ex
     if (const auto it = com.functions_by_name.find(fname); it != com.functions_by_name.end()) {
         node.token.assert(ct == compile_type::val, "cannot take the address of a function");
         const auto& func = com.functions[it->second];
-        return { type_function{func.id, func.params, func.return_type} };
+        push_value(code(com), op::push_function_ptr, func.id);
+        return { type_function_ptr{func.params, func.return_type}, func.id };
     }
 
     // It might be a function template
@@ -1326,13 +1322,14 @@ auto push_expr(compiler& com, compile_type ct, const node_field_expr& node) -> e
         if (const auto it = com.functions_by_name.find(fname); it != com.functions_by_name.end()) {
             node.token.assert(ct == compile_type::val, "cannot take the address of a function");
             const auto& func = com.functions[it->second];
-            return { type_function{func.id, func.params, func.return_type } };
+            push_value(code(com), op::push_function_ptr, func.id);
+            return { type_function_ptr{func.params, func.return_type}, func.id };
         }
 
         // It might be a function template
         if (com.function_templates.contains(fname.as_template())) {
             node.token.assert(ct == compile_type::val, "cannot take the address of a function template");
-            return { type_function_template{ filepath, no_struct, node.name } };
+            return { type_function_template{filepath, no_struct, node.name} };
         }
 
         // It might be a struct
@@ -1366,7 +1363,8 @@ auto push_expr(compiler& com, compile_type ct, const node_field_expr& node) -> e
             if (const auto it = com.functions_by_name.find(fname); it != com.functions_by_name.end()) {
                 node.token.assert(ct == compile_type::val, "cannot take the address of a function");
                 const auto& func = com.functions[it->second];
-                return { type_function{func.id, func.params, func.return_type} };   
+                push_value(code(com), op::push_function_ptr, func.id);
+                return { type_function_ptr{func.params, func.return_type}, func.id };   
             }
 
             // It might be a function template
@@ -1603,13 +1601,13 @@ auto push_expr(compiler& com, compile_type ct, const node_intrinsic_expr& node) 
         load_module(com, node.token, filepath);
         return { type_module{}, filepath };
     }
-    if (node.name == "fn_ptr") {
-        node.token.assert_eq(node.args.size(), 1, "@fn_ptr only accepts one argument");
-        const auto type = type_of_expr(com, *node.args[0]).type;
-        node.token.assert(type.is<type_function>(), "can only convert functions to function pointers");
-        const auto& info = type.as<type_function>();
-        push_value(code(com), op::push_function_ptr, info.id);
-        return { type_function_ptr{.param_types=info.param_types, .return_type=info.return_type} };
+    if (node.name == "fn_ptr_runtime") {
+        node.token.assert_eq(node.args.size(), 1, "@fn_ptr_runtime only accepts one argument");
+        const auto [type, value] = type_of_expr(com, *node.args[0]);
+        node.token.assert(type.is<type_function_ptr>(), "fn_ptr_runtime can only be called on functions");
+        node.token.assert(value.is<std::uint64_t>(), "function_ptr compile time value must be a u64");
+        push_value(code(com), op::push_function_ptr, value.as<std::uint64_t>());
+        return { type };
     }
     if (node.name == "is_fundamental") {
         node.token.assert_eq(node.args.size(), 1, "@is_fundamental only accepts one argument");

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -1602,14 +1602,6 @@ auto push_expr(compiler& com, compile_type ct, const node_intrinsic_expr& node) 
         load_module(com, node.token, filepath);
         return { type_module{}, filepath };
     }
-    if (node.name == "fn_ptr_runtime") {
-        node.token.assert_eq(node.args.size(), 1, "@fn_ptr_runtime only accepts one argument");
-        const auto [type, value] = type_of_expr(com, *node.args[0]);
-        node.token.assert(type.is<type_function>(), "fn_ptr_runtime can only be called on functions");
-        node.token.assert(value.is<std::uint64_t>(), "function_ptr compile time value must be a u64");
-        push_value(code(com), op::push_function_ptr, value.as<std::uint64_t>());
-        return { type };
-    }
     if (node.name == "is_fundamental") {
         node.token.assert_eq(node.args.size(), 1, "@is_fundamental only accepts one argument");
         const auto result = type_of_expr(com, *node.args[0]);

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -379,7 +379,7 @@ void match_placeholders(template_map& map, const token& tok, const type_name& ac
         [&](const type_span& a, const type_span& e) {
             match_placeholders(map, tok, *a.inner_type, *e.inner_type);
         },
-        [&](const type_function_ptr& a, const type_function_ptr& e) {
+        [&](const type_function& a, const type_function& e) {
             if (a.param_types.size() == e.param_types.size()) {
                 for (const auto& [a_type, e_type] : std::views::zip(a.param_types, e.param_types)) {
                     match_placeholders(map, tok, a_type, e_type);
@@ -973,9 +973,10 @@ auto push_expr(compiler& com, compile_type ct, const node_call_expr& node) -> ex
         push_args_typechecked(com, node.token, node.args, constructor_params(com, name));
         return { name };
     }
-    else if (auto info = type.get_if<type_function_ptr>()) {
+    else if (auto info = type.get_if<type_function>()) {
         const auto args_size = push_args_typechecked(com, node.token, node.args, info->param_types);
-        if (value.is<std::uint64_t>()) {
+        if (value.has_value()) {
+            node.token.assert(value.is<std::uint64_t>(), "const value of a function must be a u64");
             push_value(code(com), op::call_static, value.as<std::uint64_t>(), args_size);
         } else {
             push_expr(com, compile_type::val, *node.expr);
@@ -1039,7 +1040,7 @@ auto push_expr(compiler& com, compile_type ct, const node_template_expr& node) -
         const auto name = function_name{ .module=info->module, .struct_name=info->struct_name, .name=info->name, .templates=templates };
         const auto fn = fetch_function(com, node.token, name);
         push_value(code(com), op::push_function_ptr, fn.id);
-        return { type_function_ptr{fn.param_types, fn.return_type}, fn.id };
+        return { type_function{fn.param_types, fn.return_type}, fn.id };
     }
     else if (auto info = type.get_if<type_bound_method_template>()) {
         push_expr(com, compile_type::val, *node.expr); // push pointer to the instance to bind to
@@ -1175,7 +1176,7 @@ auto push_expr(compiler& com, compile_type ct, const node_function_ptr_type_expr
 {
     node.token.assert(ct == compile_type::val, "cannot take the address of a function ptr type expression");
     auto type = type_name{};
-    auto& inner = type.emplace<type_function_ptr>();
+    auto& inner = type.emplace<type_function>();
     for (const auto& param : node.params) {
         inner.param_types.push_back(resolve_type(com, node.token, param));
     }
@@ -1257,7 +1258,7 @@ auto push_expr(compiler& com, compile_type ct, const node_name_expr& node) -> ex
         node.token.assert(ct == compile_type::val, "cannot take the address of a function");
         const auto& func = com.functions[it->second];
         push_value(code(com), op::push_function_ptr, func.id);
-        return { type_function_ptr{func.params, func.return_type}, func.id };
+        return { type_function{func.params, func.return_type}, func.id };
     }
 
     // It might be a function template
@@ -1323,7 +1324,7 @@ auto push_expr(compiler& com, compile_type ct, const node_field_expr& node) -> e
             node.token.assert(ct == compile_type::val, "cannot take the address of a function");
             const auto& func = com.functions[it->second];
             push_value(code(com), op::push_function_ptr, func.id);
-            return { type_function_ptr{func.params, func.return_type}, func.id };
+            return { type_function{func.params, func.return_type}, func.id };
         }
 
         // It might be a function template
@@ -1364,7 +1365,7 @@ auto push_expr(compiler& com, compile_type ct, const node_field_expr& node) -> e
                 node.token.assert(ct == compile_type::val, "cannot take the address of a function");
                 const auto& func = com.functions[it->second];
                 push_value(code(com), op::push_function_ptr, func.id);
-                return { type_function_ptr{func.params, func.return_type}, func.id };   
+                return { type_function{func.params, func.return_type}, func.id };   
             }
 
             // It might be a function template
@@ -1604,7 +1605,7 @@ auto push_expr(compiler& com, compile_type ct, const node_intrinsic_expr& node) 
     if (node.name == "fn_ptr_runtime") {
         node.token.assert_eq(node.args.size(), 1, "@fn_ptr_runtime only accepts one argument");
         const auto [type, value] = type_of_expr(com, *node.args[0]);
-        node.token.assert(type.is<type_function_ptr>(), "fn_ptr_runtime can only be called on functions");
+        node.token.assert(type.is<type_function>(), "fn_ptr_runtime can only be called on functions");
         node.token.assert(value.is<std::uint64_t>(), "function_ptr compile time value must be a u64");
         push_value(code(com), op::push_function_ptr, value.as<std::uint64_t>());
         return { type };

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -588,7 +588,16 @@ auto load_module(compiler& com, const token& tok, const std::string& filepath) -
     std::print("    - Completed {}\n", filepath);
 }
 
-auto fetch_function(compiler& com, const token& tok, const function_name& name) -> type_function
+struct function_info
+{
+    std::size_t            id;
+    std::vector<type_name> param_types;
+    value_ptr<type_name>   return_type;
+
+    auto to_bound_method() -> type_bound_method { return {id, param_types, return_type}; }
+};
+
+auto fetch_function(compiler& com, const token& tok, const function_name& name) -> function_info
 {
     const auto key = name.as_template();
 
@@ -601,7 +610,7 @@ auto fetch_function(compiler& com, const token& tok, const function_name& name) 
 
     tok.assert(com.functions_by_name.contains(name), "could not find function {}\n", name);
     const auto& fn = com.functions[com.functions_by_name.at(name)];
-    return type_function{ .id = fn.id, .param_types=fn.params, .return_type=fn.return_type };
+    return function_info{ .id = fn.id, .param_types=fn.params, .return_type=fn.return_type };
 }
 
 auto push_args_typechecked(compiler& com, const token& tok, const auto& args, const auto& expected_types) -> std::size_t
@@ -1034,7 +1043,8 @@ auto push_expr(compiler& com, compile_type ct, const node_template_expr& node) -
 
     if (auto info = type.get_if<type_function_template>()) {
         const auto name = function_name{ .module=info->module, .struct_name=info->struct_name, .name=info->name, .templates=templates };
-        return { fetch_function(com, node.token, name) };
+        const auto fn = fetch_function(com, node.token, name);
+        return { type_function_ptr{fn.param_types, fn.return_type}, fn.id };
     }
     else if (auto info = type.get_if<type_bound_method_template>()) {
         push_expr(com, compile_type::val, *node.expr); // push pointer to the instance to bind to

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -37,7 +37,7 @@ auto type_name::remove_const() const -> type_name
 auto to_string_paren(const type_name& type) -> std::string
 {
     const auto str = type.to_string();
-    if (type.is<type_function_ptr>()) {
+    if (type.is<type_function>()) {
         return std::format("({})", str);
     }
     return str;
@@ -117,7 +117,7 @@ auto type_span::to_string() const -> std::string
     return std::format("{}[]", to_string_paren(*inner_type));
 }
 
-auto type_function_ptr::to_string() const -> std::string
+auto type_function::to_string() const -> std::string
 {
     return std::format(
         "{}({}) -> {}",

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -9,11 +9,6 @@
 
 namespace anzu {
 
-auto type_function::to_pointer() const -> type_name
-{
-    return type_function_ptr{ param_types, return_type };
-}
-
 auto type_name::add_ptr() const -> type_name
 {
     return { type_ptr{ .inner_type{*this} } };
@@ -151,12 +146,6 @@ auto type_bound_method_template::to_string() const -> std::string
         struct_name,
         name
     );
-}
-
-auto type_function::to_string() const -> std::string
-{
-    const auto function_ptr_type = type_function_ptr{param_types, return_type};
-    return std::format("<function: id {} {}>", id, function_ptr_type);
 }
 
 auto type_function_template::to_string() const -> std::string

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -127,6 +127,7 @@ auto type_function::to_string() const -> std::string
     );
 }
 
+// TODO: Fix this printing
 auto type_bound_method::to_string() const -> std::string
 {
     return std::format(

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -163,19 +163,6 @@ struct type_bound_method_template
     auto operator==(const type_bound_method_template&) const -> bool = default;
 };
 
-struct type_function
-{
-    std::size_t            id;
-    std::vector<type_name> param_types;
-    value_ptr<type_name>   return_type;
-
-    auto to_pointer() const -> type_name;
-    auto to_hash() const { return hash(id, param_types, return_type); }
-    auto to_bound_method() -> type_bound_method { return {id, param_types, return_type}; }
-    auto to_string() const -> std::string;
-    auto operator==(const type_function&) const -> bool = default;
-};
-
 struct type_function_template
 {
     std::filesystem::path    module;
@@ -228,7 +215,6 @@ struct type_name : public std::variant<
     type_bound_method,
     type_bound_method_template,
     
-    type_function,
     type_function_template,
     type_struct_template,
     type_placeholder>

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -131,14 +131,14 @@ struct type_span
     auto operator==(const type_span&) const -> bool = default;
 };
 
-struct type_function_ptr
+struct type_function
 {
     std::vector<type_name> param_types;
     value_ptr<type_name>   return_type;
 
     auto to_hash() const { return hash(param_types, return_type); }
     auto to_string() const -> std::string;
-    auto operator==(const type_function_ptr&) const -> bool = default;
+    auto operator==(const type_function&) const -> bool = default;
 };
 
 struct type_bound_method
@@ -205,18 +205,18 @@ struct type_name : public std::variant<
     type_type,
     type_arena,
     type_module,
-
     type_array,
-    type_struct,
     type_ptr,
     type_span,
 
-    type_function_ptr,
+    type_function,
+    type_struct,
     type_bound_method,
-    type_bound_method_template,
-    
+
     type_function_template,
     type_struct_template,
+    type_bound_method_template,
+    
     type_placeholder>
 {
     using variant::variant;


### PR DESCRIPTION
* Now that we have `expr_result` which is capable of returning compile-time values, there's no need to have separate types for `function` and `function_ptr`; a function is just a `function_ptr` with a compile-time known value!
* In the call expression, if we know the id of the function, we can call it statically, otherwise we can push the id at runtime.
* The remaining type is the old `function_ptr`, but is now just called `function`.
* The `function` type now has the same behaviour at scalar types; treat it like a runtime value, with the calling optimisation as mentioned above.
* There is no longer a need to have special logic to convert a `function` to a `function_ptr` when pushing as an argument to a function call.
* There is now a nice symmetry in the template types; `function(_template)`, `struct(_template)` and `bound_method(_template)`.
* I think this can be simplified further; functions might just be storable as variables in the variable manager now, will give this a try. 
* Remove the `@fn_ptr` intrinsic since it's now meaningless. If you ever want to force the program to do a dynamic call rather than a static call, you can capture an alias with `var`, i.e. `var f := foo` and the compile-time value is lost.