### PR TITLE
Optimise Arena Cleanup & Rename `type_struct_template`

### DIFF
--- a/examples/test.az
+++ b/examples/test.az
@@ -1,8 +1,7 @@
-fn foo() 
-{
 
+fn main() {
+    arena a;
+    print("here");
 }
 
-
-var f := foo;
-f();
+main();

--- a/src/compilation/type_manager.cpp
+++ b/src/compilation/type_manager.cpp
@@ -50,9 +50,6 @@ auto type_manager::size_of(const type_name& type) const -> std::size_t
         [](type_f64) {
             return std::size_t{8};
         },
-        [](type_type) {
-            return std::size_t{0};
-        },
         [](type_arena) {
             return sizeof(std::byte*); // the runtime will store the arena separately
         },
@@ -68,10 +65,6 @@ auto type_manager::size_of(const type_name& type) const -> std::size_t
         [](const type_span&) {
             return sizeof(std::byte*) + sizeof(std::size_t);
         },
-
-        [](const type_function&) {
-            return sizeof(std::uint64_t);
-        },
         [&](const type_struct& t) -> std::size_t {
             if (!d_classes.contains(t)) {
                 panic("unknown type '{}'", type);
@@ -82,15 +75,23 @@ auto type_manager::size_of(const type_name& type) const -> std::size_t
             }
             return std::max(std::size_t{1}, size); // empty structs take up one byte
         },
-        [](const type_bound_method&) {
-            return sizeof(std::byte*); // pointer to the object, first arg to the function
+        
+        [](const type_function&) {
+            return sizeof(std::uint64_t);
         },
-
         [](const type_function_template&) {
             return std::size_t{0};
         },
-        [](const type_struct_template&) {
+
+        [](const type_type&) {
             return std::size_t{0};
+        },
+        [](const type_type_template&) {
+            return std::size_t{0};
+        },
+
+        [](const type_bound_method&) {
+            return sizeof(std::byte*); // pointer to the object, first arg to the function
         },
         [](const type_bound_method_template&) {
             return sizeof(std::byte*); // pointer to the object, first arg to the function

--- a/src/compilation/variable_manager.cpp
+++ b/src/compilation/variable_manager.cpp
@@ -8,8 +8,8 @@ auto delete_arenas_in_scope(std::vector<std::byte>& program, const scope& scope,
 {
     for (const auto& var : scope.variables | std::views::reverse) {
         if (var.type.is<type_arena>()) {
-            const auto op = is_local ? op::push_ptr_local : op::push_ptr_global;
-            push_value(program, op, var.location, op::load, sizeof(std::byte*), op::arena_delete);
+            const auto op = is_local ? op::push_val_local : op::push_val_global;
+            push_value(program, op, var.location, var.size, op::arena_delete);
         }
     }
 }

--- a/src/compilation/variable_manager.hpp
+++ b/src/compilation/variable_manager.hpp
@@ -49,7 +49,7 @@ struct scope
 class variable_manager
 {
     std::vector<scope> d_scopes;
-    bool d_local;
+    bool               d_local;
 
 public:
     variable_manager(bool local = true) : d_local{local} {}

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -1571,13 +1571,6 @@ auto push_expr(compiler& com, compile_type ct, const node_intrinsic_expr& node) 
         push_value(code(com), op::push_string_literal, insert_into_rom(com, str), str.size());
         return { string_literal_type() };
     }
-    if (node.name == "type_class_of") {
-        node.token.assert_eq(node.args.size(), 1, "@type_class_of only accepts one argument");
-        const auto [type, value] = type_of_expr(com, *node.args[0]);
-        std::print("{}: {}\n", type, value);
-        push_value(code(com), op::push_null);
-        return { type_null{} };
-    }
     if (node.name == "copy") {
         node.token.assert_eq(node.args.size(), 2, "@copy requires two spans");
         const auto lhs = push_expr(com, ct, *node.args[0]).type;

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -960,7 +960,7 @@ auto push_expr(compiler& com, compile_type ct, const node_call_expr& node) -> ex
         }
         return { inner };
     }
-    else if (auto info = type.get_if<type_struct_template>()) {
+    else if (auto info = type.get_if<type_type_template>()) {
         const auto& ast = com.struct_templates[*info];
         const auto params = ast.fields
                           | std::views::transform(&node_parameter::type)
@@ -1047,9 +1047,9 @@ auto push_expr(compiler& com, compile_type ct, const node_template_expr& node) -
         const auto name = function_name{info->module, info->struct_name, info->name, templates};
         return { fetch_function(com, node.token, name).to_bound_method() };
     }
-    else if (auto info = type.get_if<type_struct_template>()) {
+    else if (auto info = type.get_if<type_type_template>()) {
         const auto name = type_struct{info->name, info->module, templates};
-        const auto key = type_struct_template{info->module, info->name};
+        const auto key = type_type_template{info->module, info->name};
 
         if (!com.types.contains(name) && com.struct_templates.contains(key)) {
             const auto& ast = com.struct_templates.at(key);
@@ -1274,10 +1274,10 @@ auto push_expr(compiler& com, compile_type ct, const node_name_expr& node) -> ex
     }
 
     // It might be a struct template
-    const auto stemp = type_struct_template{curr_module(com), node.name};
+    const auto stemp = type_type_template{curr_module(com), node.name};
     if (com.struct_templates.contains(stemp)) {
         node.token.assert(ct == compile_type::val, "cannot take the address of a struct template");
-        return { type_struct_template{ .module=curr_module(com), .name=node.name } };
+        return { type_type_template{ .module=curr_module(com), .name=node.name } };
     }
 
     // It might be a fundamental type
@@ -1341,10 +1341,10 @@ auto push_expr(compiler& com, compile_type ct, const node_field_expr& node) -> e
         }
 
         // It might be a struct template
-        const auto skey = type_struct_template{filepath, node.name};
+        const auto skey = type_type_template{filepath, node.name};
         if (com.struct_templates.contains(skey)) {
             node.token.assert(ct == compile_type::val, "cannot take the address of a struct template");
-            return { type_struct_template{ filepath, node.name } };
+            return { type_type_template{ filepath, node.name } };
         }
 
         // Otherwise, it must be a variable
@@ -1570,6 +1570,13 @@ auto push_expr(compiler& com, compile_type ct, const node_intrinsic_expr& node) 
         std::print("@type_name_of == {}\n", str);
         push_value(code(com), op::push_string_literal, insert_into_rom(com, str), str.size());
         return { string_literal_type() };
+    }
+    if (node.name == "type_class_of") {
+        node.token.assert_eq(node.args.size(), 1, "@type_class_of only accepts one argument");
+        const auto [type, value] = type_of_expr(com, *node.args[0]);
+        std::print("{}: {}\n", type, value);
+        push_value(code(com), op::push_null);
+        return { type_null{} };
     }
     if (node.name == "copy") {
         node.token.assert_eq(node.args.size(), 2, "@copy requires two spans");
@@ -1879,7 +1886,7 @@ void push_stmt(compiler& com, const node_if_stmt& node)
 void push_stmt(compiler& com, const node_struct_stmt& node)
 {
     if (!node.templates.empty()) {
-        const auto key = type_struct_template{curr_module(com), node.name};
+        const auto key = type_type_template{curr_module(com), node.name};
         const auto [it, success] = com.struct_templates.emplace(key, node);
         node.token.assert(success, "struct template named '<{}>.{}' already defined", curr_module(com).string(), node.name);
         return;

--- a/src/compiler.hpp
+++ b/src/compiler.hpp
@@ -39,7 +39,7 @@ struct compiler
     std::unordered_map<function_name, std::size_t> functions_by_name;
     
     std::unordered_map<type_function_template, node_function_stmt> function_templates;
-    std::unordered_map<type_struct_template,   node_struct_stmt>   struct_templates;
+    std::unordered_map<type_type_template,     node_struct_stmt>   struct_templates;
 
     std::vector<std::filesystem::path> current_module;
     std::vector<type_struct>           current_struct;

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -154,7 +154,7 @@ auto type_function_template::to_string() const -> std::string
     return std::format("<function_template: <{}>.{}.{}>", module.string(), struct_name.name, name);
 }
 
-auto type_struct_template::to_string() const -> std::string
+auto type_type_template::to_string() const -> std::string
 {
     return std::format("<struct_template: <{}>.{}>", module.string(), name);
 }

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -271,20 +271,6 @@ struct const_value : public std::variant<
     template <typename T> auto as()     const -> const T& { return std::get<T>(*this); }
     template <typename T> auto get_if() const -> const T* { return std::get_if<T>(this); }
     auto has_value()                    const -> bool     { return !is<std::monostate>(); }
-
-    auto to_string() const -> std::string {
-        return std::visit(overloaded{
-            [](std::monostate) { return std::format("null"); },
-            [](bool b) { return std::format("{}", b ? "true" : "false"); },
-            [](char c) { return std::format("{}", c); },
-            [](std::int32_t i) { return std::format("{}", i); },
-            [](std::int64_t i) { return std::format("{}", i); },
-            [](std::uint64_t i) { return std::format("{}u", i); },
-            [](double d) { return std::format("{}", d); },
-            [](std::filesystem::path fp) { return std::format("<filepath>"); },
-            [](type_name type) { return std::format("{}", type); }
-        }, *this);
-    }
 };
 
 }

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -152,17 +152,6 @@ struct type_bound_method
     auto operator==(const type_bound_method&) const -> bool = default;
 };
 
-struct type_bound_method_template
-{
-    std::filesystem::path    module;
-    type_struct              struct_name;
-    std::string              name;
-
-    auto to_hash() const { return hash(module, struct_name, name); }
-    auto to_string() const -> std::string;
-    auto operator==(const type_bound_method_template&) const -> bool = default;
-};
-
 struct type_function_template
 {
     std::filesystem::path    module;
@@ -174,14 +163,25 @@ struct type_function_template
     auto operator==(const type_function_template&) const -> bool = default;
 };
 
-struct type_struct_template
+struct type_bound_method_template
+{
+    std::filesystem::path    module;
+    type_struct              struct_name;
+    std::string              name;
+
+    auto to_hash() const { return hash(module, struct_name, name); }
+    auto to_string() const -> std::string;
+    auto operator==(const type_bound_method_template&) const -> bool = default;
+};
+
+struct type_type_template
 {
     std::filesystem::path module;
     std::string           name;
 
     auto to_hash() const { return hash(module, name); }
     auto to_string() const -> std::string;
-    auto operator==(const type_struct_template&) const -> bool = default;
+    auto operator==(const type_type_template&) const -> bool = default;
 };
 
 // Only used during template argument type deduction
@@ -198,25 +198,22 @@ struct type_name : public std::variant<
     type_null,
     type_bool,
     type_char,
-    type_i32,
-    type_i64,
-    type_u64,
-    type_f64,
-    type_type,
-    type_arena,
+    type_i32, 
+    type_i64, 
+    type_u64, 
+    type_f64, 
+    type_struct,
+    type_arena, 
     type_module,
     type_array,
     type_ptr,
     type_span,
-
+    type_type,
+    type_type_template,
     type_function,
-    type_struct,
-    type_bound_method,
-
     type_function_template,
-    type_struct_template,
+    type_bound_method,
     type_bound_method_template,
-    
     type_placeholder>
 {
     using variant::variant;
@@ -274,8 +271,21 @@ struct const_value : public std::variant<
     template <typename T> auto as()     const -> const T& { return std::get<T>(*this); }
     template <typename T> auto get_if() const -> const T* { return std::get_if<T>(this); }
     auto has_value()                    const -> bool     { return !is<std::monostate>(); }
-};
 
+    auto to_string() const -> std::string {
+        return std::visit(overloaded{
+            [](std::monostate) { return std::format("null"); },
+            [](bool b) { return std::format("{}", b ? "true" : "false"); },
+            [](char c) { return std::format("{}", c); },
+            [](std::int32_t i) { return std::format("{}", i); },
+            [](std::int64_t i) { return std::format("{}", i); },
+            [](std::uint64_t i) { return std::format("{}u", i); },
+            [](double d) { return std::format("{}", d); },
+            [](std::filesystem::path fp) { return std::format("<filepath>"); },
+            [](type_name type) { return std::format("{}", type); }
+        }, *this);
+    }
+};
 
 }
 


### PR DESCRIPTION
* Rename `type_struct_template` to `type_type_template` which is more accurate (`type_type_template` resolves to a `type_type`, similarly to how `type_function_template` resolves to a `type_function`).
* Optimize cleaning up arenas, it now uses one less op code by loading the value directly rather than loading a pointer to it and then loading. This happened because I added the op codes to push values directly in https://github.com/fullptr/anzu/pull/218 which was after I added the arena op codes, and I never went back to update it.